### PR TITLE
feature: perform aws ecr login by repo region from registry url 

### DIFF
--- a/extension/credentialshelper/aws/aws_test.go
+++ b/extension/credentialshelper/aws/aws_test.go
@@ -62,3 +62,17 @@ func TestCredentialsCaching(t *testing.T) {
 		}
 	}
 }
+
+func TestAWSRegistryParse(t *testing.T) {
+	registry := "528670773427.dkr.ecr.us-east-2.amazonaws.com"
+	registryID, region, err := parseRegistry(registry)
+	if err != nil {
+		t.Fatalf("parseRegistry got error: %s", err)
+	}
+	if registryID != "528670773427" {
+		t.Fatalf("parseRegistry parse registryID(528670773427) not as expected: %s", registryID)
+	}
+	if region != "us-east-2" {
+		t.Fatalf("parseRegistry parse region(us-east-2) not as expected: %s", region)
+	}
+}


### PR DESCRIPTION
Issue:
The default AWS region env value is not compatible in multi AWS ECR with multi region situation.

changes:
- the region value can be matched with regular expression from the ECR url, so I added a regex matching to get region for authentication in different regions.
- the region value and pre-authentication is not needed, and have been removed.


