### PR TITLE
Job resource now watched.

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -191,6 +191,7 @@ func main() {
 	k8s.WatchStatefulSets(&g, implementer.Client(), wl, buf)
 	k8s.WatchDaemonSets(&g, implementer.Client(), wl, buf)
 	k8s.WatchCronJobs(&g, implementer.Client(), wl, buf)
+	k8s.WatchJobs(&g, implementer.Client(), wl, buf)
 
 	// approvalsCache := memory.NewMemoryCache()
 	approvalsManager := approvals.New(&approvals.Opts{

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	apps_v1 "k8s.io/api/apps/v1"
+	batch_v1 "k8s.io/api/batch/v1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	core_v1 "k8s.io/api/core/v1"
 )
@@ -60,4 +61,14 @@ func getCronJobIdentifier(s *v1beta1.CronJob) string {
 
 func updateCronJobContainer(s *v1beta1.CronJob, index int, image string) {
 	s.Spec.JobTemplate.Spec.Template.Spec.Containers[index].Image = image
+}
+
+// jobs
+
+func getJobIdentifier(s *batch_v1.Job) string {
+	return "job/" + s.Namespace + "/" + s.Name
+}
+
+func updateJobContainer(s *batch_v1.Job, index int, image string) {
+	s.Spec.Template.Spec.Containers[index].Image = image
 }

--- a/internal/k8s/resource.go
+++ b/internal/k8s/resource.go
@@ -332,7 +332,7 @@ func (r *GenericResource) UpdateContainer(index int, image string) {
 	case *v1beta1.CronJob:
 		updateCronJobContainer(obj, index, image)
 	case *batch_v1.Job:
-		updateCronJobContainer(obj, index, image)
+		updateJobContainer(obj, index, image)
 	}
 }
 

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -7,8 +7,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	apps_v1 "k8s.io/api/apps/v1"
+	batch_v1 "k8s.io/api/batch/v1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,11 @@ func WatchDaemonSets(g *workgroup.Group, client *kubernetes.Clientset, log logru
 // WatchCronJobs creates a SharedInformer for v1beta1.CronJob and registers it with g.
 func WatchCronJobs(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
 	watch(g, client.BatchV1beta1().RESTClient(), log, "cronjobs", new(v1beta1.CronJob), rs...)
+}
+
+// WatchJobs creates a SharedInformer for batch/v1.Job and registers it with g.
+func WatchJobs(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
+	watch(g, client.BatchV1().RESTClient(), log, "jobs", new(batch_v1.Job), rs...)
 }
 
 func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -9,7 +9,7 @@ import (
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	core_v1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,7 +43,7 @@ func WatchJobs(g *workgroup.Group, client *kubernetes.Clientset, log logrus.Fiel
 }
 
 func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource string, objType runtime.Object, rs ...cache.ResourceEventHandler) {
-	lw := cache.NewListWatchFromClient(c, resource, v1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(c, resource, core_v1.NamespaceAll, fields.Everything())
 	sw := cache.NewSharedInformer(lw, objType, 30*time.Minute)
 	for _, r := range rs {
 		sw.AddEventHandler(r)


### PR DESCRIPTION
This PR is a reference to this issue: https://github.com/keel-hq/keel/issues/352 - issue resolved.

**What has been accomplished:**

1- As the title mentions, the `Job` resource is now being watched by Keel.
2- Add supports for ressources of type -> Job
3- Fullfills a use-case of wanting to automate Jobs deployments when a new image of a given Job is available.