### PR TITLE
Helm chart updates

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -3,7 +3,7 @@ name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
 version: 0.7.0
 # Note that we use appVersion to get images tag, so make sure this is correct.
-appversion: 0.10.0
+appVersion: 0.10.0
 keywords:
 - kubernetes deployment
 - helm release

--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.6.3
+version: 0.7.0
 # Note that we use appVersion to get images tag, so make sure this is correct.
-appversion: 0.9.7
+appversion: 0.10.0
 keywords:
 - kubernetes deployment
 - helm release

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
               value: "{{ .Values.slack.channel }}"
             - name: SLACK_APPROVALS_CHANNEL
               value: "{{ .Values.slack.approvalsChannel }}"
-  {{- if .Values.slack.bot_name }}
+  {{- if .Values.slack.botName }}
             - name: SLACK_BOT_NAME
               value: "{{ .Values.slack.botName }}"
   {{- end }}
@@ -125,7 +125,7 @@ spec:
             - name: DEBUG
               value: "1"
 {{- end }}
-{{- if .Values.insecure_registry }}
+{{- if .Values.insecureRegistry }}
             # Enable insecure registries
             - name: INSECURE_REGISTRY
               value: "{{ .Values.insecureRegistry }}"

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: keelhq/keel
-  tag: 0.9.5
+  tag: 0.10.0
   pullPolicy: IfNotPresent
 
 # Enable insecure registries
@@ -110,7 +110,7 @@ keel:
 
 # RBAC manifests management
 rbac:
-  enabled: false
+  enabled: true
 
 # Resources
 resources:
@@ -131,7 +131,7 @@ tolerations: {}
 # base64 encoded json of GCP service account
 # more info available here: https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform
 # e.g. --set googleApplicationCredentials=$(cat <JSON_KEY_FIEL> | base64)
-# googleApplicationCredentials: ""
+googleApplicationCredentials: ""
 
 # Enable DEBUG logging
 debug: false

--- a/deployment/deployment-norbac-whr-sidecar.yaml
+++ b/deployment/deployment-norbac-whr-sidecar.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 
@@ -29,7 +29,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -52,7 +52,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -71,12 +71,14 @@ spec:
       containers:
         - name: keel
           # Note that we use appVersion to get images tag.
-          image: "keelhq/keel:0.9.5"
+          image: "keelhq/keel:0.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/keel"]
           env:
             - name: NAMESPACE
-              value: keel
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # Enable polling
             - name: POLL
               value: "1"
@@ -85,6 +87,16 @@ spec:
               value: ""
             - name: PUBSUB
               value: "1"
+            # Enable AWS ECR
+            - name: AWS_ACCESS_KEY_ID
+              value: ""
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-aws-ecr
+                  key: secretAccessKey
+            - name: AWS_REGION
+              value: ""
             # Enable webhook endpoint
             - name: WEBHOOK_ENDPOINT
               value: ""
@@ -177,6 +189,10 @@ spec:
 
 ---
 # Source: keel/templates/clusterrolebinding.yaml
+
+
+---
+# Source: keel/templates/secrets-aws-ecr.yaml
 
 
 ---

--- a/deployment/deployment-norbac.yaml
+++ b/deployment/deployment-norbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 
@@ -29,7 +29,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -52,7 +52,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -71,12 +71,14 @@ spec:
       containers:
         - name: keel
           # Note that we use appVersion to get images tag.
-          image: "keelhq/keel:0.9.5"
+          image: "keelhq/keel:0.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/keel"]
           env:
             - name: NAMESPACE
-              value: keel
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # Enable polling
             - name: POLL
               value: "1"
@@ -85,6 +87,16 @@ spec:
               value: ""
             - name: PUBSUB
               value: "1"
+            # Enable AWS ECR
+            - name: AWS_ACCESS_KEY_ID
+              value: ""
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-aws-ecr
+                  key: secretAccessKey
+            - name: AWS_REGION
+              value: ""
             # Enable webhook endpoint
             - name: WEBHOOK_ENDPOINT
               value: ""
@@ -129,7 +141,33 @@ spec:
               memory: 128Mi
             requests:
               cpu: 50m
-              memory: 64Mi            
+              memory: 64Mi
+            
+        - name: webhookrelayd
+          image: "webhookrelay/webhookrelayd:0.6.3"
+          imagePullPolicy: IfNotPresent
+          command: ["/relayd"]
+          env:
+            - name: KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-webhookrelay
+                  key: key
+            - name: SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keel-webhookrelay
+                  key: secret
+            - name: BUCKET
+              value: ""
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            
 
 ---
 # Source: keel/templates/pod-disruption-budget.yaml
@@ -151,6 +189,10 @@ spec:
 
 ---
 # Source: keel/templates/clusterrolebinding.yaml
+
+
+---
+# Source: keel/templates/secrets-aws-ecr.yaml
 
 
 ---

