### PR TITLE
Bugfix: Do not use nil credentials in watcher addJob

### DIFF
--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -242,8 +242,8 @@ func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) erro
 		log.WithFields(log.Fields{
 			"error":    err,
 			"image":    ti.Image.String(),
-			"username": creds.Username,
-			"password": strings.Repeat("*", len(creds.Password)),
+			"username": registryOpts.Username,
+			"password": strings.Repeat("*", len(registryOpts.Password)),
 		}).Error("trigger.poll.RepositoryWatcher.addJob: failed to get image digest")
 		return err
 	}


### PR DESCRIPTION
Fixes a use of nil credentials after an error from credentials helper and getting the image digest.

Adds a test to check for this scenario.

Should fix the panic in #453.