### PR TITLE
Update copyright year

### DIFF
--- a/ui/src/components/GlobalFooter/GlobalFooter.vue
+++ b/ui/src/components/GlobalFooter/GlobalFooter.vue
@@ -10,7 +10,7 @@
     </div>
     <div class="copyright">
       Copyright
-      <a-icon type="copyright" /> 2019 <span>Keel</span>
+      <a-icon type="copyright" /> 2020 <span>Keel</span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This is a tiny change that makes it look a little better. Copyright year says 2019, while it's almost 2021.