### PR TITLE
Add ability to configure a Gcloud Ingress and use managed certificates within Helm.

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.7.8
+version: 0.7.9
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.13.0
 keywords:

--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -77,40 +77,44 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists has the main configurable parameters (polling, triggers, notifications, service) of the _Keel_ chart and they apply to both Kubernetes and Helm providers:
 
-| Parameter                         | Description                            | Default                                                   |
-| --------------------------------- | -------------------------------------- | --------------------------------------------------------- |
-| `polling.enabled`                 | Docker registries polling              | `true`                                                    |
-| `helmProvider.enabled`            | Enable/disable Helm provider           | `true`                                                    |
-| `gcr.enabled`                     | Enable/disable GCR Registry            | `false`                                                   |
-| `gcr.projectId`                   | GCP Project ID GCR belongs to          |                                                           |
-| `gcr.pubsub.enabled`              | Enable/disable GCP Pub/Sub trigger     | `false`                                                   |
-| `ecr.enabled`                     | Enable/disable AWS ECR Registry        | `false`                                                   |
-| `ecr.accessKeyId`                 | AWS_ACCESS_KEY_ID for ECR Registry     |                                                           |
-| `ecr.secretAccessKey`             | AWS_SECRET_ACCESS_KEY for ECR Registry |                                                           |
-| `ecr.region`                      | AWS_REGION for ECR Registry            |                                                           |
-| `webhook.enabled`                 | Enable/disable Webhook Notification    | `false`                                                   |
-| `webhook.endpoint`                | Remote webhook endpoint                |                                                           |
-| `slack.enabled`                   | Enable/disable Slack Notification      | `false`                                                   |
-| `slack.token`                     | Slack token                            |                                                           |
-| `slack.channel`                   | Slack channel                          |                                                           |
-| `slack.approvalsChannel`          | Slack channel for approvals            |                                                           |
-| `service.enable`                  | Enable/disable Keel service            | `false`                                                   |
-| `service.type`                    | Keel service type                      | `LoadBalancer`                                            |
-| `service.externalPort`            | Keel service port                      | `9300`                                                    |
-| `webhookRelay.enabled`            | Enable/disable WebhookRelay integration| `false`                                                   |
-| `webhookRelay.key`                | WebhookRelay key                       |                                                           |
-| `webhookRelay.secret`             | WebhookRelay secret                    |                                                           |
-| `webhookRelay.bucket`             | WebhookRelay bucket                    |                                                           |
-| `rbac.enabled`                    | Enable/disable RBAC installation       | `false`                                                   |
-| `hipchat.enabled`                 | Enable/disable hipchat integration     | `false`                                                   |
-| `hipchat.token`                   | Hipchat token                          |                                                           |
-| `hipchat.channel`                 | Hipchat channel                        |                                                           |
-| `hipchat.approvalsChannel`        | Hipchat channel for approvals          |                                                           |
-| `hipchat.botName`                 | Name of the Hipchat bot                |                                                           |
-| `hipchat.userName`                | Hipchat username in Jabber format      |                                                           |
-| `hipchat.password`                | Hipchat password for approvals user    |                                                           |
-| `googleApplicationCredentials`    | GCP Service account key configurable   |                                                           |
-| `notificationLevel`               | Keel notification level                | `info`                                                    |
+| Parameter                                   | Description                            | Default                                                   |
+| ------------------------------------------- | -------------------------------------- | --------------------------------------------------------- |
+| `polling.enabled`                           | Docker registries polling              | `true`                                                    |
+| `helmProvider.enabled`                      | Enable/disable Helm provider           | `true`                                                    |
+| `gcr.enabled`                               | Enable/disable GCR Registry            | `false`                                                   |
+| `gcr.projectId`                             | GCP Project ID GCR belongs to          |                                                           |
+| `gcr.pubsub.enabled`                        | Enable/disable GCP Pub/Sub trigger     | `false`                                                   |
+| `ecr.enabled`                               | Enable/disable AWS ECR Registry        | `false`                                                   |
+| `ecr.accessKeyId`                           | AWS_ACCESS_KEY_ID for ECR Registry     |                                                           |
+| `ecr.secretAccessKey`                       | AWS_SECRET_ACCESS_KEY for ECR Registry |                                                           |
+| `ecr.region`                                | AWS_REGION for ECR Registry            |                                                           |
+| `webhook.enabled`                           | Enable/disable Webhook Notification    | `false`                                                   |
+| `webhook.endpoint`                          | Remote webhook endpoint                |                                                           |
+| `slack.enabled`                             | Enable/disable Slack Notification      | `false`                                                   |
+| `slack.token`                               | Slack token                            |                                                           |
+| `slack.channel`                             | Slack channel                          |                                                           |
+| `slack.approvalsChannel`                    | Slack channel for approvals            |                                                           |
+| `service.enable`                            | Enable/disable Keel service            | `false`                                                   |
+| `service.type`                              | Keel service type                      | `LoadBalancer`                                            |
+| `service.externalPort`                      | Keel service port                      | `9300`                                                    |
+| `webhookRelay.enabled`                      | Enable/disable WebhookRelay integration| `false`                                                   |
+| `webhookRelay.key`                          | WebhookRelay key                       |                                                           |
+| `webhookRelay.secret`                       | WebhookRelay secret                    |                                                           |
+| `webhookRelay.bucket`                       | WebhookRelay bucket                    |                                                           |
+| `rbac.enabled`                              | Enable/disable RBAC installation       | `false`                                                   |
+| `hipchat.enabled`                           | Enable/disable hipchat integration     | `false`                                                   |
+| `hipchat.token`                             | Hipchat token                          |                                                           |
+| `hipchat.channel`                           | Hipchat channel                        |                                                           |
+| `hipchat.approvalsChannel`                  | Hipchat channel for approvals          |                                                           |
+| `hipchat.botName`                           | Name of the Hipchat bot                |                                                           |
+| `hipchat.userName`                          | Hipchat username in Jabber format      |                                                           |
+| `hipchat.password`                          | Hipchat password for approvals user    |                                                           |
+| `googleApplicationCredentials`              | GCP Service account key configurable   |                                                           |
+| `hipchat.password`                          | Hipchat password for approvals user    |                                                           |
+| `gcloudIngress.enabled`                     | Configure Google Cloud Ingress         | `false`                                                   |
+| `gcloudIngress.allowHttp`                   | Enable/Disable ssl on Ingress          | `true`                                                    |
+| `gcloudIngress.managedCertificates.enabled` | Enable/Disable managed ssl on Gcloud   | `false`                                                   |
+| `gcloudIngress.managedCertificates.domains` | List of managed certificate domains    | `[]`                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -142,6 +142,12 @@ spec:
               port: 9300
             initialDelaySeconds: 30
             timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9300
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.webhookRelay.enabled }}

