### PR TITLE
Fix service.enabled variable in the documentation

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -96,7 +96,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `slack.token`                               | Slack token                            |                                                           |
 | `slack.channel`                             | Slack channel                          |                                                           |
 | `slack.approvalsChannel`                    | Slack channel for approvals            |                                                           |
-| `service.enable`                            | Enable/disable Keel service            | `false`                                                   |
+| `service.enabled`                           | Enable/disable Keel service            | `false`                                                   |
 | `service.type`                              | Keel service type                      | `LoadBalancer`                                            |
 | `service.externalPort`                      | Keel service port                      | `9300`                                                    |
 | `service.clusterIP`                         | Keel service clusterIP                 |                                                           |


### PR DESCRIPTION
The documentation was not in sync with `values.yaml`, I just updated the `README.md`