### PR TITLE
Feature/registry cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.9.3           
+      - image: circleci/golang:1.10.3           
 
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.3
+FROM golang:1.10.3
 COPY . /go/src/github.com/keel-hq/keel
 WORKDIR /go/src/github.com/keel-hq/keel
 RUN make install

--- a/deployment/deployment-norbac.yaml
+++ b/deployment/deployment-norbac.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: keel
       containers:
-        - image: keelhq/keel:0.8.3
+        - image: keelhq/keel:alpha
           imagePullPolicy: Always
           env:
             # - name: POLL
@@ -42,6 +42,10 @@ spec:
             #   value: "1"
             # - name: TILLER_ADDRESS
             #   value: tiller-deploy.kube-system.svc.cluster.local:44134
+            # Default Docker registry configuration (will override secrets if there are any)
+            # 'auth' parameter is base 64 encoded username:password pair. Ideally this environment variable would be a Kubernetes secret.
+            # - name: DOCKER_REGISTRY_CFG
+            #   value: '{"auths":{"https://index.docker.io/v1/":{"username":"login","password":"somepass","email":"email@email.com","auth":"longbase64secret"}}}'
             - name: PROJECT_ID
               value: "my-project-id"
             # - name: WEBHOOK_ENDPOINT

--- a/deployment/deployment-rbac.yaml
+++ b/deployment/deployment-rbac.yaml
@@ -86,7 +86,7 @@ spec:
     spec:
       serviceAccountName: keel
       containers:
-        - image: keelhq/keel:0.8.3
+        - image: keelhq/keel:0.9.3
           imagePullPolicy: Always
           env:
             # - name: POLL
@@ -96,6 +96,10 @@ spec:
             # Enable/disable Helm provider
             # - name: HELM_PROVIDER
             #   value: "1"
+            # Default Docker registry configuration (will override secrets if there are any)
+            # 'auth' parameter is base 64 encoded username:password pair. Ideally this environment variable would be a Kubernetes secret.
+            # - name: DOCKER_REGISTRY_CFG
+            #   value: '{"auths":{"https://index.docker.io/v1/":{"username":"login","password":"somepass","email":"email@email.com","auth":"longbase64secret"}}}'
             - name: PROJECT_ID
               value: "my-project-id"
             # - name: WEBHOOK_ENDPOINT

--- a/hack/deployment.sample.yml
+++ b/hack/deployment.sample.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: keel
       containers:
-        - image: keelhq/keel:0.8.3
+        - image: keelhq/keel:0.9.3
           imagePullPolicy: Always
           env:
             # - name: POLL

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -214,60 +214,6 @@ func (g *DefaultGetter) getCredentialsFromSecret(image *types.TrackedImage) (*ty
 		if found {
 			return creds, nil
 		}
-
-		// looking for our registry
-		// for registry, auth := range dockerCfg {
-		// 	h, err := hostname(registry)
-		// 	if err != nil {
-		// 		log.WithFields(log.Fields{
-		// 			"image":      image.Image.Repository(),
-		// 			"namespace":  image.Namespace,
-		// 			"registry":   registry,
-		// 			"secret_ref": secretRef,
-		// 			"error":      err,
-		// 		}).Error("secrets.defaultGetter: failed to parse hostname")
-		// 		continue
-		// 	}
-
-		// 	if h == image.Image.Registry() {
-		// 		if auth.Username != "" && auth.Password != "" {
-		// 			credentials.Username = auth.Username
-		// 			credentials.Password = auth.Password
-		// 		} else if auth.Auth != "" {
-		// 			username, password, err := decodeBase64Secret(auth.Auth)
-		// 			if err != nil {
-		// 				log.WithFields(log.Fields{
-		// 					"image":      image.Image.Repository(),
-		// 					"namespace":  image.Namespace,
-		// 					"registry":   registry,
-		// 					"secret_ref": secretRef,
-		// 					"error":      err,
-		// 				}).Error("secrets.defaultGetter: failed to decode auth secret")
-		// 				continue
-		// 			}
-		// 			credentials.Username = username
-		// 			credentials.Password = password
-		// 		} else {
-		// 			log.WithFields(log.Fields{
-		// 				"image":      image.Image.Repository(),
-		// 				"namespace":  image.Namespace,
-		// 				"registry":   registry,
-		// 				"secret_ref": secretRef,
-		// 				"error":      err,
-		// 			}).Warn("secrets.defaultGetter: secret doesn't have username, password and base64 encoded auth, skipping")
-		// 			continue
-		// 		}
-
-		// 		log.WithFields(log.Fields{
-		// 			"namespace": image.Namespace,
-		// 			"provider":  image.Provider,
-		// 			"registry":  image.Image.Registry(),
-		// 			"image":     image.Image.Repository(),
-		// 		}).Debug("secrets.defaultGetter: secret looked up successfully")
-
-		// 		return credentials, nil
-		// 	}
-		// }
 	}
 
 	if len(image.Secrets) > 0 {
@@ -299,11 +245,6 @@ func credentialsFromConfig(image *types.TrackedImage, cfg DockerCfg) (*types.Cre
 			}).Error("secrets.defaultGetter: failed to parse hostname")
 			continue
 		}