--- a/chart/keel/templates/gcloud-ingress.yaml
+++ b/chart/keel/templates/gcloud-ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gcloudIngress.enabled }}
+{{- if .Values.gcloudIngress.managedCertificates.enabled }}
+---
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: {{ template "keel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  domains:
+    {{- range .Values.gcloudIngress.managedCertificates.domains }}
+    - {{ . | title }}
+    {{- end }}
+{{- end }}
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "keel.fullname" . }}
+  annotations:
+  {{- if .Values.gcloudIngress.managedCertificates.enabled }}
+    networking.gke.io/managed-certificates: {{ template "keel.fullname" . }}
+  {{- end }}
+    kubernetes.io/ingress.allow-http: "{{- .Values.gcloudIngress.allowHttp }}"
+spec:
+  backend:
+    serviceName: {{ template "keel.fullname" . }}
+    servicePort: 9300
+{{- end }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -155,3 +155,12 @@ podDisruptionBudget:
   enabled: false
   maxUnavailable: 1
   minAvailable: null
+
+# Google Cloud Ingress
+gcloudIngress:
+  enabled: false
+  allowHttp: true
+  managedCertificates:
+    enabled: false
+    domains:
+      - ""


### PR DESCRIPTION
This PR has some configuration to let us configure an ingress within Google Cloud and associated healthcheck fixes. 

* Add README and default values to Helm
* Add Readiness Probe so ingress-gce creates healthcheck correctly
* Add Optional Gcloud Ingress to Helm Template
* Add Optional Google managed certificates to Helm Template