### PR TITLE
Default tiller address to tiller-deploy

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.17
+version: 0.8.18
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.15.0-rc1
 keywords:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -22,7 +22,7 @@ helmProvider:
   # optional Tiller address (if portforwarder tunnel doesn't work),
   # if you are using default configuration, setting it to
   # 'tiller-deploy:44134' is usually fine
-  tillerAddress: ''
+  tillerAddress: 'tiller-deploy:44134'
 
 # Google Container Registry
 # GCP Project ID


### PR DESCRIPTION
Given that helmprovider support is enabled by default, the address should be defined as well to prevent deployment issues when using default settings

```
msg="failed to setup Tiller tunnel" error="could not find tiller"
```