### PR TITLE
Add SemVer pre-release handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 deployment.yml
 .test_env.sh
 cmd/keel/release
+cmd/keel/keel
 hack/deployment-norbac.yaml
 hack/deployment-rbac.yaml
 hack/deployment-norbac-helm.yaml

--- a/internal/policy/semver_test.go
+++ b/internal/policy/semver_test.go
@@ -6,9 +6,10 @@ import (
 
 func Test_shouldUpdate(t *testing.T) {
 	type args struct {
-		spt     SemverPolicyType
-		current string
-		new     string
+		spt             SemverPolicyType
+		current         string
+		new             string
+		preReleaseMatch bool
 	}
 	tests := []struct {
 		name    string
@@ -129,9 +130,10 @@ func Test_shouldUpdate(t *testing.T) {
 		{
 			name: "prerelease patch increase, policy minor, no prerelease",
 			args: args{
-				current: "1.4.5",
-				new:     "1.4.5-xx",
-				spt:     SemverPolicyTypeMinor,
+				current:         "1.4.5",
+				new:             "1.4.5-xx",
+				spt:             SemverPolicyTypeMinor,
+				preReleaseMatch: true,
 			},
 			want:    false,
 			wantErr: false,
@@ -139,9 +141,10 @@ func Test_shouldUpdate(t *testing.T) {
 		{
 			name: "parsed prerelease patch increase, policy minor, no prerelease",
 			args: args{
-				current: "v1.0.0",
-				new:     "v1.0.1-metadata",
-				spt:     SemverPolicyTypeMinor,
+				current:         "v1.0.0",
+				new:             "v1.0.1-metadata",
+				spt:             SemverPolicyTypeMinor,
+				preReleaseMatch: true,
 			},
 			want:    false,
 			wantErr: false,
@@ -149,9 +152,10 @@ func Test_shouldUpdate(t *testing.T) {
 		{
 			name: "parsed prerelease minor increase, policy minor, both have metadata",
 			args: args{
-				current: "v1.0.0-metadata",
-				new:     "v1.0.1-metadata",
-				spt:     SemverPolicyTypeMinor,
+				current:         "v1.0.0-metadata",
+				new:             "v1.0.1-metadata",
+				spt:             SemverPolicyTypeMinor,
+				preReleaseMatch: true,
 			},
 			want:    true,
 			wantErr: false,
@@ -159,9 +163,10 @@ func Test_shouldUpdate(t *testing.T) {
 		{
 			name: "prerelease patch increase, policy minor",
 			args: args{
-				current: "1.4.5-xx",
-				new:     "1.4.6-xx",
-				spt:     SemverPolicyTypeMinor,
+				current:         "1.4.5-xx",
+				new:             "1.4.6-xx",
+				spt:             SemverPolicyTypeMinor,
+				preReleaseMatch: true,
 			},
 			want:    true,
 			wantErr: false,
@@ -169,9 +174,10 @@ func Test_shouldUpdate(t *testing.T) {
 		{
 			name: "patch increase, policy minor, wrong prerelease",
 			args: args{
-				current: "1.4.5-xx",
-				new:     "1.4.6-yy",
-				spt:     SemverPolicyTypeMinor,
+				current:         "1.4.5-xx",
+				new:             "1.4.6-yy",
+				spt:             SemverPolicyTypeMinor,
+				preReleaseMatch: true,
 			},
 			want:    false,
 			wantErr: false,
@@ -186,10 +192,31 @@ func Test_shouldUpdate(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
+		{
+			name: "pre-release increase, policy All",
+			args: args{
+				current: "1.4.5-xx",
+				new:     "1.4.5-yy",
+				spt:     SemverPolicyTypeAll,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "pre-release increase, policy Patch, do NOT match on pre-release",
+			args: args{
+				current:         "1.4.5-xx",
+				new:             "1.4.5-yy",
+				spt:             SemverPolicyTypePatch,
+				preReleaseMatch: false,
+			},
+			want:    true,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := shouldUpdate(tt.args.spt, tt.args.current, tt.args.new)
+			got, err := shouldUpdate(tt.args.spt, tt.args.preReleaseMatch, tt.args.current, tt.args.new)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("shouldUpdate() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/provider/helm/common_test.go
+++ b/provider/helm/common_test.go
@@ -60,7 +60,7 @@ func Test_getImages(t *testing.T) {
 				&types.TrackedImage{
 					Image:   img,
 					Trigger: types.TriggerTypePoll,
-					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				},
 			},
 			wantErr: false,
@@ -74,17 +74,17 @@ func Test_getImages(t *testing.T) {
 				&types.TrackedImage{
 					Image:   mustParse("quay.io/prometheus/alertmanager:v0.16.2"),
 					Trigger: types.TriggerTypePoll,
-					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				},
 				&types.TrackedImage{
 					Image:   mustParse("quay.io/coreos/prometheus-operator:v0.29.0"),
 					Trigger: types.TriggerTypePoll,
-					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				},
 				&types.TrackedImage{
 					Image:   mustParse("quay.io/prometheus/prometheus:v2.7.2"),
 					Trigger: types.TriggerTypePoll,
-					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+					Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				},
 			},
 			wantErr: false,

--- a/provider/helm/helm.go
+++ b/provider/helm/helm.go
@@ -104,6 +104,7 @@ type Root struct {
 type KeelChartConfig struct {
 	Policy               string            `json:"policy"`
 	MatchTag             bool              `json:"matchTag"`
+	MatchPreRelease      bool              `json:"matchPreRelease"`
 	Trigger              types.TriggerType `json:"trigger"`
 	PollSchedule         string            `json:"pollSchedule"`
 	Approvals            int               `json:"approvals"`        // Minimum required approvals
@@ -448,6 +449,8 @@ func getKeelConfig(vals chartutil.Values) (*KeelChartConfig, error) {
 	}
 
 	var r Root
+	// Default MatchPreRelease to true if not present (backward compatibility)
+	r.Keel.MatchPreRelease = true
 	err = yaml.Unmarshal([]byte(yamlFull), &r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse keel config: %s", err)
@@ -459,7 +462,7 @@ func getKeelConfig(vals chartutil.Values) (*KeelChartConfig, error) {
 
 	cfg := r.Keel
 
-	cfg.Plc = policy.GetPolicy(cfg.Policy, &policy.Options{MatchTag: cfg.MatchTag})
+	cfg.Plc = policy.GetPolicy(cfg.Policy, &policy.Options{MatchTag: cfg.MatchTag, MatchPreRelease: cfg.MatchPreRelease})
 
 	return &cfg, nil
 }

--- a/provider/helm/updates_test.go
+++ b/provider/helm/updates_test.go
@@ -107,8 +107,9 @@ keel:
 				CurrentVersion: "1.1.0",
 				NewVersion:     "latest",
 				Config: &KeelChartConfig{
-					Policy:  "force",
-					Trigger: types.TriggerTypePoll,
+					Policy:          "force",
+					MatchPreRelease: true,
+					Trigger:         types.TriggerTypePoll,
 					Images: []ImageDetails{
 						ImageDetails{
 							RepositoryPath: "image.repository",
@@ -139,8 +140,9 @@ keel:
 				NewVersion:     "1.2.0",
 				ReleaseNotes:   []string{"https://github.com/keel-hq/keel/releases"},
 				Config: &KeelChartConfig{
-					Policy:  "force",
-					Trigger: types.TriggerTypePoll,
+					Policy:          "force",
+					MatchPreRelease: true,
+					Trigger:         types.TriggerTypePoll,
 					Images: []ImageDetails{
 						ImageDetails{
 							RepositoryPath: "image.repository",
@@ -318,12 +320,13 @@ image:
 				NewVersion:     "1.1.2",
 				CurrentVersion: "1.1.0",
 				Config: &KeelChartConfig{
-					Policy:  "all",
-					Trigger: types.TriggerTypePoll,
+					Policy:          "all",
+					MatchPreRelease: true,
+					Trigger:         types.TriggerTypePoll,
 					Images: []ImageDetails{
 						ImageDetails{RepositoryPath: "image.repository", TagPath: "image.tag"},
 					},
-					Plc: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+					Plc: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				},
 			},
 			wantShouldUpdateRelease: true,
@@ -374,8 +377,9 @@ image:
 				NewVersion:     "1.1.0",
 				CurrentVersion: "alpha",
 				Config: &KeelChartConfig{
-					Policy:  "force",
-					Trigger: types.TriggerTypePoll,
+					Policy:          "force",
+					MatchPreRelease: true,
+					Trigger:         types.TriggerTypePoll,
 					Images: []ImageDetails{
 						ImageDetails{RepositoryPath: "image.repository", TagPath: "image.tag"},
 					},
@@ -417,12 +421,13 @@ image:
 				NewVersion:     "1.1.0",
 				CurrentVersion: "1.0.0",
 				Config: &KeelChartConfig{
-					Policy:  "major",
-					Trigger: types.TriggerTypePoll,
+					Policy:          "major",
+					MatchPreRelease: true,
+					Trigger:         types.TriggerTypePoll,
 					Images: []ImageDetails{
 						ImageDetails{RepositoryPath: "image.repository"},
 					},
-					Plc: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
+					Plc: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
 				},
 			},
 			wantShouldUpdateRelease: true,

--- a/provider/kubernetes/updates_test.go
+++ b/provider/kubernetes/updates_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keel-hq/keel/util/timeutil"
 
 	apps_v1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -674,7 +674,7 @@ func TestProvider_checkForUpdateSemver(t *testing.T) {
 		{
 			name: "standard version bump",
 			args: args{
-				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				repo:   &types.Repository{Name: "gcr.io/v2-namespace/hello-world", Tag: "1.1.2"},
 				resource: MustParseGR(&apps_v1.Deployment{
 					meta_v1.TypeMeta{},
@@ -740,7 +740,7 @@ func TestProvider_checkForUpdateSemver(t *testing.T) {
 			name: "staging pre-release",
 			args: args{
 
-				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMinor),
+				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, true),
 				repo:   &types.Repository{Name: "gcr.io/v2-namespace/hello-prerelease", Tag: "v1.1.2-staging"},
 				resource: MustParseGR(&apps_v1.Deployment{
 					meta_v1.TypeMeta{},
@@ -777,7 +777,7 @@ func TestProvider_checkForUpdateSemver(t *testing.T) {
 			name: "normal new tag while there's pre-release",
 			args: args{
 
-				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMinor),
+				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, true),
 				repo:   &types.Repository{Name: "gcr.io/v2-namespace/hello-prerelease", Tag: "v1.1.2"},
 				resource: MustParseGR(&apps_v1.Deployment{
 					meta_v1.TypeMeta{},
@@ -814,7 +814,7 @@ func TestProvider_checkForUpdateSemver(t *testing.T) {
 			name: "standard ignore version bump",
 			args: args{
 
-				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				repo:   &types.Repository{Name: "gcr.io/v2-namespace/hello-world", Tag: "1.1.1"},
 				resource: MustParseGR(&apps_v1.Deployment{
 					meta_v1.TypeMeta{},
@@ -849,7 +849,7 @@ func TestProvider_checkForUpdateSemver(t *testing.T) {
 		{
 			name: "multiple containers, version bump one",
 			args: args{
-				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+				policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 				repo:   &types.Repository{Name: "gcr.io/v2-namespace/hello-world", Tag: "1.1.2"},
 				resource: MustParseGR(&apps_v1.Deployment{
 					meta_v1.TypeMeta{},

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -2,10 +2,13 @@ package poll
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver"
 	"github.com/keel-hq/keel/approvals"
+
 	// "github.com/keel-hq/keel/cache/memory"
 	"github.com/keel-hq/keel/internal/policy"
 	"github.com/keel-hq/keel/provider"
@@ -23,7 +26,7 @@ func TestWatchMultipleTagsWithSemver(t *testing.T) {
 				Trigger:      types.TriggerTypePoll,
 				Provider:     "fp",
 				PollSchedule: types.KeelPollDefaultSchedule,
-				Policy:       policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+				Policy:       policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 			},
 		},
 	}
@@ -57,16 +60,24 @@ func TestWatchMultipleTagsWithSemver(t *testing.T) {
 	}
 }
 
-func TestWatchAllTagsJobWithSemver(t *testing.T) {
+type runTestCase struct {
+	currentTag  string
+	expectedTag string
+	bumpPolicy  policy.Policy
+}
 
-	reference, _ := image.Parse("foo/bar:1.1.0")
+// Helper function to factorize code
+func testRunHelper(testCases []runTestCase, availableTags []string, t *testing.T) {
+	var testImages []*types.TrackedImage
+	for _, testCase := range testCases {
+		reference, _ := image.Parse("foo/bar:" + testCase.currentTag)
+		testImages = append(testImages, &types.TrackedImage{
+			Image:  reference,
+			Policy: testCase.bumpPolicy,
+		})
+	}
 	fp := &fakeProvider{
-		images: []*types.TrackedImage{
-			&types.TrackedImage{
-				Image:  reference,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
-			},
-		},
+		images: testImages,
 	}
 	store, teardown := newTestingUtils()
 	defer teardown()
@@ -77,7 +88,7 @@ func TestWatchAllTagsJobWithSemver(t *testing.T) {
 	providers := provider.New([]provider.Provider{fp}, am)
 
 	frc := &fakeRegistryClient{
-		tagsToReturn: []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"},
+		tagsToReturn: availableTags,
 	}
 
 	details := &watchDetails{
@@ -88,247 +99,95 @@ func TestWatchAllTagsJobWithSemver(t *testing.T) {
 
 	job.Run()
 
+	// Compute number of expected events (version bump expected)
+	var nbEvents = 0
+	for _, testCase := range testCases {
+		if testCase.currentTag != testCase.expectedTag {
+			nbEvents++
+		}
+	}
 	// checking whether new job was submitted
-
-	if len(fp.submitted) != 1 {
+	if len(fp.submitted) != nbEvents {
 		tags := []string{}
 		for _, s := range fp.submitted {
 			tags = append(tags, s.Repository.Tag)
 		}
-		t.Errorf("expected 1 events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
+		t.Errorf("expected "+strconv.Itoa(nbEvents)+" events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
+	} else {
+		for i, testCase := range testCases {
+			submitted := fp.submitted[i]
+
+			if submitted.Repository.Name != "index.docker.io/foo/bar" {
+				t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
+			}
+
+			if submitted.Repository.Tag != testCase.expectedTag {
+				t.Errorf("expected event repository tag "+testCase.expectedTag+", but got: %s", submitted.Repository.Tag)
+			}
+		}
 	}
+}
 
-	submitted := fp.submitted[0]
-
-	if submitted.Repository.Name != "index.docker.io/foo/bar" {
-		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
-	}
-
-	if submitted.Repository.Tag != "1.5.0" {
-		t.Errorf("expected event repository tag 1.5.0, but got: %s", submitted.Repository.Tag)
-	}
-
+func TestWatchAllTagsJobWithSemver(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
+	testCases := []runTestCase{{"1.1.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)}}
+	testRunHelper(testCases, availableTags, t)
 }
 
 func TestWatchAllTagsPrerelease(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
+	testCases := []runTestCase{{"1.2.0-dev", "1.3.0-dev", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)}}
+	testRunHelper(testCases, availableTags, t)
+}
 
-	referenceB, _ := image.Parse("foo/bar:1.2.0-dev")
+// Full Semver, including pre-releases
+func TestWatchAllTagsFullSemver(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
+	testCases := []runTestCase{{"1.2.0-dev", "1.8.0-alpha", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}
+	testRunHelper(testCases, availableTags, t)
 
-	fp := &fakeProvider{
-		images: []*types.TrackedImage{
-			&types.TrackedImage{
-				Image:  referenceB,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
-			},
-		},
-	}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	am := approvals.New(&approvals.Opts{
-		Store: store,
-	})
+	// Test simulating linuxserver tagging strategy
+	availableTags = []string{"v0.1.2-ls1", "v0.1.2-ls2", "v0.1.3-ls1", "v0.1.3-ls2", "v0.2.0-ls2", "v0.2.0-ls3"}
+	testCases = []runTestCase{{"v0.1.0-ls1", "v0.2.0-ls3", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}
+	testRunHelper(testCases, availableTags, t)
 
-	providers := provider.New([]provider.Provider{fp}, am)
+}
 
-	frc := &fakeRegistryClient{
-		tagsToReturn: []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"},
-	}
-
-	details := &watchDetails{
-		trackedImage: fp.images[0],
-	}
-
-	job := NewWatchRepositoryTagsJob(providers, frc, details)
-
-	job.Run()
-
-	// checking whether new job was submitted
-
-	if len(fp.submitted) != 1 {
-		tags := []string{}
-		for _, s := range fp.submitted {
-			tags = append(tags, s.Repository.Tag)
-		}
-		t.Errorf("expected 1 events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
-	}
-
-	submitted := fp.submitted[0]
-
-	if submitted.Repository.Name != "index.docker.io/foo/bar" {
-		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
-	}
-
-	if submitted.Repository.Tag != "1.3.0-dev" {
-		t.Errorf("expected event repository tag 1.3.0-dev, but got: %s", submitted.Repository.Tag)
-	}
+// Bug #490: new major version "hiding" minor one
+func TestWatchAllTagsHiddenMinor(t *testing.T) {
+	availableTags := []string{"1.3.0", "1.5.0", "2.0.0", "1.2.1"}
+	testRunHelper([]runTestCase{{"1.2.0", "1.2.1", policy.NewSemverPolicy(policy.SemverPolicyTypePatch, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"1.2.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"1.2.0", "2.0.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, false)}}, availableTags, t)
 }
 
 func TestWatchAllTagsMixed(t *testing.T) {
-
-	referenceA, _ := image.Parse("foo/bar:1.0.0")
-	referenceB, _ := image.Parse("foo/bar:1.2.0-dev")
-
-	fp := &fakeProvider{
-		images: []*types.TrackedImage{
-			&types.TrackedImage{
-				Image:  referenceB,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
-			},
-			&types.TrackedImage{
-				Image:  referenceA,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
-			},
-		},
-	}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	am := approvals.New(&approvals.Opts{
-		Store: store,
-	})
-
-	providers := provider.New([]provider.Provider{fp}, am)
-
-	frc := &fakeRegistryClient{
-		tagsToReturn: []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"},
-	}
-
-	details := &watchDetails{
-		trackedImage: fp.images[0],
-	}
-
-	job := NewWatchRepositoryTagsJob(providers, frc, details)
-
-	job.Run()
-
-	// checking whether new job was submitted
-
-	if len(fp.submitted) != 2 {
-		tags := []string{}
-		for _, s := range fp.submitted {
-			tags = append(tags, s.Repository.Tag)
-		}
-		t.Errorf("expected 1 events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
-	}
-
-	submitted := fp.submitted[0]
-	submitted2 := fp.submitted[1]
-
-	if submitted.Repository.Name != "index.docker.io/foo/bar" {
-		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
-	}
-
-	if submitted.Repository.Tag != "1.3.0-dev" {
-		t.Errorf("expected event repository tag 1.3.0-dev, but got: %s", submitted.Repository.Tag)
-	}
-
-	if submitted2.Repository.Tag != "1.5.0" {
-		t.Errorf("expected event repository tag 1.5.0, but got: %s", submitted2.Repository.Tag)
-	}
+	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
+	testCases := []runTestCase{
+		{"1.0.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)},
+		{"1.2.0-dev", "1.3.0-dev", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)}}
+	testRunHelper(testCases, availableTags, t)
 }
 
 func TestWatchAllTagsMixedPolicyAll(t *testing.T) {
-
-	referenceA, _ := image.Parse("foo/bar:1.0.0")
-	referenceB, _ := image.Parse("foo/bar:1.6.0-alpha")
-
-	fp := &fakeProvider{
-		images: []*types.TrackedImage{
-			&types.TrackedImage{
-				Image:  referenceB,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
-			},
-			&types.TrackedImage{
-				Image:  referenceA,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
-			},
-		},
-	}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	am := approvals.New(&approvals.Opts{
-		Store: store,
-	})
-
-	providers := provider.New([]provider.Provider{fp}, am)
-
-	frc := &fakeRegistryClient{
-		tagsToReturn: []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"},
-	}
-
-	details := &watchDetails{
-		trackedImage: fp.images[0],
-	}
-
-	job := NewWatchRepositoryTagsJob(providers, frc, details)
-
-	job.Run()
-
-	// checking whether new job was submitted
-
-	if len(fp.submitted) != 2 {
-		tags := []string{}
-		for _, s := range fp.submitted {
-			tags = append(tags, s.Repository.Tag)
-		}
-		t.Errorf("expected 1 events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
-	}
-
-	submitted := fp.submitted[0]
-	submitted2 := fp.submitted[1]
-
-	if submitted.Repository.Name != "index.docker.io/foo/bar" {
-		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
-	}
-
-	if submitted.Repository.Tag != "1.8.0-alpha" {
-		t.Errorf("expected event repository tag 1.8.0-alpha, but got: %s", submitted.Repository.Tag)
-	}
-
-	if submitted2.Repository.Tag != "1.5.0" {
-		t.Errorf("expected event repository tag 1.5.0, but got: %s", submitted2.Repository.Tag)
-	}
+	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
+	testCases := []runTestCase{
+		{"1.0.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)},
+		{"1.6.0-alpha", "1.8.0-alpha", policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true)}}
+	testRunHelper(testCases, availableTags, t)
 }
 
-func Test_collapse(t *testing.T) {
-	type args struct {
-		tags []string
+func Test_semverSort(t *testing.T) {
+	tags := []string{"1.3.0", "aa1.0.0", "zzz", "1.3.0-dev", "1.5.0", "2.0.0-alpha", "1.3.0-dev1", "1.8.0-alpha", "1.3.1-dev", "123", "1.2.3-rc.1.2+meta"}
+	expectedTags := []string{"2.0.0-alpha", "1.8.0-alpha", "1.5.0", "1.3.1-dev", "1.3.0", "1.3.0-dev1", "1.3.0-dev", "1.2.3-rc.1.2+meta"}
+	expectedVersions := make([]*semver.Version, len(expectedTags))
+	for i, tag := range expectedTags {
+		v, _ := semver.NewVersion(tag)
+		expectedVersions[i] = v
 	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "single version",
-			args: args{tags: []string{"1.0.0"}},
-			want: []string{"1.0.0"},
-		},
-		{
-			name: "multi",
-			args: args{tags: []string{"1.0.0", "1.4.0"}},
-			want: []string{"1.4.0"},
-		},
-		{
-			name: "prerelease",
-			args: args{tags: []string{"1.0.0-dev", "1.4.0-dev"}},
-			want: []string{"1.4.0-dev"},
-		},
-		{
-			name: "prerelease multi",
-			args: args{tags: []string{"1.3.0-bb", "1.0.0-dev", "1.4.0-dev"}},
-			want: []string{"1.3.0-bb", "1.4.0-dev"},
-		},
-		{
-			name: "prerelease multi, mixed",
-			args: args{tags: []string{"1.2.0", "1.3.0-bb", "1.0.0-dev", "1.4.0-dev"}},
-			want: []string{"1.2.0", "1.3.0-bb", "1.4.0-dev"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := collapse(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("collapse() = %v, want %v", got, tt.want)
-			}
-		})
+	sortedTags := semverSort(tags)
+
+	if !reflect.DeepEqual(sortedTags, expectedVersions) {
+		t.Errorf("Invalid sorted tags; expected: %s; got: %s", expectedVersions, sortedTags)
 	}
 }

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -179,7 +179,7 @@ func TestWatchAllTagsJob(t *testing.T) {
 		images: []*types.TrackedImage{
 			&types.TrackedImage{
 				Image:  reference,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll),
+				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 			},
 		},
 	}
@@ -270,7 +270,7 @@ func TestWatchMultipleTags(t *testing.T) {
 				Provider:     "fp",
 				PollSchedule: types.KeelPollDefaultSchedule,
 
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
+				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
 			},
 
 			&types.TrackedImage{
@@ -278,7 +278,7 @@ func TestWatchMultipleTags(t *testing.T) {
 				Image:        imgB,
 				Provider:     "fp",
 				PollSchedule: types.KeelPollDefaultSchedule,
-				Policy:       policy.NewSemverPolicy(policy.SemverPolicyTypeMajor),
+				Policy:       policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
 			},
 
 			&types.TrackedImage{

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,9 @@ const KeelTriggerLabel = "keel.sh/trigger"
 const KeelForceTagMatchLegacyLabel = "keel.sh/match-tag"
 const KeelForceTagMatchLabel = "keel.sh/matchTag"
 
+// KeelMatchPreReleaseAnnotation - label or annotation to set pre-release matching for SemVer, defaults to true for backward compatibility
+const KeelMatchPreReleaseAnnotation = "keel.sh/matchPreRelease"
+
 // KeelPollScheduleAnnotation - optional variable to setup custom schedule for polling, defaults to @every 10m
 const KeelPollScheduleAnnotation = "keel.sh/pollSchedule"
 


### PR DESCRIPTION
Previously, SemVer pre-release version was used to differentiate kind
of "branches", not allowing to cross pre-release on update.
According to SemVer spec, this should rather rely on the metadata.
New "keel.sh/matchPreRelease" annotation (or label) is added to disable
current keel behavior and consider the pre-release as a standard
SemVer versioning token.
For backward compatibility purpose, its value defaults to "true" if not
specified.
Closes #252

Also reviewed WatchRepositoryTagsJob tags handling.
Fixes #490