### PR TITLE
Allow google cloud artifact registry repositories to make pub/sub subscriptions

### DIFF
--- a/trigger/pubsub/manager.go
+++ b/trigger/pubsub/manager.go
@@ -95,7 +95,7 @@ func (s *DefaultManager) scan(ctx context.Context) error {
 	}
 
 	for _, trackedImage := range trackedImages {
-		if !isGoogleContainerRegistry(trackedImage.Image.Registry()) {
+		if !isGoogleArtifactRegistry(trackedImage.Image.Registry()) {
 			log.Debugf("registry %s is not a GCR, skipping", trackedImage.Image.Registry())
 			continue
 		}

--- a/trigger/pubsub/util.go
+++ b/trigger/pubsub/util.go
@@ -3,7 +3,7 @@ package pubsub
 import (
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"regexp"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -51,10 +51,17 @@ func getClusterName(metadataEndpoint string) (string, error) {
 	return string(body), nil
 }
 
-// isGoogleContainerRegistry - we only care about gcr.io images,
+// isGoogleContainerRegistry - we only care about gcr.io and pkg.dev images,
 // with other registries - we won't be able to receive events.
 // Theoretically if someone publishes messages for updated images to
 // google pubsub - we could turn this off
 func isGoogleContainerRegistry(registry string) bool {
-	return strings.Contains(registry, "gcr.io")
+	matched, err := regexp.MatchString(`(gcr\.io|pkg\.dev)`, registry)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Warn("trigger.pubsub.isGoogleContainerRegistry: got error while checking if registry is gcr")
+		return false
+	}
+	return matched
 }

--- a/trigger/pubsub/util.go
+++ b/trigger/pubsub/util.go
@@ -51,16 +51,16 @@ func getClusterName(metadataEndpoint string) (string, error) {
 	return string(body), nil
 }
 
-// isGoogleContainerRegistry - we only care about gcr.io and pkg.dev images,
+// isGoogleArtifactRegistry - we only care about gcr.io and pkg.dev images,
 // with other registries - we won't be able to receive events.
 // Theoretically if someone publishes messages for updated images to
 // google pubsub - we could turn this off
-func isGoogleContainerRegistry(registry string) bool {
+func isGoogleArtifactRegistry(registry string) bool {
 	matched, err := regexp.MatchString(`(gcr\.io|pkg\.dev)`, registry)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Warn("trigger.pubsub.isGoogleContainerRegistry: got error while checking if registry is gcr")
+		}).Warn("trigger.pubsub.isGoogleArtifactRegistry: got error while checking if registry is gcr")
 		return false
 	}
 	return matched

--- a/trigger/pubsub/util_test.go
+++ b/trigger/pubsub/util_test.go
@@ -48,8 +48,8 @@ func Test_isGoogleContainerRegistry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isGoogleContainerRegistry(tt.args.registry); got != tt.want {
-				t.Errorf("isGoogleContainerRegistry() = %v, want %v", got, tt.want)
+			if got := isGoogleArtifactRegistry(tt.args.registry); got != tt.want {
+				t.Errorf("isGoogleArtifactRegistry() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/trigger/pubsub/util_test.go
+++ b/trigger/pubsub/util_test.go
@@ -16,7 +16,7 @@ func unsafeImageRef(img string) *image.Reference {
 	return ref
 }
 
-func Test_isGoogleContainerRegistry(t *testing.T) {
+func Test_isGoogleArtifactRegistry(t *testing.T) {
 	type args struct {
 		registry string
 	}

--- a/trigger/pubsub/util_test.go
+++ b/trigger/pubsub/util_test.go
@@ -31,6 +31,11 @@ func Test_isGoogleContainerRegistry(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "google artifact registry",
+			args: args{registry: unsafeImageRef("europe-west3-docker.pkg.dev/v2-namespace/hello-world:1.1").Registry()},
+			want: true,
+		},
+		{
 			name: "docker registry",
 			args: args{registry: unsafeImageRef("docker.io/v2-namespace/hello-world:1.1").Registry()},
 			want: false,


### PR DESCRIPTION
Google recommends their [artifact registry](https://cloud.google.com/artifact-registry) instead of container registry. It uses the same pub/sub mechanism as the container registry so we only have to allow pkg.dev images to create pub/sub subscriptions.