-
-		log.WithFields(log.Fields{
-			"wanted":  h,
-			"current": image.Image.Registry(),
-		}).Info("searching for the registry")
 
 		if h == image.Image.Registry() {
 			if auth.Username != "" && auth.Password != "" {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -36,12 +36,20 @@ type Getter interface {
 // DefaultGetter - default kubernetes secret getter implementation
 type DefaultGetter struct {
 	kubernetesImplementer kubernetes.Implementer
+	defaultDockerConfig   DockerCfg // default configuration supplied by optional environment variable
 }
 
 // NewGetter - create new default getter
-func NewGetter(implementer kubernetes.Implementer) *DefaultGetter {
+func NewGetter(implementer kubernetes.Implementer, defaultDockerConfig DockerCfg) *DefaultGetter {
+
+	// initialising empty configuration
+	if defaultDockerConfig == nil {
+		defaultDockerConfig = make(DockerCfg)
+	}
+
 	return &DefaultGetter{
 		kubernetesImplementer: implementer,
+		defaultDockerConfig:   defaultDockerConfig,
 	}
 }
 
@@ -49,6 +57,12 @@ func NewGetter(implementer kubernetes.Implementer) *DefaultGetter {
 func (g *DefaultGetter) Get(image *types.TrackedImage) (*types.Credentials, error) {
 	if image.Namespace == "" {
 		return nil, ErrNamespaceNotSpecified
+	}
+
+	// checking in default creds
+	creds, found := g.lookupDefaultDockerConfig(image)
+	if found {
+		return creds, nil
 	}
 
 	switch image.Provider {
@@ -64,6 +78,10 @@ func (g *DefaultGetter) Get(image *types.TrackedImage) (*types.Credentials, erro
 	}
 
 	return g.getCredentialsFromSecret(image)
+}
+
+func (g *DefaultGetter) lookupDefaultDockerConfig(image *types.TrackedImage) (*types.Credentials, bool) {
+	return credentialsFromConfig(image, g.defaultDockerConfig)
 }
 
 func (g *DefaultGetter) lookupSecrets(image *types.TrackedImage) ([]string, error) {
@@ -170,7 +188,7 @@ func (g *DefaultGetter) getCredentialsFromSecret(image *types.TrackedImage) (*ty
 				continue
 			}
 
-			dockerCfg, err = decodeJSONSecret(secretDataBts)
+			dockerCfg, err = DecodeDockerCfgJson(secretDataBts)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"image":       image.Image.Repository(),
@@ -192,59 +210,64 @@ func (g *DefaultGetter) getCredentialsFromSecret(image *types.TrackedImage) (*ty
 			continue
 		}
 
-		// looking for our registry
-		for registry, auth := range dockerCfg {
-			h, err := hostname(registry)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"image":      image.Image.Repository(),
-					"namespace":  image.Namespace,
-					"registry":   registry,
-					"secret_ref": secretRef,
-					"error":      err,
-				}).Error("secrets.defaultGetter: failed to parse hostname")
-				continue
-			}
-
-			if h == image.Image.Registry() {
-				if auth.Username != "" && auth.Password != "" {
-					credentials.Username = auth.Username
-					credentials.Password = auth.Password
-				} else if auth.Auth != "" {
-					username, password, err := decodeBase64Secret(auth.Auth)
-					if err != nil {
-						log.WithFields(log.Fields{
-							"image":      image.Image.Repository(),
-							"namespace":  image.Namespace,
-							"registry":   registry,
-							"secret_ref": secretRef,
-							"error":      err,
-						}).Error("secrets.defaultGetter: failed to decode auth secret")
-						continue
-					}
-					credentials.Username = username
-					credentials.Password = password
-				} else {
-					log.WithFields(log.Fields{
-						"image":      image.Image.Repository(),
-						"namespace":  image.Namespace,
-						"registry":   registry,
-						"secret_ref": secretRef,
-						"error":      err,
-					}).Warn("secrets.defaultGetter: secret doesn't have username, password and base64 encoded auth, skipping")
-					continue
-				}
-
-				log.WithFields(log.Fields{
-					"namespace": image.Namespace,
-					"provider":  image.Provider,
-					"registry":  image.Image.Registry(),
-					"image":     image.Image.Repository(),
-				}).Debug("secrets.defaultGetter: secret looked up successfully")
-
-				return credentials, nil
-			}
+		creds, found := credentialsFromConfig(image, dockerCfg)
+		if found {
+			return creds, nil
 		}
+
+		// looking for our registry
+		// for registry, auth := range dockerCfg {
+		// 	h, err := hostname(registry)
+		// 	if err != nil {
+		// 		log.WithFields(log.Fields{
+		// 			"image":      image.Image.Repository(),
+		// 			"namespace":  image.Namespace,
+		// 			"registry":   registry,
+		// 			"secret_ref": secretRef,
+		// 			"error":      err,
+		// 		}).Error("secrets.defaultGetter: failed to parse hostname")
+		// 		continue
+		// 	}
+
+		// 	if h == image.Image.Registry() {
+		// 		if auth.Username != "" && auth.Password != "" {
+		// 			credentials.Username = auth.Username
+		// 			credentials.Password = auth.Password
+		// 		} else if auth.Auth != "" {
+		// 			username, password, err := decodeBase64Secret(auth.Auth)
+		// 			if err != nil {
+		// 				log.WithFields(log.Fields{
+		// 					"image":      image.Image.Repository(),
+		// 					"namespace":  image.Namespace,
+		// 					"registry":   registry,
+		// 					"secret_ref": secretRef,
+		// 					"error":      err,
+		// 				}).Error("secrets.defaultGetter: failed to decode auth secret")
+		// 				continue
+		// 			}
+		// 			credentials.Username = username
+		// 			credentials.Password = password
+		// 		} else {
+		// 			log.WithFields(log.Fields{
+		// 				"image":      image.Image.Repository(),
+		// 				"namespace":  image.Namespace,
+		// 				"registry":   registry,
+		// 				"secret_ref": secretRef,
+		// 				"error":      err,
+		// 			}).Warn("secrets.defaultGetter: secret doesn't have username, password and base64 encoded auth, skipping")
+		// 			continue
+		// 		}
+
+		// 		log.WithFields(log.Fields{
+		// 			"namespace": image.Namespace,
+		// 			"provider":  image.Provider,
+		// 			"registry":  image.Image.Registry(),
+		// 			"image":     image.Image.Repository(),
+		// 		}).Debug("secrets.defaultGetter: secret looked up successfully")
+
+		// 		return credentials, nil
+		// 	}
+		// }
 	}
 
 	if len(image.Secrets) > 0 {
@@ -258,6 +281,69 @@ func (g *DefaultGetter) getCredentialsFromSecret(image *types.TrackedImage) (*ty
 	}
 
 	return credentials, nil
+}
+
+func credentialsFromConfig(image *types.TrackedImage, cfg DockerCfg) (*types.Credentials, bool) {
+	credentials := &types.Credentials{}
+	found := false
+	// looking for our registry
+	for registry, auth := range cfg {
+		h, err := hostname(registry)
+
+		if err != nil {
+			log.WithFields(log.Fields{
+				"image":     image.Image.Repository(),
+				"namespace": image.Namespace,
+				"registry":  registry,
+				"error":     err,
+			}).Error("secrets.defaultGetter: failed to parse hostname")
+			continue
+		}
+
+		log.WithFields(log.Fields{
+			"wanted":  h,
+			"current": image.Image.Registry(),
+		}).Info("searching for the registry")
+
+		if h == image.Image.Registry() {
+			if auth.Username != "" && auth.Password != "" {
+				credentials.Username = auth.Username
+				credentials.Password = auth.Password
+			} else if auth.Auth != "" {
+				username, password, err := decodeBase64Secret(auth.Auth)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"image":     image.Image.Repository(),
+						"namespace": image.Namespace,
+						"registry":  registry,
+						"error":     err,
+					}).Error("secrets.defaultGetter: failed to decode auth secret")
+					continue
+				}
+				credentials.Username = username
+				credentials.Password = password
+				found = true
+			} else {
+				log.WithFields(log.Fields{
+					"image":     image.Image.Repository(),
+					"namespace": image.Namespace,
+					"registry":  registry,
+					"error":     err,
+				}).Warn("secrets.defaultGetter: secret doesn't have username, password and base64 encoded auth, skipping")
+				continue
+			}
+
+			log.WithFields(log.Fields{
+				"namespace": image.Namespace,
+				"provider":  image.Provider,
+				"registry":  image.Image.Registry(),
+				"image":     image.Image.Repository(),
+			}).Debug("secrets.defaultGetter: secret looked up successfully")
+
+			return credentials, true
+		}
+	}
+	return credentials, found
 }
 
 func decodeBase64Secret(authSecret string) (username, password string, err error) {
@@ -296,7 +382,7 @@ func decodeSecret(data []byte) (DockerCfg, error) {
 	return cfg, nil
 }
 
-func decodeJSONSecret(data []byte) (DockerCfg, error) {
+func DecodeDockerCfgJson(data []byte) (DockerCfg, error) {
 	var cfg DockerCfgJSON
 	err := json.Unmarshal(data, &cfg)
 	if err != nil {


### PR DESCRIPTION
Implementing https://github.com/keel-hq/keel/issues/226

DOCKER_REGISTRY_CFG  

Example value:

```
{"auths":{"https://index.docker.io/v1/":{"username":"login","password":"somepass","email":"email@email.com","auth":"longbase64secret"}}}
```