### PR TITLE
setting change cause for versioned deployment

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -220,6 +220,7 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*v1beta1.De
 			err = p.forceUpdate(&deployment)
 		} else {
 			// regular update
+			deployment.Annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update version %s -> %s", plan.CurrentVersion, plan.NewVersion)
 			err = p.implementer.Update(&deployment)
 		}
 		if err != nil {


### PR DESCRIPTION
Showing change cause:

```
➜  keel git:(feature/change_cause) ✗ kubectl rollout history deployment/whr
deployments "whr"
REVISION  CHANGE-CAUSE
41        keel automated update version 0.10.5 -> 0.10.6
```