### PR TITLE
Allow usage of IAM Role for service account

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.15
+version: 0.8.16
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.15.0-rc1
 keywords:

--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -85,6 +85,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `gcr.projectId`                             | GCP Project ID GCR belongs to          |                                                           |
 | `gcr.pubsub.enabled`                        | Enable/disable GCP Pub/Sub trigger     | `false`                                                   |
 | `ecr.enabled`                               | Enable/disable AWS ECR Registry        | `false`                                                   |
+| `ecr.roleArn`                               | Service Account IAM Role ARN for EKS   |                                                           |
 | `ecr.accessKeyId`                           | AWS_ACCESS_KEY_ID for ECR Registry     |                                                           |
 | `ecr.secretAccessKey`                       | AWS_SECRET_ACCESS_KEY for ECR Registry |                                                           |
 | `ecr.region`                                | AWS_REGION for ECR Registry            |                                                           |

--- a/chart/keel/templates/service-account.yaml
+++ b/chart/keel/templates/service-account.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: {{ template "keel.name" . }}
   namespace: {{ .Release.Namespace }}
+{{- if (and .Values.ecr.enabled .Values.ecr.roleArn) }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.ecr.roleArn }}
+{{- end }}
   labels:
     app: {{ template "keel.name" . }}
     chart: {{ template "keel.chart" . }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -40,6 +40,7 @@ notificationLevel: info
 # https://keel.sh/v1/guide/documentation.html#Polling-with-AWS-ECR
 ecr:
   enabled: false
+  roleArn: ""
   accessKeyId: ""
   secretAccessKey: ""
   region: ""


### PR DESCRIPTION
With EKS is possible to assign an IAM Role to a service account, this selector allow the configs.

Ref: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html