### PR TITLE
Add native harbor support

### DIFF
--- a/pkg/http/harbor_webhook_trigger.go
+++ b/pkg/http/harbor_webhook_trigger.go
@@ -1,0 +1,119 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+	"regexp"
+
+	"github.com/keel-hq/keel/types"
+	"github.com/prometheus/client_golang/prometheus"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var newHarborWebhooksCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "harbor_webhook_requests_total",
+		Help: "How many /v1/webhooks/harbor requests processed, partitioned by image.",
+	},
+	[]string{"image"},
+)
+
+func init() {
+	prometheus.MustRegister(newHarborWebhooksCounter)
+}
+
+// Example of Harbor trigger
+// {
+//     "type": "pushImage",
+//     "occur_at": 1582640688,
+//     "operator": "<user>",
+//     "event_data": {
+//         "resources": [
+//             {
+//                 "digest": "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848",
+//                 "tag": "2.1.6",
+//                 "resource_url": "<url>/<namespace>/<repo>:<version>"
+//             }
+//         ],
+//         "repository": {
+//             "date_created": 1582634337,
+//             "name": "<repo>",
+//             "namespace": "<namespace>",
+//             "repo_full_name": "<namespace>/<repo>",
+//             "repo_type": "private"
+//         }
+//     }
+}
+
+type harborWebhook struct {
+	Type      string `json:"type"`
+	OccurAt   int    `json:"occur_at"`
+	Operator  string `json:"operator"`
+	EventData struct {
+		Resources []struct {
+			Digest      string `json:"digest"`
+			Tag         string `json:"tag"`
+			ResourceURL string `json:"resource_url"`
+		} `json:"resources"`
+		Repository struct {
+			DateCreated  int    `json:"date_created"`
+			Name         string `json:"name"`
+			Namespace    string `json:"namespace"`
+			RepoFullName string `json:"repo_full_name"`
+			RepoType     string `json:"repo_type"`
+		} `json:"repository"`
+	} `json:"event_data"`
+}
+
+func (s *TriggerServer) harborHandler(resp http.ResponseWriter, req *http.Request) {
+	qw := harborWebhook{}
+	if err := json.NewDecoder(req.Body).Decode(&qw); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error("trigger.harborHandler: failed to decode request")
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if qw.type == "pushImage" {
+		if qw.ResourceURL == "" {
+			resp.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(resp, "ResourceURL cannot be empty")
+			return
+		}
+		//Split the combined <URL>:<tag> into seperate fields
+		split_regexp := regexp.MustCompile("(.*):(.*)")
+		split_string := split_regexp.FindAllStringSubmatch(qw.ResourceURL,-1)
+		DockerURL    := split_string[0][1]
+		tag          := split_string[0][2]
+		
+		if len(DockerURL) == 0 {
+			resp.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(resp, "DockerURL cannot be empty")
+			return
+		}
+		
+		if len(tag) == 0 {
+			resp.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(resp, "tags cannot be empty")
+			return
+		}
+
+	    //create event		
+		event := types.Event{}
+		event.CreatedAt = time.Now()
+		event.TriggerName = "harbor"
+		event.Repository.Name = DockerURL
+		event.Repository.Tag = tag
+
+		s.trigger(event)
+		newHarborWebhooksCounter.With(prometheus.Labels{"image": event.Repository.Name}).Inc()
+		
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	return
+}

--- a/pkg/http/harbor_webhook_trigger.go
+++ b/pkg/http/harbor_webhook_trigger.go
@@ -84,7 +84,6 @@ func (s *TriggerServer) harborHandler(resp http.ResponseWriter, req *http.Reques
 
 		//go trough all the ressource arrays
 		for _, e := range hn.EventData.Resources {
-			fmt.Println("Push found!")
 			//Split the combined <URL>:<tag> into seperate fields
 			splitRegexp := regexp.MustCompile("(.*):(.*)")
 			splitString := splitRegexp.FindAllStringSubmatch(e.ResourceURL, -1)

--- a/pkg/http/harbor_webhook_trigger_test.go
+++ b/pkg/http/harbor_webhook_trigger_test.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"bytes"
+	"net/http"
+
+	"net/http/httptest"
+	"testing"
+)
+
+var fakeHarborWebhook = ` {
+    "type": "pushImage",
+    "occur_at": 1582640688,
+    "operator": "user",
+    "event_data": {
+        "resources": [
+            {
+                "digest": "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848",
+                "tag": "2.1.6",
+                "resource_url": "quay.io/mynamespace/repository:1.2.3"
+            }
+        ],
+        "repository": {
+            "date_created": 1582634337,
+            "name": "repository",
+            "namespace": "mynamespace",
+            "repo_full_name": "mynamespace/repository",
+            "repo_type": "private"
+        }
+    }
+}
+`
+
+func TestQuayWebhookHandler(t *testing.T) {
+
+	fp := &fakeProvider{}
+	srv, teardown := NewTestingServer(fp)
+	defer teardown()
+
+	req, err := http.NewRequest("POST", "/v1/webhooks/harbor", bytes.NewBuffer([]byte(fakeHarborWebhook)))
+	if err != nil {
+		t.Fatalf("failed to create req: %s", err)
+	}
+
+	//The response recorder used to record HTTP responses
+	rec := httptest.NewRecorder()
+
+	srv.router.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("unexpected status code: %d", rec.Code)
+
+		t.Log(rec.Body.String())
+	}
+
+	if len(fp.submitted) != 1 {
+		t.Fatalf("unexpected number of events submitted: %d", len(fp.submitted))
+	}
+
+	if fp.submitted[0].Repository.Name != "quay.io/mynamespace/repository" {
+		t.Errorf("expected quay.io/mynamespace/repository but got %s", fp.submitted[0].Repository.Name)
+	}
+
+	if fp.submitted[0].Repository.Tag != "1.2.3" {
+		t.Errorf("expected 1.2.3 but got %s", fp.submitted[0].Repository.Tag)
+	}
+}

--- a/pkg/http/harbor_webhook_trigger_test.go
+++ b/pkg/http/harbor_webhook_trigger_test.go
@@ -16,7 +16,7 @@ var fakeHarborWebhook = ` {
         "resources": [
             {
                 "digest": "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848",
-                "tag": "2.1.6",
+                "tag": "1.2.3",
                 "resource_url": "quay.io/mynamespace/repository:1.2.3"
             }
         ],
@@ -31,7 +31,7 @@ var fakeHarborWebhook = ` {
 }
 `
 
-func TestQuayWebhookHandler(t *testing.T) {
+func TestHarborWebhookHandler(t *testing.T) {
 
 	fp := &fakeProvider{}
 	srv, teardown := NewTestingServer(fp)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -183,6 +183,7 @@ func (s *TriggerServer) registerWebhookRoutes(mux *mux.Router) {
 		mux.HandleFunc("/v1/webhooks/quay", s.requireAdminAuthorization(s.quayHandler)).Methods("POST", "OPTIONS")
 		mux.HandleFunc("/v1/webhooks/azure", s.requireAdminAuthorization(s.azureHandler)).Methods("POST", "OPTIONS")
 		mux.HandleFunc("/v1/webhooks/github", s.requireAdminAuthorization(s.githubHandler)).Methods("POST", "OPTIONS")
+		mux.HandleFunc("/v1/webhooks/harbor", s.requireAdminAuthorization(s.harborHandler)).Methods("POST", "OPTIONS")
 
 		// Docker registry notifications, used by Docker, Gitlab, Harbor
 		// https://docs.docker.com/registry/notifications/
@@ -194,6 +195,7 @@ func (s *TriggerServer) registerWebhookRoutes(mux *mux.Router) {
 		mux.HandleFunc("/v1/webhooks/quay", s.quayHandler).Methods("POST", "OPTIONS")
 		mux.HandleFunc("/v1/webhooks/azure", s.azureHandler).Methods("POST", "OPTIONS")
 		mux.HandleFunc("/v1/webhooks/github", s.githubHandler).Methods("POST", "OPTIONS")
+		mux.HandleFunc("/v1/webhooks/harbor", s.harborHandler).Methods("POST", "OPTIONS")
 
 		// Docker registry notifications, used by Docker, Gitlab, Harbor
 		// https://docs.docker.com/registry/notifications/


### PR DESCRIPTION
Harbor Version v1.10 seems no longer to be compatible with the registry handler. Therefore i've added an additional handler to be able to integrate a internal/external harbor registry with keel