### PR TITLE
Changed creation of AWS Session object

### DIFF
--- a/extension/credentialshelper/aws/aws_test.go
+++ b/extension/credentialshelper/aws/aws_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"os"
 	"testing"
 
 	"github.com/keel-hq/keel/registry"
@@ -10,10 +9,6 @@ import (
 )
 
 func TestAWS(t *testing.T) {
-
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		t.Skip()
-	}
 
 	ch := New()
 
@@ -48,10 +43,8 @@ func TestAWS(t *testing.T) {
 
 func TestCredentialsCaching(t *testing.T) {
 
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		t.Skip()
-	}
 	ch := New()
+
 	imgRef, _ := image.Parse("528670773427.dkr.ecr.us-east-2.amazonaws.com/webhook-demo:master")
 	for i := 0; i < 200; i++ {
 		_, err := ch.GetCredentials(&types.TrackedImage{

--- a/extension/credentialshelper/aws/aws_test.go
+++ b/extension/credentialshelper/aws/aws_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"os"
 	"testing"
 
 	"github.com/keel-hq/keel/registry"
@@ -9,6 +10,10 @@ import (
 )
 
 func TestAWS(t *testing.T) {
+
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		t.Skip()
+	}
 
 	ch := New()
 
@@ -42,6 +47,10 @@ func TestAWS(t *testing.T) {
 }
 
 func TestCredentialsCaching(t *testing.T) {
+
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		t.Skip()
+	}
 
 	ch := New()
 


### PR DESCRIPTION
@rusenask I see some potential issues in the design of the https://github.com/keel-hq/keel/tree/master/extension/credentialshelper/aws. The major issue is in the fact that the method `GetCredentials(...)` has a dependency on the `aws.Session` object. By instantiating this object inside this method, I cannot test it locally because I cannot set up the `region` and `endpoint` (for accessing a local service such as [moto](https://github.com/spulec/moto) or [localstack](https://github.com/localstack/localstack)). I tried few ways but it's either very ugly or I break the `CredentialsHelper` interface.

What I am not happy with, is the fact that I cannot make a proper unit-test without either make it very ugly or breaking the interface. Using a bit more Dependency Injection for this type of issue would benefit the code base I believe.

I'm 100% sure that you (or whoever) had very good reasons to design it that way but I would be happy to contribute in re-thinking a little bit the design of the interface 😄 

Anyway, I tested this version in our production cluster. I post here also the policy we have to use to make it work properly

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "ecr:*",
                "ec2:*"
            ],
            "Resource": "*"
        }
    ]
}
```

For some reasons, without the `ec2:*` it doesn't work at all. There is something in the ECR aws-sdk-go (I haven't investigate due to lack of time) that has a dependency on EC2 policy. I tried many different policies and this one is the only one that works.

It solves #425 