### PR TITLE
Fix DEBUG value to be true instead of 1

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.13
+version: 0.8.14
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.15.0-rc1
 keywords:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
 {{- if .Values.debug }}
             # Enable debug logging
             - name: DEBUG
-              value: "1"
+              value: "true"
 {{- end }}
 {{- if .Values.insecureRegistry }}
             # Enable insecure registries


### PR DESCRIPTION
The checks in `go` files are using `if os.Getenv("DEBUG") == "true"`, as you can see in [`http.go`
](https://github.com/keel-hq/keel/blob/b0993b7f6baa0d42b4bf05a1bc8a76692436a7bf/pkg/http/http.go#L120).