### PR TITLE
feat: force tracking semver tag

### DIFF
--- a/trigger/poll/manager_test.go
+++ b/trigger/poll/manager_test.go
@@ -100,7 +100,7 @@ func TestCheckDeployment(t *testing.T) {
 	}
 
 	ref, _ := image.Parse(imageA)
-	keyA := getImageIdentifier(ref)
+	keyA := getImageIdentifier(ref, false)
 	if watcher.watched[keyA].digest != frc.digestToReturn {
 		t.Errorf("unexpected digest")
 	}
@@ -115,7 +115,7 @@ func TestCheckDeployment(t *testing.T) {
 	}
 
 	refB, _ := image.Parse(imageB)
-	keyB := getImageIdentifier(refB)
+	keyB := getImageIdentifier(refB, false)
 	if watcher.watched[keyB].digest != frc.digestToReturn {
 		t.Errorf("unexpected digest")
 	}
@@ -176,7 +176,7 @@ func TestCheckECRDeployment(t *testing.T) {
 		t.Fatalf("unexpected list of cron entries: %d", len(entries))
 	}
 
-	keyA := getImageIdentifier(imgA)
+	keyA := getImageIdentifier(imgA, false)
 
 	if len(watcher.watched) != 1 {
 		t.Fatalf("expected to find 1 entry in watcher.watched map, found: %d", len(watcher.watched))

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -130,7 +130,6 @@ func testRunHelper(testCases []runTestCase, availableTags []string, t *testing.T
 	}
 }
 
-
 func TestWatchAllTagsJobWith2pointSemver(t *testing.T) {
 	availableTags := []string{"1.3", "2.5", "2.7", "3.8"}
 	testRunHelper([]runTestCase{{"1.3", "3.8", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, false)}}, availableTags, t)

--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -261,11 +261,15 @@ func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) erro
 	// adding job to internal map
 	w.watched[key] = details
 
-	// checking tag type, for versioned (semver) tags we setup a watch all tags job
-	// and for non-semver types we create a single tag watcher which
+	// checking tag type:
+	//  - for versioned (semver) tags:
+	//    - we setup a watch all tags job (default)
+	//    - if "force" to follow a floating tag, a single tag watcher is
+	//      setup, which checks digest
+	//  - for non-semver types we create a single tag watcher which
 	// checks digest
 	_, err = version.GetVersion(ti.Image.Tag())
-	if err != nil || (ti.Policy != nil && ti.Policy.Name() == "force") {
+	if err != nil || keepTag == true {
 		// adding new job
 		job := NewWatchTagJob(w.providers, w.registryClient, details)
 		log.WithFields(log.Fields{


### PR DESCRIPTION
It currently not possible to _force_ watching a semver tag.

This should, as side effect, solve issues about loop update, since that will compare digest and not image tags
 - https://github.com/keel-hq/keel/issues/465
 - https://github.com/keel-hq/keel/issues/505
 - https://github.com/keel-hq/keel/issues/560