### PR TITLE
Added gcp service account support

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel is stateless, robust and lightweight.
-version: 0.9.10
+version: 0.9.11
 # Note that we use appVersion to get images tag, so make sure this is correct.
 appVersion: 0.16.1
 keywords:

--- a/chart/keel/templates/service-account.yaml
+++ b/chart/keel/templates/service-account.yaml
@@ -7,6 +7,9 @@ metadata:
 {{- if (and .Values.ecr.enabled .Values.ecr.roleArn) }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.ecr.roleArn }}
+{{- else if (and .Values.gcr.enabled .Values.gcr.gcpServiceAccount) }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.gcr.gcpServiceAccount }}
 {{- end }}
   labels:
     app: {{ template "keel.name" . }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -40,6 +40,7 @@ helmProvider:
 gcr:
   enabled: false
   projectId: ""
+  gcpServiceAccount: ""
   clusterName: ""
   pubSub:
     enabled: false


### PR DESCRIPTION
Ability to specify a google service account and add it as an annotation for the kubernetes service account for the GKE workload identity.