### PR TITLE
Support polling GCR

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -48,6 +48,7 @@ import (
 
 	// credentials helpers
 	_ "github.com/keel-hq/keel/extension/credentialshelper/aws"
+	_ "github.com/keel-hq/keel/extension/credentialshelper/gcr"
 	secretsCredentialsHelper "github.com/keel-hq/keel/extension/credentialshelper/secrets"
 
 	// bots

--- a/extension/credentialshelper/gcr/gcr.go
+++ b/extension/credentialshelper/gcr/gcr.go
@@ -1,0 +1,56 @@
+package gcr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/keel-hq/keel/extension/credentialshelper"
+	"github.com/keel-hq/keel/types"
+)
+
+func init() {
+	credentialshelper.RegisterCredentialsHelper("gcr", New())
+}
+
+type CredentialsHelper struct {
+	enabled     bool
+	credentials string
+}
+
+func New() *CredentialsHelper {
+	ch := &CredentialsHelper{}
+
+	credentialsFile, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
+	if !ok {
+		return ch
+	}
+
+	credentials, err := ioutil.ReadFile(credentialsFile)
+	if err != nil {
+		return ch
+	}
+
+	ch.enabled = true
+	ch.credentials = string(credentials)
+	return ch
+}
+
+func (h *CredentialsHelper) IsEnabled() bool {
+	return h.enabled
+}
+
+func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
+	if !h.enabled {
+		return nil, fmt.Errorf("not initialised")
+	}
+
+	if image.Image.Registry() != "gcr.io" {
+		return nil, nil
+	}
+
+	return &types.Credentials{
+		Username: "_json_key",
+		Password: h.credentials,
+	}, nil
+}


### PR DESCRIPTION
Polling does not presently work with private images hosted on GCR:
```
keel 2019-07-31T21:00:17.710427436Z time="2019-07-31T21:00:17Z" level=debug msg="extension.credentialshelper: helper doesn't support this registry" error="unsupported registry" helper=aws tracked_image="namespace:default,image:gcr.io/foo/bar:latest,provider:kubernetes,trigger:poll,sched:@every 1m,secrets:[]"
keel 2019-07-31T21:00:17.710630275Z time="2019-07-31T21:00:17Z" level=debug msg="extension.credentialshelper: credentials not found" error="no secrets were specified" helper=secrets tracked_image="namespace:default,image:gcr.io/foo/bar:latest,provider:kubernetes,trigger:poll,sched:@every 1m,secrets:[]"
keel 2019-07-31T21:00:17.710746648Z time="2019-07-31T21:00:17Z" level=debug msg="extension.credentialshelper: credentials helper not found" tracked_image="namespace:default,image:gcr.io/foo/bar:latest,provider:kubernetes,trigger:poll,sched:@every 1m,secrets:[]"
keel 2019-07-31T21:00:17.710858829Z time="2019-07-31T21:00:17Z" level=debug msg="registry.manifest.head url=https://gcr.io/v2/foo/bar/manifests/latest repository=foo/bar reference=latest"
keel 2019-07-31T21:00:17.872414500Z time="2019-07-31T21:00:17Z" level=error msg="trigger.poll.RepositoryWatcher.addJob: failed to get image digest" error="Get https://gcr.io/v2/foo/bar/manifests/latest: http: non-successful response (status=401 body=\"{\\\"errors\\\":[{\\\"code\\\":\\\"UNAUTHORIZED\\\",\\\"message\\\":\\\"You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\\"}]}\")" image="foo/bar:latest" password= username=
keel 2019-07-31T21:00:17.872512664Z time="2019-07-31T21:00:17Z" level=error msg="trigger.poll.RepositoryWatcher.Watch: failed to add image watch job" error="Get https://gcr.io/v2/foo/bar/manifests/latest: http: non-successful response (status=401 body=\"{\\\"errors\\\":[{\\\"code\\\":\\\"UNAUTHORIZED\\\",\\\"message\\\":\\\"You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\\"}]}\")" image="namespace:default,image:gcr.io/foo/bar:latest,provider:kubernetes,trigger:poll,sched:@every 1m,secrets:[]"
keel 2019-07-31T21:00:17.872525430Z time="2019-07-31T21:00:17Z" level=error msg="trigger.poll.manager: got error(-s) while watching images" error="encountered errors while adding images: Get https://gcr.io/v2/foo/bar/manifests/latest: http: non-successful response (status=401 body=\"{\\\"errors\\\":[{\\\"code\\\":\\\"UNAUTHORIZED\\\",\\\"message\\\":\\\"You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication\\\"}]}\")"
```

GCR provides a few methods to authenticate. For our purposes, we're interested in using a [JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#json_key_file), sourced from `GOOGLE_APPLICATION_CREDENTIALS`.

I don't really expect this PR to be merged as written, but I figured I'd sketch a solution to my problem.