### PR TITLE
Don't set a value for the default image tag

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.19
+version: 0.8.20
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.0
 keywords:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: keelhq/keel
-  tag: 0.15.0-rc1
+  tag: null
   pullPolicy: Always
 
 # Enable insecure registries


### PR DESCRIPTION
Currently, the chart is is hardcoding a value for the image tag so the default setting is not being used.