### PR TITLE
approval bot refactoring

### DIFF
--- a/bot/approvals.go
+++ b/bot/approvals.go
@@ -2,11 +2,127 @@ package bot
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keel-hq/keel/approvals"
 	"github.com/keel-hq/keel/bot/formatter"
+	"github.com/keel-hq/keel/types"
+
+	log "github.com/Sirupsen/logrus"
 )
+
+type BotRequestApproval func(req *types.Approval) error
+type BotReplyApproval func(approval *types.Approval) error
+
+func (bm *BotManager) SubscribeForApprovals(ctx context.Context, approval BotRequestApproval) error {
+	approvalsCh, err := bm.approvalsManager.Subscribe(ctx)
+	if err != nil {
+		log.Errorf("bot.subscribeForApprovals(): %s", err.Error())
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case a := <-approvalsCh:
+			err = approval(a)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"error":    err,
+					"approval": a.Identifier,
+				}).Error("bot.subscribeForApprovals: approval request failed")
+			}
+		}
+	}
+}
+
+func (bm *BotManager) ProcessApprovalResponses(ctx context.Context, reply BotReplyApproval) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case resp := <-bm.approvalsRespCh:
+			switch resp.Status {
+			case types.ApprovalStatusApproved:
+				err := bm.processApprovedResponse(resp, reply)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"error": err,
+					}).Error("bot.processApprovalResponses: failed to process approval response message")
+				}
+			case types.ApprovalStatusRejected:
+				err := bm.processRejectedResponse(resp, reply)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"error": err,
+					}).Error("bot.processApprovalResponses: failed to process approval reject response message")
+				}
+			}
+		}
+	}
+}
+
+func (bm *BotManager) processApprovedResponse(approvalResponse *ApprovalResponse, reply BotReplyApproval) error {
+	trimmed := strings.TrimPrefix(approvalResponse.Text, ApprovalResponseKeyword)
+	identifiers := strings.Split(trimmed, " ")
+	if len(identifiers) == 0 {
+		return nil
+	}
+
+	for _, identifier := range identifiers {
+		if identifier == "" {
+			continue
+		}
+		approval, err := bm.approvalsManager.Approve(identifier, approvalResponse.User)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":      err,
+				"identifier": identifier,
+			}).Error("bot.processApprovedResponse: failed to approve")
+			continue
+		}
+
+		err = reply(approval)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":      err,
+				"identifier": identifier,
+			}).Error("bot.processApprovedResponse: got error while replying after processing approved approval")
+		}
+	}
+	return nil
+}
+
+func (bm *BotManager) processRejectedResponse(approvalResponse *ApprovalResponse, reply BotReplyApproval) error {
+	trimmed := strings.TrimPrefix(approvalResponse.Text, RejectResponseKeyword)
+	identifiers := strings.Split(trimmed, " ")
+	if len(identifiers) == 0 {
+		return nil
+	}
+
+	for _, identifier := range identifiers {
+		approval, err := bm.approvalsManager.Reject(identifier)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":      err,
+				"identifier": identifier,
+			}).Error("bot.processApprovedResponse: failed to reject")
+			continue
+		}
+
+		err = reply(approval)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":      err,
+				"identifier": identifier,
+			}).Error("bot.processApprovedResponse: got error while replying after processing rejected approval")
+		}
+	}
+	return nil
+}
 
 func ApprovalsResponse(approvalsManager approvals.Manager) string {
 	approvals, err := approvalsManager.List()
@@ -31,6 +147,26 @@ func ApprovalsResponse(approvalsManager approvals.Manager) string {
 	}
 
 	return buf.String()
+}
+
+func IsApproval(eventUser string, eventText string) (resp *ApprovalResponse, ok bool) {
+	if strings.HasPrefix(strings.ToLower(eventText), ApprovalResponseKeyword) {
+		return &ApprovalResponse{
+			User:   eventUser,
+			Status: types.ApprovalStatusApproved,
+			Text:   eventText,
+		}, true
+	}
+
+	if strings.HasPrefix(strings.ToLower(eventText), RejectResponseKeyword) {
+		return &ApprovalResponse{
+			User:   eventUser,
+			Status: types.ApprovalStatusRejected,
+			Text:   eventText,
+		}, true
+	}
+
+	return nil, false
 }
 
 func RemoveApprovalHandler(identifier string, approvalsManager approvals.Manager) string {

--- a/bot/hipchat/approvals.go
+++ b/bot/hipchat/approvals.go
@@ -2,39 +2,11 @@ package hipchat
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/keel-hq/keel/bot"
 	"github.com/keel-hq/keel/types"
-
-	log "github.com/Sirupsen/logrus"
 )
 
