### PR TITLE
allow keel-webhookrelay secret to be external

### DIFF
--- a/chart/keel/templates/secrets-webhookrelay.yaml
+++ b/chart/keel/templates/secrets-webhookrelay.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhookRelay.enabled }}
+{{- if (and .Values.webhookRelay.enabled .Values.webhookRelay.key .Values.webhookRelay.secret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -70,10 +70,12 @@ service:
 # which can deliver webhooks to your internal Keel service through Keel sidecar container.
 webhookRelay:
   enabled: false
+  bucket: ""
   # webhookrelay.com credentials
+  # Set the key and secret values here to create the keel-webhookrelay secret with this
+  # chart -or- leave key and secret blank and create the keel-webhookrelay secret separately.
   key: ""
   secret: ""
-  bucket: ""
   # webhookrelay docker image
   image:
     repository: webhookrelay/webhookrelayd


### PR DESCRIPTION
We manage secrets with https://github.com/bitnami-labs/sealed-secrets

This PR allows the webhookrelay.com secret to be either in the keel chart or managed separately.