### PR TITLE
Allow explicitly selecting NilPolicy

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -92,6 +92,8 @@ func GetPolicy(policyName string, options *Options) Policy {
 		return ParseSemverPolicy(policyName)
 	case "force":
 		return NewForcePolicy(options.MatchTag)
+	case "", "never":
+		return &NilPolicy{}
 	}
 
 	log.Infof("policy.GetPolicy: unknown policy '%s', please check your configuration", policyName)


### PR DESCRIPTION
Make it easier to temporarily disable keel on a resource.

```
    keel.sh/policy: never
```