### PR TITLE
Helm chart AWS region, pod annotations, and pod disruption budget

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.2.1
+version: 0.2.2
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appversion: 0.9.5
 keywords:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app: {{ template "keel.name" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "keel.name" . }}
       containers:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
             - name: INSECURE_REGISTRY
               value: "{{ .Values.insecure_registry }}"
  {{- end }}
+{{- if .Values.aws.region }}
+            - name: AWS_REGION
+              value: "{{ .Values.aws.region }}"
+{{- end }}
           ports:
             - containerPort: 9300
           livenessProbe:

--- a/chart/keel/templates/pod-disruption-budget.yaml
+++ b/chart/keel/templates/pod-disruption-budget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "keel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "keel.name" . }}
+{{- end }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -134,3 +134,8 @@ podAnnotations: {}
 
 aws:
   region: null
+
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+  minAvailable: null

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -130,5 +130,7 @@ debug: false
 # within. It should **not** be used if you are using Helm for deployment.
 createNamespaceResource: false
 
+podAnnotations: {}
+
 aws:
   region: null

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -129,3 +129,6 @@ debug: false
 # namespace manifest for the namespace that cert-manager is being installed
 # within. It should **not** be used if you are using Helm for deployment.
 createNamespaceResource: false
+
+aws:
+  region: null


### PR DESCRIPTION
This adds the following to the chart:

- `AWS_REGION` environment variable. If your instance profile allows read access to ECR repositories, this is all you need to set.
- `podAnnotations`. If you are using kiam or kube2iam, then the above only works if you annotate the pod to give it permission to do things (so it thinks its instance profile is allowing read access). There are probably plenty of other things that require pod annotations, but this is the relevant one in my case.
- a `poddisruptionbudget`.