### PR TITLE
feat: networking.k8s.io ingress apiVersion

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.9.9
+version: 0.10.0
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.1
 keywords:

--- a/chart/keel/templates/ingress.yaml
+++ b/chart/keel/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
     {{- end }}
 {{- end }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
BREAKING-CHANGE: support for the `extensions/v1beta1` api is dropped.
The ingress resource now uses `networking.k8s.io/v1beta1` which requires
Kubernetes 1.14+

Closes #533