### PR TITLE
user-guide link does not exist

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -1,7 +1,7 @@
 # Keel - automated Kubernetes deployments for the rest of us
 
 * Website [https://keel.sh](https://keel.sh)
-* User Guide [https://keel.sh/user-guide/](https://keel.sh/user-guide/)
+* User Guide [https://keel.sh/docs/](https://keel.sh/docs/)
 
 Keel is a tool for automating [Kubernetes](https://kubernetes.io/) deployment updates. Keel is stateless, robust and lightweight.
 


### PR DESCRIPTION
It seems that the link https://keel.sh/user-guide/ is no longer valid and has instead shifted to https://keel.sh/docs/