### PR TITLE
chore: Account for deprecation

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.9.10
+version: 0.9.11
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.1
 keywords:

--- a/chart/keel/templates/pod-disruption-budget.yaml
+++ b/chart/keel/templates/pod-disruption-budget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "keel.fullname" . }}

--- a/deployment/deployment-template.yaml
+++ b/deployment/deployment-template.yaml
@@ -242,7 +242,7 @@ spec:
 ---
 # Source: keel/templates/pod-disruption-budget.yaml
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: keel


### PR DESCRIPTION
policy/v1beta1/PodDisruptionBudget has been deprecated in Kuberenetes v. 1.21. It will be removed in 1.25, which would break the current deployment/deployment-template.yaml and Helm chart if not updated by then.