### PR TITLE
Improving helm chart to allow for service serviceAnnotations:

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.7.4
+version: 0.7.5
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.12.0
 keywords:

--- a/chart/keel/templates/service.yaml
+++ b/chart/keel/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "keel.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.serviceAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterIP }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -143,6 +143,11 @@ createNamespaceResource: false
 
 podAnnotations: {}
 
+serviceAnnotations: {}
+# Useful for making the load balancer internal
+# serviceAnnotations:
+#    cloud.google.com/load-balancer-type: Internal
+
 aws:
   region: null
 


### PR DESCRIPTION
I need the ability to define serviceAnnotations for the keel service.

This is a small fix to allow that functionality in the same way you can do it for the pods themselves.