### PR TITLE
Add force-match-tag policy menu to web ui

### DIFF
--- a/pkg/http/policy_endpoint.go
+++ b/pkg/http/policy_endpoint.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/keel-hq/keel/types"
 )
@@ -39,7 +41,12 @@ func (s *TriggerServer) policyUpdateHandler(resp http.ResponseWriter, req *http.
 			v.SetLabels(labels)
 
 			ann := v.GetAnnotations()
-			ann[types.KeelPolicyLabel] = policyRequest.Policy
+			if strings.HasPrefix(policyRequest.Policy, "force") {
+				ann[types.KeelPolicyLabel] = "force"
+				ann[types.KeelForceTagMatchLegacyLabel] = strconv.FormatBool(strings.HasSuffix(policyRequest.Policy, "match-tag"))
+			} else {
+				ann[types.KeelPolicyLabel] = policyRequest.Policy
+			}
 
 			v.SetAnnotations(ann)
 

--- a/ui/src/views/dashboard/Analysis.vue
+++ b/ui/src/views/dashboard/Analysis.vue
@@ -154,8 +154,9 @@
               <a-menu-item @click="setPolicy(resource, 'major')" key="3">major</a-menu-item>
               <a-menu-item @click="setPolicy(resource, 'all')" key="4">all</a-menu-item>
               <a-menu-item @click="setPolicy(resource, 'force')" key="5">force</a-menu-item>
-              <a-menu-item @click="showPolicyModal(resource, 'glob')" key="6">glob</a-menu-item>
-              <a-menu-item @click="showPolicyModal(resource, 'regexp')" key="7">regexp</a-menu-item>
+              <a-menu-item @click="setPolicy(resource, 'force-match-tag')" key="6">force (match tag)</a-menu-item>
+              <a-menu-item @click="showPolicyModal(resource, 'glob')" key="7">glob</a-menu-item>
+              <a-menu-item @click="showPolicyModal(resource, 'regexp')" key="8">regexp</a-menu-item>
             </a-menu>
             <a-button size="small" type="primary">
               Policy<a-icon type="down" />


### PR DESCRIPTION
Currently, there is no way to add `match-tag` annotation on the web ui.

![image](https://user-images.githubusercontent.com/5079364/97374851-48f47800-18f4-11eb-8ca3-ae6fdfad363f.png)
