### PR TITLE
fix(bot): fix bot icon url

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.9.7
+version: 0.9.8
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.1
 keywords:

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -53,4 +53,4 @@ const EnvAuthenticatedWebhooks = "AUTHENTICATED_WEBHOOKS"
 const EnvTokenSecret = "TOKEN_SECRET"
 
 // KeelLogoURL - is a logo URL for bot icon
-const KeelLogoURL = "https://keel.sh/images/logo.png"
+const KeelLogoURL = "https://keel.sh/img/logo.png"


### PR DESCRIPTION
Since the old URL is now 404, the bot's icon in chat notifications no longer displays.