### PR TITLE
update PodDisruptionBudget to policy/v1

### DIFF
--- a/deployment/deployment-template.yaml
+++ b/deployment/deployment-template.yaml
@@ -242,7 +242,7 @@ spec:
 ---
 # Source: keel/templates/pod-disruption-budget.yaml
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: keel


### PR DESCRIPTION
because of this warning...
```
Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```