### PR TITLE
More version comparison logging

### DIFF
--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -407,9 +407,8 @@ func (j *WatchRepositoryTagsJob) Run() {
 		return
 	}
 
-	log.Debugf("new tag '%s' available", latestVersion)
-
 	if newAvailable {
+		log.Debugf("new tag '%s' available", latestVersion)
 		// updating current latest
 		j.details.latest = latestVersion
 		event := types.Event{
@@ -424,5 +423,7 @@ func (j *WatchRepositoryTagsJob) Run() {
 			"new_tag":    latestVersion,
 		}).Info("trigger.poll.WatchRepositoryTagsJob: submiting event to providers")
 		j.providers.Submit(event)
+	} else {
+		log.Debugf("no new tag available")
 	}
 }

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -109,7 +109,9 @@ func NewAvailable(current string, tags []string) (newVersion string, newAvailabl
 	sort.Sort(sort.Reverse(semver.Collection(vs)))
 
 	if currentVersion.LessThan(vs[0]) {
+		log.WithFields(log.Fields{"currentVersion": currentVersion, "latestAvailable": vs[0]}).Debug("latest available is newer than current")
 		return vs[0].Original(), true, nil
 	}
+	log.WithFields(log.Fields{"currentVersion": currentVersion, "latestAvailable": vs[0]}).Debug("latest available is not newer than current")
 	return "", false, nil
 }


### PR DESCRIPTION
I sometimes find it tricky to work out what has happened when I find that keel has/hasn't updated a deployment when I expected it not to/to.

Also, this removes the oddity of getting a log message of `new tag '' available` which always confuses me.

Hopefully these log message will make it easier for me to work out what image tags keel has found in the repo and in the deployment, and what it has decided about them (especially with the pre-release support) and work out if I need to change a `keel.sh/policy` or if my tags are not being compared correctly.