### PR TITLE
Split regexp policy into two strings only

### DIFF
--- a/internal/policy/regexp.go
+++ b/internal/policy/regexp.go
@@ -14,7 +14,7 @@ type RegexpPolicy struct {
 
 func NewRegexpPolicy(policy string) (*RegexpPolicy, error) {
 	if strings.Contains(policy, ":") {
-		parts := strings.Split(policy, ":")
+		parts := strings.SplitN(policy, ":", 2)
 		if len(parts) == 2 {
 
 			rx, err := regexp.Compile(parts[1])


### PR DESCRIPTION
This PR fixes #596 as the current implementations doesn't allow to use regular expressions with column characters, which are valid as for RE2 library.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>