### PR TITLE
Helm unversioned digest annotations

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,14 @@
+FROM golang:1.9.3
+COPY . /go/src/github.com/keel-hq/keel
+WORKDIR /go/src/github.com/keel-hq/keel
+RUN make build
+
+FROM debian:latest
+RUN apt-get update && apt-get install -y \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=0 /go/src/github.com/keel-hq/keel/cmd/keel/keel /bin/keel
+ENTRYPOINT ["/bin/keel"]
+
+EXPOSE 9300

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ install:
 image:
 	docker build -t keelhq/keel:alpha -f Dockerfile .
 
+image-debian:
+	docker build -t keelhq/keel:alpha -f Dockerfile.debian .
+
 alpha: image
 	@echo "++ Pushing keel alpha"	
 	docker push keelhq/keel:alpha

--- a/provider/helm/helm.go
+++ b/provider/helm/helm.go
@@ -106,6 +106,7 @@ type KeelChartConfig struct {
 type ImageDetails struct {
 	RepositoryPath string `json:"repository"`
 	TagPath        string `json:"tag"`
+	DigestPath     string `json:"digest"`
 }
 
 // Provider - helm provider, responsible for managing release updates

--- a/provider/helm/unversioned_updates.go
+++ b/provider/helm/unversioned_updates.go
@@ -70,6 +70,14 @@ func checkUnversionedRelease(repo *types.Repository, namespace, name string, cha
 			continue
 		}
 
+		if imageDetails.DigestPath != "" {
+			plan.Values[imageDetails.DigestPath] = repo.Digest
+			log.WithFields(log.Fields{
+				"image_details_digestPath": imageDetails.DigestPath,
+				"target_image_digest":      repo.Digest,
+			}).Debug("provider.helm: setting image Digest")
+		}
+
 		path, value := getUnversionedPlanValues(repo.Tag, imageRef, &imageDetails)
 		plan.Values[path] = value
 		plan.NewVersion = repo.Tag


### PR DESCRIPTION
Add support for image digest annotations on podSpec for helm provider.

Currently, we may force rolling updates on deployment by adding `date/deploy-date: {{ now | quote }}` as an annotation on the podSpec.

This PR adds support for image digest annotations to ensure only changed deployments get a rolling update.

Tested using [k8s-flask-app](https://github.com/so0k/flask_app_k8s/blob/2ba1bfba39bfebfaf12d04864fc79df679e932a8/chart/flask-app/values.yaml#L49) and [swo0k/keel](https://hub.docker.com/r/swo0k/keel/tags/) alpha image

keel logs on image digest change for the above sample chart:

```
time="2018-05-28T16:08:22Z" level=info msg="provider.helm: processing event" registry= repository=index.docker.io/swo0k/flask-demo-app tag=master"
time="2018-05-28T16:08:22Z" level=debug msg="provider.helm: setting image Digest" image_details_digestPath=image.digest target_image_digest="sha256:bc012350f240c6bae60fc4d4531b3811c5bee1f0c61ed4410a2cc94183f0273b"
```
