### PR TITLE
#381 upload longer messages as files

### DIFF
--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -386,7 +386,6 @@ func (p *Provider) createUpdatePlans(repo *types.Repository) ([]*UpdatePlan, err
 
 		plc := policy.GetPolicyFromLabelsOrAnnotations(labels, annotations)
 		if plc.Type() == policy.PolicyTypeNone {
-			log.Debugf("no policy defined, skipping: %s, labels: %s, annotations: %s", resource.Identifier, labels, annotations)
 			continue
 		}
 


### PR DESCRIPTION
Fixed:
* long slack messages are now uploaded as text files so formatting is still preserved
* bots with changed name (keel -> k33l) wouldn't recognize commands