### PR TITLE
feat(chart): mount existing secrets as envs

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.9.6
+version: 0.9.7
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.1
 keywords:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
             - name: AWS_REGION
               value: "{{ .Values.aws.region }}"
 {{- end }}
-{{- if .Values.secret.create }}
+{{- if or .Values.secret.create .Values.secret.name }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name | default (include "keel.fullname" .) }}


### PR DESCRIPTION
Enables using an existing secret, externally managed, to be mounted as envs just as if it was managed through Helm.