### PR TITLE
bump webhookrelay → 0.6.3

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
         - name: webhookrelayd
           image: "{{ .Values.webhookRelay.image.repository }}:{{ .Values.webhookRelay.image.tag }}"
           imagePullPolicy: {{ .Values.webhookRelay.image.pullPolicy }}
-          command: ["/webhookrelayd"]
+          command: ["/relayd"]
           env:
             - name: KEY
               valueFrom:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -77,7 +77,7 @@ webhookRelay:
   # webhookrelay docker image
   image:
     repository: webhookrelay/webhookrelayd
-    tag: 0.6.0
+    tag: 0.6.3
     pullPolicy: IfNotPresent
 
 # Keel self-update


### PR DESCRIPTION
The latest version of the relay sidecar works with dockerhub webhooks, after setting up a webrelay.com account. Nivce

The daemon executable name was changed with `webhookrelay/webhookrelayd:0.6.3`.

Also just fyi `webhookrelay/webhookrelayd:latest` is pretty old so that made figuring out the above a little more interesting.

Is `relayd` open source?