### PR TITLE
Semver with 2 points

### DIFF
--- a/internal/policy/semver.go
+++ b/internal/policy/semver.go
@@ -69,7 +69,7 @@ func shouldUpdate(spt SemverPolicyType, matchPreRelease bool, current, new strin
 	}
 
 	parts := strings.SplitN(new, ".", 3)
-	if len(parts) != 3 {
+	if len(parts) != 2 && len(parts) != 3 {
 		return false, ErrNoMajorMinorPatchElementsFound
 	}
 

--- a/internal/policy/semver_test.go
+++ b/internal/policy/semver_test.go
@@ -48,6 +48,16 @@ func Test_shouldUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "minor increase - 2 points, policy all",
+			args: args{
+				current: "1.4",
+				new:     "1.5",
+				spt:     SemverPolicyTypeAll,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name: "minor increase, policy major",
 			args: args{
 				current: "1.4.5",
@@ -78,10 +88,40 @@ func Test_shouldUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "patch release, policy patch",
+			args: args{
+				current: "1.4",
+				new:     "1.4.6",
+				spt:     SemverPolicyTypePatch,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "minor and patch release, policy patch",
+			args: args{
+				current: "1.4",
+				new:     "1.5.6",
+				spt:     SemverPolicyTypePatch,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "patch decrease, policy patch",
 			args: args{
 				current: "1.4.5",
 				new:     "1.4.4",
+				spt:     SemverPolicyTypePatch,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "2 points minor change, policy patch",
+			args: args{
+				current: "1.4",
+				new:     "1.5",
 				spt:     SemverPolicyTypePatch,
 			},
 			want:    false,
@@ -112,6 +152,16 @@ func Test_shouldUpdate(t *testing.T) {
 			args: args{
 				current: "1.4.5",
 				new:     "1.5.5",
+				spt:     SemverPolicyTypeMinor,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "minor increase 2 points, policy minor",
+			args: args{
+				current: "1.4",
+				new:     "1.5",
 				spt:     SemverPolicyTypeMinor,
 			},
 			want:    true,

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -152,7 +152,7 @@ func exists(tag string, events []types.Event) bool {
 func semverSort(tags []string) []*semver.Version {
 	var versions []*semver.Version
 	for _, t := range tags {
-		if len(strings.SplitN(t, ".", 3)) < 3 {
+		if len(strings.SplitN(t, ".", 3)) < 2 {
 			// Keep only X.Y.Z+ semver
 			continue
 		}

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -130,6 +130,14 @@ func testRunHelper(testCases []runTestCase, availableTags []string, t *testing.T
 	}
 }
 
+
+func TestWatchAllTagsJobWith2pointSemver(t *testing.T) {
+	availableTags := []string{"1.3", "2.5", "2.7", "3.8"}
+	testRunHelper([]runTestCase{{"1.3", "3.8", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"2.5", "3.8", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"2.5", "2.7", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}, availableTags, t)
+}
+
 func TestWatchAllTagsJobWithSemver(t *testing.T) {
 	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
 	testCases := []runTestCase{{"1.1.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)}}
@@ -153,6 +161,13 @@ func TestWatchAllTagsFullSemver(t *testing.T) {
 	testCases = []runTestCase{{"v0.1.0-ls1", "v0.2.0-ls3", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}
 	testRunHelper(testCases, availableTags, t)
 
+}
+
+func TestWatchAllTagsHiddenMinorWith2PointVersions(t *testing.T) {
+	availableTags := []string{"1.3", "1.5", "2.0", "1.2.1"}
+	testRunHelper([]runTestCase{{"1.2", "1.2.1", policy.NewSemverPolicy(policy.SemverPolicyTypePatch, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"1.2", "1.5", policy.NewSemverPolicy(policy.SemverPolicyTypeMinor, false)}}, availableTags, t)
+	testRunHelper([]runTestCase{{"1.2", "2.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, false)}}, availableTags, t)
 }
 
 // Bug #490: new major version "hiding" minor one

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -32,7 +32,7 @@ func MustParse(version string) *types.Version {
 func GetVersion(version string) (*types.Version, error) {
 
 	parts := strings.SplitN(version, ".", 3)
-	if len(parts) != 3 {
+	if len(parts) != 2 && len(parts) != 3 {
 		return nil, ErrNoMajorMinorPatchElementsFound
 	}
 

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -46,6 +46,12 @@ func TestGetVersionFromImageName(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "2 point semver, missing minor",
+			args:    args{name: "index.docker.io/application:12.14"},
+			want:    MustParse("12.14"),
+			wantErr: false,
+		},
+		{
 			name:    "non semver, missing minor and patch",
 			args:    args{name: "index.docker.io/application:42"},
 			want:    nil,


### PR DESCRIPTION
We use versions like 2.1, 2.2, 12.15 and very rarely use the patch version. It just seems like a lot of overhead to have the extra point.

This PR adds some test cases for treating 2 point versions the same as 3 point versions

Let me know if I've missed any key places