### PR TITLE
Update Harbor webhook to add PUSH_ARTIFACT as valid type

### DIFF
--- a/pkg/http/harbor_webhook_trigger.go
+++ b/pkg/http/harbor_webhook_trigger.go
@@ -81,7 +81,7 @@ func (s *TriggerServer) harborHandler(resp http.ResponseWriter, req *http.Reques
 		"event": hn,
 	}).Debug("harborHandler: received event, looking for a pushImage tag")
 
-	if hn.Type == "pushImage" {
+	if hn.Type == "pushImage" || hn.Type == "PUSH_ARTIFACT" { 
 		// go trough all the ressource items
 		for _, e := range hn.EventData.Resources {
 			imageRepo, err := image.Parse(e.ResourceURL)

--- a/pkg/http/harbor_webhook_trigger_test.go
+++ b/pkg/http/harbor_webhook_trigger_test.go
@@ -31,6 +31,30 @@ var fakeHarborWebhook = ` {
 }
 `
 
+var fakeHarborWebhook2 = `
+	{
+		"type": "PUSH_ARTIFACT",
+		"occur_at": 1582640688,
+		"operator": "user",
+		"event_data": {
+		  "resources": [
+			{
+			  "digest": "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848",
+			  "tag": "latest",
+			  "resource_url": "quay.io/mynamespace/repository:1.2.3"
+			}
+		  ],
+		  "repository": {
+			"date_created": 1582634337,
+			"name": "repository",
+			"namespace": "mynamespace",
+			"repo_full_name": "mynamespace/repository",
+			"repo_type": "private"
+		  }
+		}
+	}
+`
+
 func TestHarborWebhookHandler(t *testing.T) {
 
 	fp := &fakeProvider{}
@@ -38,6 +62,40 @@ func TestHarborWebhookHandler(t *testing.T) {
 	defer teardown()
 
 	req, err := http.NewRequest("POST", "/v1/webhooks/harbor", bytes.NewBuffer([]byte(fakeHarborWebhook)))
+	if err != nil {
+		t.Fatalf("failed to create req: %s", err)
+	}
+
+	//The response recorder used to record HTTP responses
+	rec := httptest.NewRecorder()
+
+	srv.router.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("unexpected status code: %d", rec.Code)
+
+		t.Log(rec.Body.String())
+	}
+
+	if len(fp.submitted) != 1 {
+		t.Fatalf("unexpected number of events submitted: %d", len(fp.submitted))
+	}
+
+	if fp.submitted[0].Repository.Name != "quay.io/mynamespace/repository" {
+		t.Errorf("expected quay.io/mynamespace/repository but got %s", fp.submitted[0].Repository.Name)
+	}
+
+	if fp.submitted[0].Repository.Tag != "1.2.3" {
+		t.Errorf("expected 1.2.3 but got %s", fp.submitted[0].Repository.Tag)
+	}
+}
+
+func TestHarborWebhookHandler2(t *testing.T) {
+
+	fp := &fakeProvider{}
+	srv, teardown := NewTestingServer(fp)
+	defer teardown()
+
+	req, err := http.NewRequest("POST", "/v1/webhooks/harbor", bytes.NewBuffer([]byte(fakeHarborWebhook2)))
 	if err != nil {
 		t.Fatalf("failed to create req: %s", err)
 	}


### PR DESCRIPTION
I don't know if this is the way you want to fix this bug, so don't hesitate to do it differently and/or request changes.
I've tested it on my own cluster and it seems to work fine. I've also added a test for `type == PUSH_ARTIFACT` by copying the already existing one.

Fixes #510 