### PR TITLE
Helm Chart: Add Slack bot name as variable

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
               value: "{{ .Values.slack.channel }}"
             - name: SLACK_APPROVALS_CHANNEL
               value: "{{ .Values.slack.approvals_channel }}"
+  {{- if .Values.slack.bot_name }}
+            - name: SLACK_BOT_NAME
+              value: "{{ .Values.slack.bot_name }}"
+  {{- end }}
 {{- end }}
 {{- if .Values.hipchat.enabled }}
             # Enable hipchat approvials and notification

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -31,8 +31,10 @@ webhook:
   endpoint: ""
 
 # Slack Notification
+# bot name (default keel) must exist!
 slack:
   enabled: false
+  bot_name: ""
   token: ""
   channel: ""
   approvals_channel: ""


### PR DESCRIPTION
like `hipchat`, allow `bot_name` to be set.