### PR TITLE
[chart] fix referencing missing secret

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.8.21
+version: 0.8.22
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.0
 keywords:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -154,14 +154,16 @@ spec:
             # Enable insecure registries
             - name: INSECURE_REGISTRY
               value: "{{ .Values.insecureRegistry }}"
- {{- end }}
+{{- end }}
 {{- if .Values.aws.region }}
             - name: AWS_REGION
               value: "{{ .Values.aws.region }}"
 {{- end }}
+{{- if .Values.secret.create }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name | default (include "keel.fullname" .) }}
+{{- end }}
           ports:
             - containerPort: 9300
           livenessProbe:


### PR DESCRIPTION
This PR fixes deployment template in the Helm chart by excluding `secretRef` when the secret creation is disabled by `--set secret.create=false`.