### PR TITLE
Added externalIP to service in chart

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.14
+version: 0.8.15
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.15.0-rc1
 keywords:

--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -98,6 +98,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `slack.approvalsChannel`                    | Slack channel for approvals            |                                                           |
 | `service.enabled`                           | Enable/disable Keel service            | `false`                                                   |
 | `service.type`                              | Keel service type                      | `LoadBalancer`                                            |
+| `service.externalIP`                        | Keel static IP                         |                                                           |
 | `service.externalPort`                      | Keel service port                      | `9300`                                                    |
 | `service.clusterIP`                         | Keel service clusterIP                 |                                                           |
 | `webhookRelay.enabled`                      | Enable/disable WebhookRelay integration| `false`                                                   |

--- a/chart/keel/templates/service.yaml
+++ b/chart/keel/templates/service.yaml
@@ -18,6 +18,10 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote  }}
   {{- end }}
+  {{- if .Values.service.externalIP }}
+  externalIPs:
+    - {{ .Values.service.externalIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.externalPort }}
   {{- if or (ne .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "None") }}


### PR DESCRIPTION
Added the option to define an externalIP for the service. This allows you to use the keel webhook with a static port without the need for an external load balancer.