### PR TITLE
updated helm README: added missing slack.approvals_channel param

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -89,6 +89,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `slack.enabled`                   | Enable/disable Slack Notification      | `false`                                                   |
 | `slack.token`                     | Slack token                            |                                                           |
 | `slack.channel`                   | Slack channel                          |                                                           |
+| `slack.approvals_channel`         | Slack channel for approvals            |                                                           |
 | `service.enable`                  | Enable/disable Keel service            | `false`                                                   |
 | `service.type`                    | Keel service type                      | `LoadBalancer`                                            |
 | `service.externalPort`            | Keel service port                      | `9300`                                                    |


### PR DESCRIPTION
param `slack.approvals_channel` was missing in the readme file