### PR TITLE
Fix AWS ECR (status=401 body=\"Not Authorized\\n\")

### DIFF
--- a/extension/credentialshelper/credentialshelper.go
+++ b/extension/credentialshelper/credentialshelper.go
@@ -86,13 +86,15 @@ func GetCredentials(image *types.TrackedImage) (creds *types.Credentials) {
 						"helper":        name,
 						"error":         err,
 						"tracked_image": image,
-					}).Error("extension.credentialshelper: credentials not found")
+					}).Debug("extension.credentialshelper: credentials not found")
 				}
 			} else {
 				return creds
 			}
 		}
 	}
-
+	log.WithFields(log.Fields{
+		"tracked_image": image,
+	}).Error("extension.credentialshelper: credentials helper not found")
 	return creds
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -76,6 +76,9 @@ func (g *DefaultGetter) Get(image *types.TrackedImage) (*types.Credentials, erro
 		// populating secrets
 		image.Secrets = secrets
 	}
+	if len(image.Secrets) == 0 {
+		return nil, ErrSecretsNotSpecified
+	}
 
 	return g.getCredentialsFromSecret(image)
 }


### PR DESCRIPTION
Issue:
found logs like:
time="2018-05-02T23:55:18Z" level=error msg="trigger.poll.WatchTagJob: failed to check digest" error="Get https://someuid.dkr.ecr.eu-west-1.amazonaws.com/v2/some_repo_1/manifests/latest: http: non-successful response (status=401 body=\"Not Authorized\\n\")" image="some_repo_1:latest"

Findings:
- both secrets and aws CredentialsHelpers will be tried to get credential.  
- For the secret CredentialsHelpers,  the Get() at secrets/secrets.go will be called and may get an empty image.Secrets array to be passed into `g.getCredentialsFromSecret(image)`
- empty credential{} will be returned and cause the 401 in requesting ECR.

Changes:
- added image.Secrets length check before passing to `g.getCredentialsFromSecret(image)`
- mute error log in generic credentialshelper in searching credentialshelper

Ps. I am a newbie to golang, and not sure the changes follow design. Feel free to let me know what I have missed. 