### PR TITLE
Add timestamp to rollout history log

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -246,7 +246,8 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 
 		var err error
 
-		annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update, version %s -> %s", plan.CurrentVersion, plan.NewVersion)
+		timestamp := time.Now().Format(time.RFC3339)
+		annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update, version %s -> %s [%s]", plan.CurrentVersion, plan.NewVersion, timestamp)
 
 		resource.SetAnnotations(annotations)
 


### PR DESCRIPTION
Add timestamp using RFC3339 to rollout history logout in the end of the string to avoid breaking any existing script that may use this output.

Fixes: #277 