### PR TITLE
Use helm release namespace for installation

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.1.12
-appversion: 0.8.2
+version: 0.2.0
+appversion: 0.9.0
 keywords:
 - kubernetes deployment
 - helm release

--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -22,8 +22,6 @@ Keel provides several key features:
 * __Notifications__ - out of the box Keel has Slack and standard webhook notifications, more info [here](https://keel.sh/user-guide/#notifications)
 
 
-**Note**: For now Keel gets installed into `kube-system` _namespace_ by default as where Helm's `Tiller` is installed.
-
 ## Installing
 
 Docker image _polling_, _Kubernetes provider_ and _Helm provider_ support are set by default, then Kubernetes _deployments_ can be upgraded when new Docker image is available:

--- a/chart/keel/templates/NOTES.txt
+++ b/chart/keel/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 To verify that {{ template "keel.name" . }} has started, run:
 
-  kubectl --namespace=kube-system get pods -l "app={{ template "keel.name" . }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "keel.name" . }}"
 
 {{- if .Values.service.enabled }}
 
@@ -11,21 +11,21 @@ To verify that {{ template "keel.name" . }} has started, run:
 {{- if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace kube-system -w {{ template "keel.name" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "keel.name" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace kube-system  {{ template "keel.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }}  {{ template "keel.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace kube-system  -l "app={{ template "keel.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }}  -l "app={{ template "keel.name" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.service.externalPort }}
-  kubectl port-forward --namespace kube-system $POD_NAME {{ .Values.service.externalPort }}:{{ .Values.service.externalPort }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.externalPort }}:{{ .Values.service.externalPort }}
 
 {{- else if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace kube-system  -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "keel.name" . }})
-  export NODE_IP=$(kubectl get nodes --namespace kube-system  -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }}  -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "keel.name" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }}  -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 
 {{- end }}

--- a/chart/keel/templates/clusterrolebinding.yaml
+++ b/chart/keel/templates/clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "keel.name" . }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: HELM_PROVIDER
               value: "1"
             - name: TILLER_ADDRESS
-              value: "1"
+              value: "{{ .Values.helmProvider.tillerAddress }}"
 {{- end }}
 {{- if .Values.gcr.enabled }}
             # Enable GCR with pub/sub support

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "keel.fullname" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}
@@ -33,6 +33,8 @@ spec:
               readOnly: true
 {{- end }}
           env:
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
 {{- if .Values.googleApplicationCredentials }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /google/google-application-credentials.json
@@ -49,6 +51,8 @@ spec:
 {{- if .Values.helmProvider.enabled }}
             # Enable/disable Helm provider
             - name: HELM_PROVIDER
+              value: "1"
+            - name: TILLER_ADDRESS
               value: "1"
 {{- end }}
 {{- if .Values.gcr.enabled }}

--- a/chart/keel/templates/secrets-google.yaml
+++ b/chart/keel/templates/secrets-google.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "keel.name" . }}-google
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}

--- a/chart/keel/templates/secrets-webhookrelay.yaml
+++ b/chart/keel/templates/secrets-webhookrelay.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "keel.name" . }}-webhookrelay
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}

--- a/chart/keel/templates/service-account.yaml
+++ b/chart/keel/templates/service-account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "keel.name" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}

--- a/chart/keel/templates/service.yaml
+++ b/chart/keel/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "keel.name" . }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -18,6 +18,7 @@ polling:
 # Helm provider support
 helmProvider:
   enabled: true
+  tillerAddress: tiller-deploy.kube-system.svc.cluster.local.:44134
 
 # Google Container Registry
 # GCP Project ID

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: keelhq/keel
-  tag: 0.8.3
+  tag: 0.9.0
   pullPolicy: IfNotPresent
 
 # Enable insecure registries

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -18,7 +18,7 @@ polling:
 # Helm provider support
 helmProvider:
   enabled: true
-  tillerAddress: tiller-deploy.kube-system.svc.cluster.local.:44134
+  tillerAddress: "tiller-deploy.kube-system.svc.cluster.local:44134"
 
 # Google Container Registry
 # GCP Project ID


### PR DESCRIPTION
This removes hard-coded installation into `kube-system` in favor of using the helm release namespace, allowing the user to chose where to install keel.

To connect to tiller, I added a new value `helmProvider.tillerAddress` with a default that should match the old behavior (tiller-deploy in kube-system).

Mentioned in #136 