### PR TITLE
Add support for http proxies

### DIFF
--- a/extension/notification/mattermost/mattermost.go
+++ b/extension/notification/mattermost/mattermost.go
@@ -68,9 +68,8 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 	s.endpoint = httpConfig.Endpoint
 
 	// Setup HTTP client.
-	transport := &http.Transport{}
 	s.client = &http.Client{
-		Transport: transport,
+		Transport: http.DefaultTransport,
 		Timeout:   timeout,
 	}
 

--- a/extension/notification/webhook/webhook.go
+++ b/extension/notification/webhook/webhook.go
@@ -52,9 +52,8 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 	s.endpoint = httpConfig.Endpoint
 
 	// Setup HTTP client.
-	transport := &http.Transport{}
 	s.client = &http.Client{
-		Transport: transport,
+		Transport: http.DefaultTransport,
 		Timeout:   timeout,
 	}
 


### PR DESCRIPTION
Hello,

I have a Mattermost Instance sitting behind a HTTP proxy and I would like to enable Keel notifications through this proxy. 

The standard way to define a HTTP proxy in Go is through environment variables `HTTP_PROXY` and `HTTPS_PROXY`.
The default golang HTTP transport support transparently setting proxy if the environment variable exists.
See [http.DefaultTransport](https://golang.org/pkg/net/http/#RoundTripper), excerpt :
> DefaultTransport is the default implementation of Transport and is used by DefaultClient. It establishes network connections as needed and caches them for reuse by subsequent calls. It uses HTTP proxies as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables.

However in Mattermost and Webhook notification implementation, a custom transport is defined (with no parameters) which does not take proxy variable into account. This forbids the use of a proxy.

This PR modifies the transport to the default `http.DefaultTransport` which takes HTTP_PROXY environment variable into account to enable proxy support.

If a new empty transport is needed here for some reason, another implementation could be to check if environment variables exists and set: `http.Transport{Proxy: http.ProxyURL(proxyUrl)}` accordingly.