### PR TITLE
Feature/optional link

### DIFF
--- a/provider/helm/approvals.go
+++ b/provider/helm/approvals.go
@@ -76,13 +76,5 @@ func (p *Provider) isApproved(event *types.Event, plan *UpdatePlan) (bool, error
 		return false, err
 	}
 
-	if event.Repository.Digest != "" && event.Repository.Digest != existing.Digest {
-		err = p.approvalManager.Reset(existing)
-		if err != nil {
-			return false, fmt.Errorf("failed to reset approval after changed digest, error %s", err)
-		}
-		return false, nil
-	}
-
 	return existing.Status() == types.ApprovalStatusApproved, nil
 }

--- a/provider/helm/unversioned_updates.go
+++ b/provider/helm/unversioned_updates.go
@@ -84,6 +84,9 @@ func checkUnversionedRelease(repo *types.Repository, namespace, name string, cha
 		plan.CurrentVersion = imageRef.Tag()
 		plan.Config = keelCfg
 		shouldUpdateRelease = true
+		if imageDetails.ReleaseNotes != "" {
+			plan.ReleaseNotes = append(plan.ReleaseNotes, imageDetails.ReleaseNotes)
+		}
 	}
 
 	return plan, shouldUpdateRelease, nil

--- a/provider/helm/unversioned_updates_test.go
+++ b/provider/helm/unversioned_updates_test.go
@@ -26,6 +26,24 @@ keel:
       tag: image.tag
 
 `
+	chartValuesPolicyForceReleaseNotes := `
+name: al Rashid
+where:
+  city: Basrah
+  title: caliph
+image:
+  repository: gcr.io/v2-namespace/hello-world
+  tag: 1.1.0
+
+keel:  
+  policy: force  
+  trigger: poll  
+  images:
+    - repository: image.repository
+      tag: image.tag
+      releaseNotes: https://github.com/keel-hq/keel/releases			
+
+`
 
 	chartValuesPolicyMajor := `
 name: al Rashid
@@ -51,6 +69,10 @@ keel:
 
 	helloWorldChartPolicyMajor := &hapi_chart.Chart{
 		Values: &hapi_chart.Config{Raw: chartValuesPolicyMajor},
+	}
+
+	helloWorldChartPolicyMajorReleaseNotes := &hapi_chart.Chart{
+		Values: &hapi_chart.Config{Raw: chartValuesPolicyForceReleaseNotes},
 	}
 
 	type args struct {
@@ -90,6 +112,38 @@ keel:
 						ImageDetails{
 							RepositoryPath: "image.repository",
 							TagPath:        "image.tag",
+						},
+					},
+				},
+			},
+			wantShouldUpdateRelease: true,
+			wantErr:                 false,
+		},
+		{
+			name: "correct force update, with release notes",
+			args: args{
+				repo:      &types.Repository{Name: "gcr.io/v2-namespace/hello-world", Tag: "1.2.0"},
+				namespace: "default",
+				name:      "release-1",
+				chart:     helloWorldChartPolicyMajorReleaseNotes,
+				config:    &hapi_chart.Config{Raw: ""},
+			},
+			wantPlan: &UpdatePlan{
+				Namespace:      "default",
+				Name:           "release-1",
+				Chart:          helloWorldChartPolicyMajorReleaseNotes,
+				Values:         map[string]string{"image.tag": "1.2.0"},
+				CurrentVersion: "1.1.0",
+				NewVersion:     "1.2.0",
+				ReleaseNotes:   []string{"https://github.com/keel-hq/keel/releases"},
+				Config: &KeelChartConfig{
+					Policy:  types.PolicyTypeForce,
+					Trigger: types.TriggerTypePoll,
+					Images: []ImageDetails{
+						ImageDetails{
+							RepositoryPath: "image.repository",
+							TagPath:        "image.tag",
+							ReleaseNotes:   "https://github.com/keel-hq/keel/releases",
 						},
 					},
 				},

--- a/provider/helm/versioned_updates.go
+++ b/provider/helm/versioned_updates.go
@@ -73,6 +73,9 @@ func checkVersionedRelease(newVersion *types.Version, repo *types.Repository, na
 			plan.CurrentVersion = imageRef.Tag()
 			plan.Config = keelCfg
 			shouldUpdateRelease = true
+			if imageDetails.ReleaseNotes != "" {
+				plan.ReleaseNotes = append(plan.ReleaseNotes, imageDetails.ReleaseNotes)
+			}
 
 			log.WithFields(log.Fields{
 				"parsed_image":     imageRef.Remote(),
@@ -131,6 +134,9 @@ func checkVersionedRelease(newVersion *types.Version, repo *types.Repository, na
 			plan.CurrentVersion = currentVersion.String()
 			plan.Config = keelCfg
 			shouldUpdateRelease = true
+			if imageDetails.ReleaseNotes != "" {
+				plan.ReleaseNotes = append(plan.ReleaseNotes, imageDetails.ReleaseNotes)
+			}
 
 			log.WithFields(log.Fields{
 				"container_image":  imageRef.Repository(),

--- a/types/types.go
+++ b/types/types.go
@@ -52,6 +52,9 @@ const KeelApprovalDeadlineLabel = "keel.sh/approvalDeadline"
 // KeelApprovalDeadlineDefault - default deadline in hours
 const KeelApprovalDeadlineDefault = 24
 
+// KeelReleasePage - optional release notes URL passed on with notification
+const KeelReleaseNotesURL = "keel.sh/releaseNotes"
+
 // KeelPodDeleteDelay - optional delay betwen killing pods
 // during force deploy
 // const KeelPodDeleteDelay = "keel.sh/forceDelay"
@@ -230,6 +233,14 @@ func ParseEventNotificationChannels(annotations map[string]string) []string {
 	}
 
 	return channels
+}
+
+func ParseReleaseNotesURL(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+
+	return annotations[KeelReleaseNotesURL]
 }
 
 // ParsePodDeleteDelay - parses pod delete delay time in seconds

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -166,3 +166,43 @@ func TestParseEventNotificationChannels(t *testing.T) {
 		})
 	}
 }
+
+func TestParseReleaseNotesURL(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "nil map",
+			args: args{},
+			want: "",
+		},
+		{
+			name: "empty map",
+			args: args{
+				make(map[string]string),
+			},
+			want: "",
+		},
+		{
+			name: "link",
+			args: args{
+				annotations: map[string]string{
+					KeelReleaseNotesURL: "http://link",
+				},
+			},
+			want: "http://link",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseReleaseNotesURL(tt.args.annotations); got != tt.want {
+				t.Errorf("ParseReleaseNotesURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Optional release notes for deployments:

Kubernetes annotation example:

```
apiVersion: apps/v1
kind: Deployment
metadata: 
  name: pushwf  
  labels: 
    name: "pushwf"
    keel.sh/policy: force
  annotations:
    keel.sh/releaseNotes: https://github.com/keel-hq/keel/releases
spec:
  .... 
  ....
```

Helm chart values.yaml example:
```
image:
  repository: gcr.io/v2-namespace/hello-world
  tag: 1.1.0

keel:  
  policy: force  
  trigger: poll  
  images:
    - repository: image.repository
      tag: image.tag
      releaseNotes: https://github.com/keel-hq/keel/releases			

```

https://github.com/keel-hq/keel/issues/227