### PR TITLE
update helm chart for keel

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -107,6 +107,13 @@ The following table lists has the main configurable parameters (polling, trigger
 | `webhookRelay.secret`             | WebhookRelay secret                    |                                                           |
 | `webhookRelay.bucket`             | WebhookRelay bucket                    |                                                           |
 | `rbac.enabled`                    | Enable/disable RBAC installation       | `false`                                                   |
+| `hipchat.enabled`                 | Enable/disable hipchat integration     | `false`                                                   |
+| `hipchat.token`                   | Hipchat token                          |                                                           |
+| `hipchat.channel`                 | Hipchat channel                        |                                                           |
+| `hipchat.approvals_channel`       | Hipchat channel for approvals          |                                                           |
+| `hipchat.bot_name`                | Name of the Hipchat bot                |                                                           |
+| `hipchat.user_name`               | Hipchat username in Jabber format      |                                                           |
+| `hipchat.password`                | Hipchat password for approvals user    |                                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -54,6 +54,21 @@ spec:
             - name: SLACK_CHANNELS
               value: "{{ .Values.slack.channel }}"
 {{- end }}
+{{- if .Values.hipchat.enabled }}
+            # Enable hipchat approvials and notification
+            - name: HIPCHAT_TOKEN
+              value: "{{ .Values.hipchat.token }}"
+            - name: HIPCHAT_CHANNELS
+              value: "{{ .Values.hipchat.channel }}"
+            - name: HIPCHAT_APPROVALS_CHANNEL
+              value: "{{ .Values.hipchat.approvals_channel }}"
+            - name: HIPCHAT_APPROVALS_BOT_NAME
+              value: "{{ .Values.hipchat.bot_name }}"
+            - name: HIPCHAT_APPROVALS_USER_NAME
+              value: "{{ .Values.hipchat.user_name }}"
+            - name: HIPCHAT_APPROVALS_PASSWORT
+              value: "{{ .Values.hipchat.password }}"
+{{- end }}
           ports:
             - containerPort: 9300
           livenessProbe:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -36,6 +36,16 @@ slack:
   token: ""
   channel: ""
 
+# Hipchat notification and approvals
+hipchat:
+  enabled: false
+  token: ""
+  channel: ""
+  approvals_channel: ""
+  bot_name: ""
+  user_name: ""
+  password: ""
+
 # Keel service
 # Enable to receive webhooks from Docker registries
 service:


### PR DESCRIPTION
I added the hipchat environment variables in the values.yml as well as in the deployment.yaml
If hipchat.enabled is set to ```true``` those variables will be used otherwise not. 

I also added the variables and a short description in the readme of the helm chart. 

the related Issue can be found [here](https://github.com/keel-hq/keel/issues/134)
edit: 
```helm lint . ``` shows
```
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
```