--- a/deployment/deployment-rbac-whr-sidecar.yaml
+++ b/deployment/deployment-rbac-whr-sidecar.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 
@@ -25,15 +25,52 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    name: keel
   name: keel
 rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ['*']
-  - nonResourceURLs: ['*']
-    verbs: ['*']
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+      - extensions
+      - apps
+      - batch
+    resources:
+      - pods
+      - replicasets
+      - replicationcontrollers
+      - statefulsets
+      - deployments
+      - daemonsets
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - delete # required to delete pods during force upgrade of the same tag
+      - watch
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - update
+
 
 ---
 # Source: keel/templates/clusterrolebinding.yaml
@@ -62,7 +99,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -85,7 +122,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -104,12 +141,14 @@ spec:
       containers:
         - name: keel
           # Note that we use appVersion to get images tag.
-          image: "keelhq/keel:0.9.5"
+          image: "keelhq/keel:0.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/keel"]
           env:
             - name: NAMESPACE
-              value: keel
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # Enable polling
             - name: POLL
               value: "1"
@@ -118,6 +157,16 @@ spec:
               value: ""
             - name: PUBSUB
               value: "1"
+            # Enable AWS ECR
+            - name: AWS_ACCESS_KEY_ID
+              value: ""
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-aws-ecr
+                  key: secretAccessKey
+            - name: AWS_REGION
+              value: ""
             # Enable webhook endpoint
             - name: WEBHOOK_ENDPOINT
               value: ""
@@ -203,6 +252,10 @@ spec:
   selector:
     matchLabels:
       app: keel
+
+---
+# Source: keel/templates/secrets-aws-ecr.yaml
+
 
 ---
 # Source: keel/templates/secrets-google.yaml

--- a/deployment/deployment-rbac.yaml
+++ b/deployment/deployment-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 
@@ -25,15 +25,52 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    name: keel
   name: keel
 rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ['*']
-  - nonResourceURLs: ['*']
-    verbs: ['*']
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+      - extensions
+      - apps
+      - batch
+    resources:
+      - pods
+      - replicasets
+      - replicationcontrollers
+      - statefulsets
+      - deployments
+      - daemonsets
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - delete # required to delete pods during force upgrade of the same tag
+      - watch
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - update
+
 
 ---
 # Source: keel/templates/clusterrolebinding.yaml
@@ -62,7 +99,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -85,7 +122,7 @@ metadata:
   namespace: keel
   labels:
     app: keel
-    chart: keel-0.6.1
+    chart: keel-0.7.0
     release: keel
     heritage: Tiller
 spec:
@@ -104,12 +141,14 @@ spec:
       containers:
         - name: keel
           # Note that we use appVersion to get images tag.
-          image: "keelhq/keel:0.9.7"
+          image: "keelhq/keel:0.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/keel"]
           env:
             - name: NAMESPACE
-              value: keel
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # Enable polling
             - name: POLL
               value: "1"
@@ -118,6 +157,16 @@ spec:
               value: ""
             - name: PUBSUB
               value: "1"
+            # Enable AWS ECR
+            - name: AWS_ACCESS_KEY_ID
+              value: ""
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-aws-ecr
+                  key: secretAccessKey
+            - name: AWS_REGION
+              value: ""
             # Enable webhook endpoint
             - name: WEBHOOK_ENDPOINT
               value: ""
@@ -162,7 +211,33 @@ spec:
               memory: 128Mi
             requests:
               cpu: 50m
-              memory: 64Mi        
+              memory: 64Mi
+            
+        - name: webhookrelayd
+          image: "webhookrelay/webhookrelayd:0.6.3"
+          imagePullPolicy: IfNotPresent
+          command: ["/relayd"]
+          env:
+            - name: KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keel-webhookrelay
+                  key: key
+            - name: SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keel-webhookrelay
+                  key: secret
+            - name: BUCKET
+              value: ""
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            
 
 ---
 # Source: keel/templates/pod-disruption-budget.yaml
@@ -177,6 +252,10 @@ spec:
   selector:
     matchLabels:
       app: keel
+
+---
+# Source: keel/templates/secrets-aws-ecr.yaml
+
 
 ---
 # Source: keel/templates/secrets-google.yaml

--- a/deployment/scripts/gen-deploy.sh
+++ b/deployment/scripts/gen-deploy.sh
@@ -16,7 +16,7 @@ gen() {
 
 	mkdir -p "$(dirname ${OUTPUT})"
   cp chart/keel/values.yaml "${TMP_VALUES}"/
-  sed -i "" 's/false/true/g' "${TMP_VALUES}/values.yaml"
+  sed -i 's/false/true/g' "${TMP_VALUES}/values.yaml"
 	helm template \
 		"chart/keel" \
     --values "${TMP_VALUES}/values.yaml" \


### PR DESCRIPTION
* fix dual/inconsistent `slac.bot_name` / `slack.botName`, 'insecure_registry`/`insecureRegistry`
* bump version
* lint 
* set RBAC to default enable (new guidelines, makes sense too)