-func (b *Bot) subscribeForApprovals() error {
-	approvalsCh, err := b.approvalsManager.Subscribe(b.ctx)
-	if err != nil {
-		log.Errorf("hipchat.subscribeForApprovals(): %s", err.Error())
-		return err
-	}
-
-	for {
-		select {
-		case <-b.ctx.Done():
-			return nil
-		case a := <-approvalsCh:
-			err = b.requestApproval(a)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"error":    err,
-					"approval": a.Identifier,
-				}).Error("bot.subscribeForApprovals: approval request failed")
-			}
-		}
-	}
-}
-
-// Request - request approval
-func (b *Bot) requestApproval(req *types.Approval) error {
+func (b *Bot) RequestApproval(req *types.Approval) error {
 	msg := fmt.Sprintf(ApprovalRequiredTempl,
 		req.Message, b.mentionName, req.Identifier, b.mentionName, req.Identifier,
 		req.VotesReceived, req.VotesRequired, req.Delta(), req.Identifier,
@@ -42,92 +14,7 @@ func (b *Bot) requestApproval(req *types.Approval) error {
 	return b.postMessage(formatAsSnippet(msg))
 }
 
-func (b *Bot) processApprovalResponses() error {
-	for {
-		select {
-		case <-b.ctx.Done():
-			return nil
-		case resp := <-b.approvalsRespCh:
-			switch resp.Status {
-			case types.ApprovalStatusApproved:
-				err := b.processApprovedResponse(resp)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"error": err,
-					}).Error("bot.processApprovalResponses: failed to process approval response message")
-				}
-			case types.ApprovalStatusRejected:
-				err := b.processRejectedResponse(resp)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"error": err,
-					}).Error("bot.processApprovalResponses: failed to process approval reject response message")
-				}
-			}
-		}
-	}
-}
-
-func (b *Bot) processApprovedResponse(approvalResponse *bot.ApprovalResponse) error {
-	trimmed := strings.TrimPrefix(approvalResponse.Text, bot.ApprovalResponseKeyword)
-	identifiers := strings.Split(trimmed, " ")
-	if len(identifiers) == 0 {
-		return nil
-	}
-
-	for _, identifier := range identifiers {
-		if identifier == "" {
-			continue
-		}
-		approval, err := b.approvalsManager.Approve(identifier, approvalResponse.User)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"error":      err,
-				"identifier": identifier,
-			}).Error("bot.processApprovedResponse: failed to approve")
-			continue
-		}
-
-		err = b.replyToApproval(approval)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"error":      err,
-				"identifier": identifier,
-			}).Error("bot.processApprovedResponse: got error while replying after processing approved approval")
-		}
-	}
-	return nil
-}
-
-func (b *Bot) processRejectedResponse(approvalResponse *bot.ApprovalResponse) error {
-	trimmed := strings.TrimPrefix(approvalResponse.Text, bot.RejectResponseKeyword)
-	identifiers := strings.Split(trimmed, " ")
-	if len(identifiers) == 0 {
-		return nil
-	}
-
-	for _, identifier := range identifiers {
-		approval, err := b.approvalsManager.Reject(identifier)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"error":      err,
-				"identifier": identifier,
-			}).Error("bot.processApprovedResponse: failed to reject")
-			continue
-		}
-
-		err = b.replyToApproval(approval)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"error":      err,
-				"identifier": identifier,
-			}).Error("bot.processApprovedResponse: got error while replying after processing rejected approval")
-		}
-	}
-	return nil
-}
-
-func (b *Bot) replyToApproval(approval *types.Approval) error {
+func (b *Bot) ReplyToApproval(approval *types.Approval) error {
 	switch approval.Status() {
 	case types.ApprovalStatusPending:
 		msg := fmt.Sprintf(VoteReceivedTempl,

--- a/bot/hipchat/client.go
+++ b/bot/hipchat/client.go
@@ -1,0 +1,49 @@
+package hipchat
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/daneharrigan/hipchat"
+)
+
+type XmppImplementer interface {
+	Say(roomID, name, body string)
+	Status(s string)
+	Join(roomID, resource string)
+	KeepAlive()
+	Messages() <-chan *hipchat.Message
+}
+
+type HipchatClient struct {
+	XmppImplementer
+}
+
+func connect(username, password string, connAttempts int) *HipchatClient {
+	// c := &Client{}
+	attempts := connAttempts
+	for {
+		if attempts == 0 {
+			log.Errorf("Can not reach hipchat server after %d attempts", connAttempts)
+			return nil
+		}
+		log.Info("bot.hipchat.connect: try to connect to hipchat")
+		client, err := hipchat.NewClient(username, password, "bot", "plain")
+
+		if err != nil {
+			log.Errorf("bot.hipchat.connect: Error=%s", err)
+			if err.Error() == "could not authenticate" {
+				return nil
+			}
+		}
+		if client != nil && err == nil {
+			log.Info("Successfully connected to hipchat server")
+			return &HipchatClient{client}
+			// c.cli = client
+			// return c
+		}
+		log.Debugln("Can not connect to hipcaht now, wait fo 30 seconds")
+		time.Sleep(30 * time.Second)
+		attempts--
+	}
+}

--- a/bot/hipchat/hipchat.go
+++ b/bot/hipchat/hipchat.go
@@ -5,18 +5,17 @@ import (
 	"errors"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
-	"time"
 
-	"github.com/keel-hq/keel/approvals"
 	"github.com/keel-hq/keel/bot"
 	"github.com/keel-hq/keel/constants"
-	"github.com/keel-hq/keel/provider/kubernetes"
-	"github.com/keel-hq/keel/types"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/daneharrigan/hipchat"
+	h "github.com/daneharrigan/hipchat"
 )
+
+const connectionAttemptsDefault = 5
 
 // Bot - main hipchat bot container
 type Bot struct {
@@ -27,146 +26,70 @@ type Bot struct {
 	userName string // bot user name
 	password string // bot user password
 
-	users map[string]string
+	hipchatClient    XmppImplementer
+	approvalsChannel string
+	ctx              context.Context
 
-	msgPrefix string
-
-	hipchatClient *hipchat.Client
-
-	approvalsRespCh chan *bot.ApprovalResponse
-
-	approvalsManager approvals.Manager
-	approvalsChannel string // hipchat approvals channel name
-
-	k8sImplementer kubernetes.Implementer
-
-	ctx context.Context
+	botMessagesChannel chan *bot.BotMessage
+	approvalsRespCh    chan *bot.ApprovalResponse
 }
 
 func init() {
-	bot.RegisterBot("hipchat", Run)
+	if isHipchatConfigured() {
+		bot.RegisterBot("hipchat", &Bot{})
+	}
 }
 
-// Run ...
-func Run(k8sImplementer kubernetes.Implementer, approvalsManager approvals.Manager) (teardown func(), err error) {
-
-	if os.Getenv(constants.EnvHipchatApprovalsPasswort) != "" &&
-		os.Getenv(constants.EnvHipchatApprovalsUserName) != "" {
-		botName := "keel"
+func (b *Bot) Configure(approvalsRespCh chan *bot.ApprovalResponse, botMessagesChannel chan *bot.BotMessage) bool {
+	if isHipchatConfigured() {
+		b.name = "keel"
 		if os.Getenv(constants.EnvHipchatApprovalsBotName) != "" {
-			botName = os.Getenv(constants.EnvHipchatApprovalsBotName)
+			b.name = os.Getenv(constants.EnvHipchatApprovalsBotName)
 		}
 
-		botUserName := ""
-		if os.Getenv(constants.EnvHipchatApprovalsUserName) != "" {
-			botUserName = os.Getenv(constants.EnvHipchatApprovalsUserName)
+		b.userName = os.Getenv(constants.EnvHipchatApprovalsUserName)
+		b.password = os.Getenv(constants.EnvHipchatApprovalsPasswort)
+		connAttempts := getConnectionAttempts()
+
+		cli := connect(b.userName, b.password, connAttempts)
+		if cli != nil {
+			b.hipchatClient = cli
 		}
+		b.mentionName = "@" + strings.Replace(b.name, " ", "", -1)
+		b.botMessagesChannel = botMessagesChannel
+		b.approvalsRespCh = approvalsRespCh
 
-		pass := os.Getenv(constants.EnvHipchatApprovalsPasswort)
-
-		approvalsChannel := "general"
+		b.approvalsChannel = "general"
 		if os.Getenv(constants.EnvHipchatApprovalsChannel) != "" {
-			approvalsChannel = os.Getenv(constants.EnvHipchatApprovalsChannel)
+			b.approvalsChannel = os.Getenv(constants.EnvHipchatApprovalsChannel)
 		}
 
-		bot := new(botName, botUserName, pass, approvalsChannel, k8sImplementer, approvalsManager)
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		err := bot.Start(ctx)
-		if err != nil {
-			cancel()
-			return nil, err
-		}
-
-		teardown := func() {
-			// cancelling context
-			cancel()
-		}
-
-		return teardown, nil
-	}
-	log.Info("bot.hipchat.Run(): HipChat approval bot ist not configured, ignore")
-	return func() {}, nil
-}
-
-//--------------------- <XMPP client> -------------------------------------
-
-func connect(username, password string) *hipchat.Client {
-	attempts := 10
-	for {
-		log.Info("bot.hipchat.connect: try to connect to hipchat")
-		client, err := hipchat.NewClient(username, password, "bot", "plain")
-		// could not authenticate
-		if err != nil {
-			log.Errorf("bot.hipchat.connect: Error=%s", err)
-			if err.Error() == "could not authenticate" {
-				return nil
-			}
-		}
-		if attempts == 0 {
-			return nil
-		}
-		if client != nil && err == nil {
-			log.Info("Successfully connected to hipchat server")
-			return client
-		}
-		log.Debugln("Can not connect to hipcaht now, wait fo 30 seconds")
-		time.Sleep(30 * time.Second)
-		attempts--
-	}
-}
-
-//--------------------- </XMPP client> -------------------------------------
-
-func new(name, username, pass, approvalsChannel string, k8sImplementer kubernetes.Implementer, approvalsManager approvals.Manager) *Bot {
-
-	client := connect(username, pass)
-
-	bot := &Bot{
-		hipchatClient:    client,
-		k8sImplementer:   k8sImplementer,
-		name:             name,
-		mentionName:      "@" + strings.Replace(name, " ", "", -1),
-		approvalsManager: approvalsManager,
-		approvalsChannel: approvalsChannel,                 // roomJid
-		approvalsRespCh:  make(chan *bot.ApprovalResponse), // don't add buffer to make it blocking
+		return true
 	}
 
-	return bot
+	log.Info("bot.hipchat.Configure(): HipChat approval bot is not configured")
+	return false
 }
 
 // Start the bot
 func (b *Bot) Start(ctx context.Context) error {
-
 	if b.hipchatClient == nil {
 		return errors.New("could not conect to hipchat server")
 	}
 
 	// setting root context
 	b.ctx = ctx
-
-	// processing messages coming from slack RTM client
-	go b.startInternal()
-
-	// processing slack approval responses
-	go b.processApprovalResponses()
-
-	// subscribing for approval requests
-	go b.subscribeForApprovals()
-
-	return nil
-}
-
-func (b *Bot) startInternal() error {
 	client := b.hipchatClient
 	client.Status("chat")
 	client.Join(b.approvalsChannel, b.name)
-	b.postMessage("Keel bot started ...")
+	b.postMessage("Keel bot was started")
+
 	go client.KeepAlive()
 	go func() {
 		for {
 			select {
+			case <-b.ctx.Done():
+				return
 			case message := <-client.Messages():
 				b.handleMessage(message)
 			}
@@ -176,7 +99,11 @@ func (b *Bot) startInternal() error {
 	return nil
 }
 
-func (b *Bot) handleMessage(message *hipchat.Message) {
+func (b *Bot) Respond(response string, channel string) {
+	b.hipchatClient.Say(channel, b.name, formatAsSnippet(response))
+}
+
+func (b *Bot) handleMessage(message *h.Message) {
 	msg := b.trimXMPPMessage(message)
 	if msg.From == "" || msg.To == "" {
 		log.Debugln("hipchat.handleMessage(): fields 'From:' or 'To:' are empty, ignore")
@@ -184,81 +111,33 @@ func (b *Bot) handleMessage(message *hipchat.Message) {
 	}
 
 	if !b.isBotMessage(msg) {
+		log.Debugf("handleMessage(): is not a bot message [%v]", msg)
 		return
 	}
 
-	approval, ok := b.isApproval(msg)
+	approval, ok := bot.IsApproval(msg.From, msg.Body)
 	if ok {
+		log.Debug("handleMessage(): approval=%v", approval)
 		b.approvalsRespCh <- approval
 		return
 	}
 
-	if responseLines, ok := bot.BotEventTextToResponse[msg.Body]; ok {
-		response := strings.Join(responseLines, "\n")
-		b.respond(formatAsSnippet(response))
-		return
+	b.botMessagesChannel <- &bot.BotMessage{
+		Message: msg.Body,
+		User:    msg.From,
+		Channel: b.approvalsChannel,
+		Name:    "hipchat",
 	}
 
-	if b.isCommand(msg) {
-		b.handleCommand(msg)
-		return
-	}
-
-	log.WithFields(log.Fields{
-		"name":      b.name,
-		"bot_id":    b.id,
-		"command":   msg.Body,
-		"untrimmed": message.Body,
-	}).Debug("handleMessage: bot couldn't recognise command")
-}
-
-func (b *Bot) handleCommand(message *hipchat.Message) {
-	eventText := message.Body
-	switch eventText {
-	case "get deployments":
-		log.Info("getting deployments")
-		response := bot.DeploymentsResponse(bot.Filter{}, b.k8sImplementer)
-		b.respond(formatAsSnippet(response))
-		return
-	case "get approvals":
-		log.Info("getting approvals")
-		response := bot.ApprovalsResponse(b.approvalsManager)
-		b.respond(formatAsSnippet(response))
-		return
-	}
-
-	// handle dynamic commands
-	if strings.HasPrefix(eventText, bot.RemoveApprovalPrefix) {
-		id := strings.TrimSpace(strings.TrimPrefix(eventText, bot.RemoveApprovalPrefix))
-		snippet := bot.RemoveApprovalHandler(id, b.approvalsManager)
-		b.respond(formatAsSnippet(snippet))
-		return
-	}
-
-	log.Info("hipchat.handleCommand(): command not found")
+	return
 }
 
 func formatAsSnippet(msg string) string {
 	return "/code " + msg
 }
 
-func (b *Bot) isCommand(message *hipchat.Message) bool {
-
-	if bot.StaticBotCommands[message.Body] {
-		return true
-	}
-
-	for _, prefix := range bot.DynamicBotCommandPrefixes {
-		if strings.HasPrefix(message.Body, prefix) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (b *Bot) trimXMPPMessage(message *hipchat.Message) *hipchat.Message {
-	msg := hipchat.Message{}
+func (b *Bot) trimXMPPMessage(message *h.Message) *h.Message {
+	msg := h.Message{}
 	msg.MentionName = trimMentionName(message.Body)
 	msg.Body = b.trimBot(message.Body)
 	msg.From = b.trimUser(message.From)
@@ -296,10 +175,6 @@ func (b *Bot) postMessage(msg string) error {
 	return nil
 }
 
-func (b *Bot) respond(response string) {
-	b.hipchatClient.Say(b.approvalsChannel, b.name, response)
-}
-
 func (b *Bot) trimBot(msg string) string {
 	msg = strings.TrimPrefix(msg, b.mentionName)
 	msg = strings.Trim(msg, "\n")
@@ -307,30 +182,28 @@ func (b *Bot) trimBot(msg string) string {
 	return strings.ToLower(msg)
 }
 
-func (b *Bot) isApproval(message *hipchat.Message) (resp *bot.ApprovalResponse, ok bool) {
-
-	if strings.HasPrefix(message.Body, bot.ApprovalResponseKeyword) {
-		return &bot.ApprovalResponse{
-			User:   message.From,
-			Status: types.ApprovalStatusApproved,
-			Text:   message.Body,
-		}, true
-	}
-
-	if strings.HasPrefix(message.Body, bot.RejectResponseKeyword) {
-		return &bot.ApprovalResponse{
-			User:   message.From,
-			Status: types.ApprovalStatusRejected,
-			Text:   message.Body,
-		}, true
-	}
-
-	return nil, false
-}
-
-func (b *Bot) isBotMessage(message *hipchat.Message) bool {
+func (b *Bot) isBotMessage(message *h.Message) bool {
 	if message.MentionName == b.mentionName {
 		return true
 	}
 	return false
+}
+
+func isHipchatConfigured() bool {
+	if os.Getenv(constants.EnvHipchatApprovalsPasswort) != "" &&
+		os.Getenv(constants.EnvHipchatApprovalsUserName) != "" {
+		return true
+	}
+	return false
+}
+
+func getConnectionAttempts() int {
+	if os.Getenv(constants.EnvHipchatConnectionAttempts) != "" {
+		i, err := strconv.Atoi(os.Getenv(constants.EnvHipchatConnectionAttempts))
+		if err == nil {
+			return i
+		}
+		return connectionAttemptsDefault
+	}
+	return connectionAttemptsDefault
 }

--- a/bot/hipchat/hipchat_test.go
+++ b/bot/hipchat/hipchat_test.go
@@ -1,0 +1,265 @@
+package hipchat
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	h "github.com/daneharrigan/hipchat"
+	"github.com/keel-hq/keel/approvals"
+	b "github.com/keel-hq/keel/bot"
+	"github.com/keel-hq/keel/cache/memory"
+	"github.com/keel-hq/keel/provider/kubernetes"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/codecs"
+	testutil "github.com/keel-hq/keel/util/testing"
+)
+
+type fakeProvider struct {
+	submitted []types.Event
+	images    []*types.TrackedImage
+}
+
+func (p *fakeProvider) Submit(event types.Event) error {
+	p.submitted = append(p.submitted, event)
+	return nil
+}
+
+func (p *fakeProvider) TrackedImages() ([]*types.TrackedImage, error) {
+	return p.images, nil
+}
+
+func (p *fakeProvider) List() []string {
+	return []string{"fakeprovider"}
+}
+func (p *fakeProvider) Stop() {
+	return
+}
+func (p *fakeProvider) GetName() string {
+	return "fp"
+}
+
+var botMessagesChannel chan *b.BotMessage
+var approvalsRespCh chan *b.ApprovalResponse
+
+type postedMessage struct {
+	channel string
+	text    string
+}
+
+type fakeXmppImplementer struct {
+	postedMessages []postedMessage
+	messages       chan *h.Message
+}
+
+func (i *fakeXmppImplementer) messageFromChat(message string) {
+	i.messages <- &h.Message{
+		Body: "@keel " + message,
+		From: "111111_approvals@conf.hipchat.com/test",
+		To:   "222222_333333@chat.hipchat.com/bot",
+	}
+}
+
+func (i *fakeXmppImplementer) Say(roomID, name, body string) {
+	i.postedMessages = append(i.postedMessages, postedMessage{
+		text:    body,
+		channel: roomID,
+	})
+}
+func (i *fakeXmppImplementer) Status(s string) {
+}
+func (i *fakeXmppImplementer) Join(roomID, resource string) {
+}
+func (i *fakeXmppImplementer) KeepAlive() {
+}
+func (i *fakeXmppImplementer) Messages() <-chan *h.Message {
+	return i.messages
+}
+
+func NewBot(k8sImplementer kubernetes.Implementer,
+	approvalsManager approvals.Manager, fi XmppImplementer) *Bot {
+
+	approvalsRespCh = make(chan *b.ApprovalResponse)
+	botMessagesChannel = make(chan *b.BotMessage)
+	fakeBot := &Bot{}
+	fakeBot.hipchatClient = fi
+
+	os.Setenv("HIPCHAT_APPROVALS_CHANNEL", "111111_approvals@conf.hipchat.com")
+	os.Setenv("HIPCHAT_APPROVALS_BOT_NAME", "keel")
+	os.Setenv("HIPCHAT_APPROVALS_USER_NAME", "111111_222222")
+	os.Setenv("HIPCHAT_APPROVALS_PASSWORT", "pass")
+	os.Setenv("HIPCHAT_CONNECTION_ATTEMPTS", "0")
+
+	b.RegisterBot("fakechat", fakeBot)
+	b.Run(k8sImplementer, approvalsManager)
+	return fakeBot
+}
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+func TestHelpCommand(t *testing.T) {
+	f8s := &testutil.FakeK8sImplementer{}
+	fi := &fakeXmppImplementer{}
+	fi.messages = make(chan *h.Message)
+	mem := memory.NewMemoryCache(100*time.Second, 100*time.Second, 10*time.Second)
+	am := approvals.New(mem, codecs.DefaultSerializer())
+
+	NewBot(f8s, am, fi)
+	defer b.Stop()
+
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 1 {
+		t.Errorf("expected to find 1 message, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[0].text, "Keel bot was started") {
+		t.Errorf("expected to find greeting message, but got: %s", fi.postedMessages[0].text)
+	}
+
+	fi.messageFromChat("help")
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 2 {
+		t.Errorf("expected to find 2 messages, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[1].text, "/code Here's a list of supported commands") {
+		t.Errorf("expected to find help message, but got: %s", fi.postedMessages[1].text)
+	}
+}
+
+func TestBotAproval(t *testing.T) {
+	f8s := &testutil.FakeK8sImplementer{}
+	fi := &fakeXmppImplementer{}
+	fi.messages = make(chan *h.Message)
+	mem := memory.NewMemoryCache(100*time.Second, 100*time.Second, 10*time.Second)
+	am := approvals.New(mem, codecs.DefaultSerializer())
+
+	NewBot(f8s, am, fi)
+	defer b.Stop()
+
+	time.Sleep(1 * time.Second)
+
+	err := am.Create(&types.Approval{
+		Identifier:     "k8s/project/repo:1.2.3",
+		VotesRequired:  1,
+		CurrentVersion: "2.3.4",
+		NewVersion:     "3.4.5",
+		Event: &types.Event{
+			Repository: types.Repository{
+				Name: "project/repo",
+				Tag:  "2.3.4",
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error while creating : %s", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 2 {
+		t.Errorf("expected to find 2 message, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[1].text, "/code Approval required!") {
+		t.Errorf("expected to find help message, but got: %s", fi.postedMessages[1].text)
+	}
+
+	// approve
+	fi.messageFromChat("approve k8s/project/repo:1.2.3")
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 3 {
+		t.Errorf("expected to find 3 message, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[2].text, "/code Update approved!") {
+		t.Errorf("expected to find message, but got: %s", fi.postedMessages[2].text)
+	}
+
+	// get approvals
+	fi.messageFromChat("get approvals")
+	time.Sleep(1 * time.Second)
+	if len(fi.postedMessages) != 4 {
+		t.Errorf("expected to find 4 message, but got: %d", len(fi.postedMessages))
+	}
+	resp := trimSpaces(fi.postedMessages[3].text)
+
+	if !strings.Contains(resp, "k8s/project/repo:1.2.3 2.3.4 -> 3.4.5 1/1 false") {
+		t.Errorf("expected to find message, but got: %s", resp)
+	}
+}
+
+func TestBotReject(t *testing.T) {
+	f8s := &testutil.FakeK8sImplementer{}
+	fi := &fakeXmppImplementer{}
+	fi.messages = make(chan *h.Message)
+	mem := memory.NewMemoryCache(100*time.Second, 100*time.Second, 10*time.Second)
+	am := approvals.New(mem, codecs.DefaultSerializer())
+
+	NewBot(f8s, am, fi)
+	defer b.Stop()
+
+	time.Sleep(1 * time.Second)
+
+	err := am.Create(&types.Approval{
+		Identifier:     "k8s/project/repo:1.2.3",
+		VotesRequired:  1,
+		CurrentVersion: "2.3.4",
+		NewVersion:     "3.4.5",
+		Event: &types.Event{
+			Repository: types.Repository{
+				Name: "project/repo",
+				Tag:  "2.3.4",
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error while creating : %s", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 2 {
+		t.Errorf("expected to find 2 message, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[1].text, "/code Approval required!") {
+		t.Errorf("expected to find help message, but got: %s", fi.postedMessages[1].text)
+	}
+
+	// reject
+	fi.messageFromChat("reject k8s/project/repo:1.2.3")
+	time.Sleep(1 * time.Second)
+
+	if len(fi.postedMessages) != 3 {
+		t.Errorf("expected to find 3 message, but got: %d", len(fi.postedMessages))
+	}
+	if !strings.HasPrefix(fi.postedMessages[2].text, "/code Change rejected") {
+		t.Errorf("expected to find message, but got: %s", fi.postedMessages[2].text)
+	}
+
+	// get approvals
+	fi.messageFromChat("get approvals")
+	time.Sleep(1 * time.Second)
+	if len(fi.postedMessages) != 4 {
+		t.Errorf("expected to find 4 message, but got: %d", len(fi.postedMessages))
+	}
+	resp := trimSpaces(fi.postedMessages[3].text)
+
+	if !strings.Contains(resp, "k8s/project/repo:1.2.3 2.3.4 -> 3.4.5 0/1 true") {
+		t.Errorf("expected to find message, but got: %s", resp)
+	}
+}
+
+func trimSpaces(input string) string {
+	reLeadcloseWhtsp := regexp.MustCompile(`^[\s\p{Zs}]+|[\s\p{Zs}]+$`)
+	reInsideWhtsp := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
+	final := reLeadcloseWhtsp.ReplaceAllString(input, "")
+	final = reInsideWhtsp.ReplaceAllString(final, " ")
+	return final
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -20,10 +20,11 @@ const (
 	EnvHipchatBotName  = "HIPCHAT_BOT_NAME"
 	EnvHipchatChannels = "HIPCHAT_CHANNELS"
 
-	EnvHipchatApprovalsChannel  = "HIPCHAT_APPROVALS_CHANNEL"
-	EnvHipchatApprovalsUserName = "HIPCHAT_APPROVALS_USER_NAME"
-	EnvHipchatApprovalsBotName  = "HIPCHAT_APPROVALS_BOT_NAME"
-	EnvHipchatApprovalsPasswort = "HIPCHAT_APPROVALS_PASSWORT"
+	EnvHipchatApprovalsChannel   = "HIPCHAT_APPROVALS_CHANNEL"
+	EnvHipchatApprovalsUserName  = "HIPCHAT_APPROVALS_USER_NAME"
+	EnvHipchatApprovalsBotName   = "HIPCHAT_APPROVALS_BOT_NAME"
+	EnvHipchatApprovalsPasswort  = "HIPCHAT_APPROVALS_PASSWORT"
+	EnvHipchatConnectionAttempts = "HIPCHAT_CONNECTION_ATTEMPTS"
 )
 
 // EnvNotificationLevel - minimum level for notifications, defaults to info


### PR DESCRIPTION
* moved duplicated code to bot.go
* added interface for approval bots 
* fixed slack tests
* added hipchat tests (was tricky to mock hipchat calls out)
* Issues: if both approval bots are configured it doesn't work properly. If this can be a use-case, I can fix it, it is not so complicated
* TODO: if the new interface is OK we can write some tests for approval bot without any chat, using only interfaces 
