### PR TITLE
Allow not creating a service account automatically and use a custom one

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.16
+version: 0.8.17
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.15.0-rc1
 keywords:

--- a/chart/keel/templates/_helpers.tpl
+++ b/chart/keel/templates/_helpers.tpl
@@ -7,10 +7,10 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "serviceAccount.name" -}}
-{{- if .Values.rbac.serviceAccount.create -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
+{{- if .Values.rbac.serviceAccount.name -}}
 {{- .Values.rbac.serviceAccount.name -}}
+{{- else -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/chart/keel/templates/_helpers.tpl
+++ b/chart/keel/templates/_helpers.tpl
@@ -6,6 +6,14 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "serviceAccount.name" -}}
+{{- if .Values.rbac.serviceAccount.create -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Values.rbac.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/chart/keel/templates/clusterrolebinding.yaml
+++ b/chart/keel/templates/clusterrolebinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: {{ template "keel.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "keel.name" . }}
+    name: {{ template "serviceAccount.name" . }}
     namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      serviceAccountName: {{ template "keel.name" . }}
+      serviceAccountName: {{ template "serviceAccount.name" . }}
       containers:
         - name: keel
           # Note that we use appVersion to get images tag.

--- a/chart/keel/templates/service-account.yaml
+++ b/chart/keel/templates/service-account.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.rbac.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "keel.name" . }}
+  name: {{ template "serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{- if (and .Values.ecr.enabled .Values.ecr.roleArn) }}
   annotations:
@@ -12,3 +13,4 @@ metadata:
     chart: {{ template "keel.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{ end }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -130,6 +130,12 @@ keel:
 # RBAC manifests management
 rbac:
   enabled: true
+  serviceAccount:
+    # Kubernetes service account name to be used for ClusterRoleBinding and Deployment.
+    #name:
+    # Create a new Kubernetes service account automatically. Set to false if you want to use your own service account.
+    # If rbac.serviceAccount.name is not set, a new name for the service account is generated
+    create: true
 
 # Resources
 resources:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -132,7 +132,7 @@ rbac:
   enabled: true
   serviceAccount:
     # Kubernetes service account name to be used for ClusterRoleBinding and Deployment.
-    #name:
+    # name:
     # Create a new Kubernetes service account automatically. Set to false if you want to use your own service account.
     # If rbac.serviceAccount.name is not set, a new name for the service account is generated
     create: true


### PR DESCRIPTION
This change allows users to use manually created Kubernetes service accounts for Keel.