### PR TITLE
Helm chart: RBAC to allow CronJobs

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.6.2
+version: 0.6.3
 # Note that we use appVersion to get images tag, so make sure this is correct.
-appversion: 0.9.5
+appversion: 0.9.7
 keywords:
 - kubernetes deployment
 - helm release

--- a/chart/keel/templates/clusterrole.yaml
+++ b/chart/keel/templates/clusterrole.yaml
@@ -23,6 +23,7 @@ rules:
       - ""
       - extensions
       - apps
+      - batch
     resources:
       - pods
       - replicasets
@@ -31,6 +32,7 @@ rules:
       - deployments
       - daemonsets
       - jobs
+      - cronjobs
     verbs:
       - get
       - delete # required to delete pods during force upgrade of the same tag


### PR DESCRIPTION
This fixxes perm denied errors for me, haven't tested much more yet, but if something comes up I'll PR again ;)

```
ERROR: logging before flag.Parse: E0831 12:08:18.048112       1 reflector.go:205] github.com/keel-hq/keel/internal/k8s/watcher.go:49: Failed to list *v1beta1.CronJob: cronjobs.batch is forbidden: User "system:serviceaccount:kube-global:keel" cannot list cronjobs.batch at the cluster scope: Unknown user "system:serviceaccount:kube-global:keel"
```
