### PR TITLE
remove unsupported @mention name from Hipchat bot

### DIFF
--- a/bot/hipchat/approvals.go
+++ b/bot/hipchat/approvals.go
@@ -8,7 +8,7 @@ import (
 
 func (b *Bot) RequestApproval(req *types.Approval) error {
 	msg := fmt.Sprintf(ApprovalRequiredTempl,
-		req.Message, b.mentionName, req.Identifier, b.mentionName, req.Identifier,
+		req.Message, req.Identifier, req.Identifier,
 		req.VotesReceived, req.VotesRequired, req.Delta(), req.Identifier,
 		req.Provider.String())
 	return b.postMessage(formatAsSnippet(msg))

--- a/bot/hipchat/client.go
+++ b/bot/hipchat/client.go
@@ -19,7 +19,7 @@ type HipchatClient struct {
 	XmppImplementer
 }
 
-func connect(username, password string, connAttempts int) *HipchatClient {
+func connect(username, password, botName string, connAttempts int) *HipchatClient {
 	// c := &Client{}
 	attempts := connAttempts
 	for {
@@ -27,8 +27,8 @@ func connect(username, password string, connAttempts int) *HipchatClient {
 			log.Errorf("Can not reach hipchat server after %d attempts", connAttempts)
 			return nil
 		}
-		log.Info("bot.hipchat.connect: try to connect to hipchat")
-		client, err := hipchat.NewClient(username, password, "bot", "plain")
+		log.Infof("bot.hipchat.connect: try to connect to hipchat as [%s]", botName)
+		client, err := hipchat.NewClient(username, password, botName, "plain")
 
 		if err != nil {
 			log.Errorf("bot.hipchat.connect: Error=%s", err)
@@ -39,8 +39,6 @@ func connect(username, password string, connAttempts int) *HipchatClient {
 		if client != nil && err == nil {
 			log.Info("Successfully connected to hipchat server")
 			return &HipchatClient{client}
-			// c.cli = client
-			// return c
 		}
 		log.Debugln("Can not connect to hipcaht now, wait fo 30 seconds")
 		time.Sleep(30 * time.Second)

--- a/bot/hipchat/client.go
+++ b/bot/hipchat/client.go
@@ -19,16 +19,15 @@ type HipchatClient struct {
 	XmppImplementer
 }
 
-func connect(username, password, botName string, connAttempts int) *HipchatClient {
-	// c := &Client{}
+func connect(username, password string, connAttempts int) *HipchatClient {
 	attempts := connAttempts
 	for {
 		if attempts == 0 {
 			log.Errorf("Can not reach hipchat server after %d attempts", connAttempts)
 			return nil
 		}
-		log.Infof("bot.hipchat.connect: try to connect to hipchat as [%s]", botName)
-		client, err := hipchat.NewClient(username, password, botName, "plain")
+		// Room history is automatically sent when joining a room unless your JID resource is “bot”.
+		client, err := hipchat.NewClient(username, password, "bot", "plain")
 
 		if err != nil {
 			log.Errorf("bot.hipchat.connect: Error=%s", err)

--- a/bot/hipchat/hipchat.go
+++ b/bot/hipchat/hipchat.go
@@ -19,9 +19,8 @@ const connectionAttemptsDefault = 5
 
 // Bot - main hipchat bot container
 type Bot struct {
-	id          string // bot id
-	name        string // bot name
-	mentionName string
+	id   string // bot id
+	name string // bot name
 
 	userName string // bot user name
 	password string // bot user password
@@ -51,11 +50,10 @@ func (b *Bot) Configure(approvalsRespCh chan *bot.ApprovalResponse, botMessagesC
 		b.password = os.Getenv(constants.EnvHipchatApprovalsPasswort)
 		connAttempts := getConnectionAttempts()
 
-		cli := connect(b.userName, b.password, connAttempts)
+		cli := connect(b.userName, b.password, b.name, connAttempts)
 		if cli != nil {
 			b.hipchatClient = cli
 		}
-		b.mentionName = "@" + strings.Replace(b.name, " ", "", -1)
 		b.botMessagesChannel = botMessagesChannel
 		b.approvalsRespCh = approvalsRespCh
 
@@ -83,7 +81,6 @@ func (b *Bot) Start(ctx context.Context) error {
 	client.Status("chat")
 	client.Join(b.approvalsChannel, b.name)
 	b.postMessage("Keel bot was started")
-
 	go client.KeepAlive()
 	go func() {
 		for {
@@ -111,13 +108,12 @@ func (b *Bot) handleMessage(message *h.Message) {
 	}
 
 	if !b.isBotMessage(msg) {
-		log.Debugf("handleMessage(): is not a bot message [%v]", msg)
+		log.Debugf("handleMessage(): is not a bot message [%#v]", msg)
 		return
 	}
 
 	approval, ok := bot.IsApproval(msg.From, msg.Body)
 	if ok {
-		log.Debug("handleMessage(): approval=%v", approval)
 		b.approvalsRespCh <- approval
 		return
 	}
@@ -138,24 +134,11 @@ func formatAsSnippet(msg string) string {
 
 func (b *Bot) trimXMPPMessage(message *h.Message) *h.Message {
 	msg := h.Message{}
-	msg.MentionName = trimMentionName(message.Body)
 	msg.Body = b.trimBot(message.Body)
 	msg.From = b.trimUser(message.From)
 	msg.To = b.trimUser(message.To)
 
 	return &msg
-}
-
-func trimMentionName(message string) string {
-	re := regexp.MustCompile(`^(@\w+)`)
-	match := re.FindStringSubmatch(strings.TrimSpace(message))
-	if match == nil {
-		return ""
-	}
-	if len(match) != 0 {
-		return strings.TrimSpace(match[1])
-	}
-	return ""
 }
 
 func (b *Bot) trimUser(user string) string {
@@ -176,14 +159,15 @@ func (b *Bot) postMessage(msg string) error {
 }
 
 func (b *Bot) trimBot(msg string) string {
-	msg = strings.TrimPrefix(msg, b.mentionName)
+	var re = regexp.MustCompile(`(^@\w+)`)
+	msg = re.ReplaceAllString(msg, "")
 	msg = strings.Trim(msg, "\n")
 	msg = strings.TrimSpace(msg)
 	return strings.ToLower(msg)
 }
 
 func (b *Bot) isBotMessage(message *h.Message) bool {
-	if message.MentionName == b.mentionName {
+	if message.To == b.name {
 		return true
 	}
 	return false

--- a/bot/hipchat/hipchat.go
+++ b/bot/hipchat/hipchat.go
@@ -50,7 +50,7 @@ func (b *Bot) Configure(approvalsRespCh chan *bot.ApprovalResponse, botMessagesC
 		b.password = os.Getenv(constants.EnvHipchatApprovalsPasswort)
 		connAttempts := getConnectionAttempts()
 
-		cli := connect(b.userName, b.password, b.name, connAttempts)
+		cli := connect(b.userName, b.password, connAttempts)
 		if cli != nil {
 			b.hipchatClient = cli
 		}
@@ -167,7 +167,7 @@ func (b *Bot) trimBot(msg string) string {
 }
 
 func (b *Bot) isBotMessage(message *h.Message) bool {
-	if message.To == b.name {
+	if message.To == "bot" {
 		return true
 	}
 	return false

--- a/bot/hipchat/hipchat_test.go
+++ b/bot/hipchat/hipchat_test.go
@@ -62,7 +62,7 @@ func (i *fakeXmppImplementer) messageFromChat(message string) {
 	i.messages <- &h.Message{
 		Body: "@keel " + message,
 		From: "111111_approvals@conf.hipchat.com/test",
-		To:   "222222_333333@chat.hipchat.com/keel",
+		To:   "222222_333333@chat.hipchat.com/bot",
 	}
 }
 

--- a/bot/hipchat/hipchat_test.go
+++ b/bot/hipchat/hipchat_test.go
@@ -62,7 +62,7 @@ func (i *fakeXmppImplementer) messageFromChat(message string) {
 	i.messages <- &h.Message{
 		Body: "@keel " + message,
 		From: "111111_approvals@conf.hipchat.com/test",
-		To:   "222222_333333@chat.hipchat.com/bot",
+		To:   "222222_333333@chat.hipchat.com/keel",
 	}
 }
 

--- a/bot/hipchat/templates.go
+++ b/bot/hipchat/templates.go
@@ -2,8 +2,8 @@ package hipchat
 
 var ApprovalRequiredTempl = `Approval required!
   %s
-  To vote for change type '%s approve %s'
-  To reject it: '%s reject %s'
+  To vote for change send 'approve %s' to me
+  To reject it: 'reject %s'
     Votes: %d/%d
     Delta: %s
     Identifier: %s


### PR DESCRIPTION
removed `mentionName` from hipchat bot, it was not used correctly 