### PR TITLE
Remove the event buffer

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -187,7 +187,7 @@ func main() {
 		FieldLogger: log.WithField("context", "translator"),
 	}
 
-	buf := k8s.NewBuffer(&g, t, log.StandardLogger(), 128)
+	buf := k8s.NewBuffer(&g, t, log.StandardLogger())
 	wl := log.WithField("context", "watch")
 	k8s.WatchDeployments(&g, implementer.Client(), wl, buf)
 	k8s.WatchStatefulSets(&g, implementer.Client(), wl, buf)

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -8,7 +8,7 @@ import (
 
 	apps_v1 "k8s.io/api/apps/v1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,9 +69,9 @@ type deleteEvent struct {
 }
 
 // NewBuffer returns a ResourceEventHandler which buffers and serialises ResourceEventHandler events.
-func NewBuffer(g *workgroup.Group, rh cache.ResourceEventHandler, log logrus.FieldLogger, size int) cache.ResourceEventHandler {
+func NewBuffer(g *workgroup.Group, rh cache.ResourceEventHandler, log logrus.FieldLogger) cache.ResourceEventHandler {
 	buf := &buffer{
-		ev:        make(chan interface{}, size),
+		ev:        make(chan interface{}),
 		StdLogger: log.WithField("context", "buffer"),
 		rh:        rh,
 	}
@@ -115,11 +115,5 @@ func (b *buffer) OnDelete(obj interface{}) {
 }
 
 func (b *buffer) send(ev interface{}) {
-	select {
-	case b.ev <- ev:
-		// all good
-	default:
-		b.Printf("event channel is full, len: %v, cap: %v", len(b.ev), cap(b.ev))
-		b.ev <- ev
-	}
+	b.ev <- ev
 }


### PR DESCRIPTION
The 128 buffer capacity causes problems on clusters with more deployments, causing some deployments to not be updated.

As per the discussion on #443 the simplest thing is just to remove it. Everything still seems to work, though I couldn't get all the end to end tests running on my system if someone wouldn't mind double checking.

Fixes #443