### PR TITLE
Restricted namespace

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -32,7 +32,7 @@ const (
 	EnvMattermostName     = "MATTERMOST_USERNAME"
 
 	// MS Teams webhook url, see https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#setting-up-a-custom-incoming-webhook
-	EnvTeamsWebhookUrl	= "TEAMS_WEBHOOK_URL"
+	EnvTeamsWebhookUrl = "TEAMS_WEBHOOK_URL"
 
 	// Mail notification settings
 	EnvMailTo         = "MAIL_TO"
@@ -54,3 +54,6 @@ const EnvTokenSecret = "TOKEN_SECRET"
 
 // KeelLogoURL - is a logo URL for bot icon
 const KeelLogoURL = "https://keel.sh/img/logo.png"
+
+// Env var to define a namespace that keel will scan - avoid scan over all the cluster -
+const EnvRestrictedNamespace = "RESTRICTED_NAMESPACE"

--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -42,16 +42,16 @@ func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource 
 	//Check if the env var RESTRICTED_NAMESPACE is empty or equal to keel
 	// If equal to keel or empty, the scan will be over all the cluster
 	// If RESTRICTED_NAMESPACE is different than keel or empty, keel will scan in the defined namespace
-	namespace_scan := "keel"
+	namespaceScan := "keel"
 	if os.Getenv(constants.EnvRestrictedNamespace) == "keel" {
-		namespace_scan = v1.NamespaceAll
+		namespaceScan = v1.NamespaceAll
 	} else if os.Getenv(constants.EnvRestrictedNamespace) == "" {
-		namespace_scan = v1.NamespaceAll
+		namespaceScan = v1.NamespaceAll
 	} else {
-		namespace_scan = os.Getenv(constants.EnvRestrictedNamespace)
+		namespaceScan = os.Getenv(constants.EnvRestrictedNamespace)
 	}
 
-	lw := cache.NewListWatchFromClient(c, resource, namespace_scan, fields.Everything())
+	lw := cache.NewListWatchFromClient(c, resource, namespaceScan, fields.Everything())
 	sw := cache.NewSharedInformer(lw, objType, 30*time.Minute)
 	for _, r := range rs {
 		sw.AddEventHandler(r)


### PR DESCRIPTION
Possibility to use Keel in one namespace => with RESTRICTED_NAMESPACE env var. It is allowing to use only role + rolebinding instead clusterrole + clusterrolebinding, and can be used when you have only one namespace dedicated with policies restrictions.