### PR TITLE
added HIPCHAT_SERVER environment variable

### DIFF
--- a/extension/notification/hipchat/hipchat.go
+++ b/extension/notification/hipchat/hipchat.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"net/url"
+
 	"github.com/tbruyelle/hipchat-go/hipchat"
 
 	"github.com/keel-hq/keel/constants"
@@ -46,6 +48,11 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 	}
 
 	s.hipchatClient = hipchat.NewClient(token)
+
+	if os.Getenv("HIPCHAT_SERVER") != "" {
+		server, _ := url.Parse(os.Getenv("HIPCHAT_SERVER"))
+		s.hipchatClient.BaseURL = server
+	}
 
 	log.WithFields(log.Fields{
 		"name":     "hipchat",


### PR DESCRIPTION
allows specifying a self hosted hipchat server

```yaml
...
        env:
...
        - name: HIPCHAT_SERVER
          value: https://hipchat.example.com/v2/
...
```

i've ran it in production for a good month now without any issue
<img width="490" alt="hc" src="https://user-images.githubusercontent.com/612475/46346245-b404ef00-c647-11e8-9577-57a29823193e.png">
