### PR TITLE
Fix for PR 375 - Generic Ingress

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.4
+version: 0.8.5
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.14.0
 keywords:

--- a/chart/keel/templates/ingress.yaml
+++ b/chart/keel/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   domains:
     {{- range .Values.gcloud.managedCertificates.domains }}
-    - {{ . | title }}
+    - {{ . }}
     {{- end }}
 {{- end }}
 ---
@@ -34,6 +34,11 @@ metadata:
     networking.gke.io/managed-certificates: {{ $fullName }}
   {{- end }}
 spec:
+{{- if not .Values.ingress.hosts }}
+  backend:
+    serviceName: {{ $fullName }}
+    servicePort: keel
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -44,6 +49,7 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+{{- if .Values.ingress.hosts }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -56,4 +62,5 @@ spec:
               servicePort: keel
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
When not making use of any ingress rules, there are no rules generated and this will not deploy properly. 

This changed makes the ingress backend conditional to fix issues when not using any ingress rules.

Old PR which this fix relates to:

https://github.com/keel-hq/keel/pull/375

Also a minor change with removing 'title' from managed certificates.

@botzill 

