### PR TITLE
DefaultUpdateTimeout is in `ns`, should be `s`

### DIFF
--- a/provider/helm3/implementer.go
+++ b/provider/helm3/implementer.go
@@ -21,7 +21,7 @@ import (
 
 // #595 - DefaultUpdateTimeout is in ns
 // Per https://pkg.go.dev/helm.sh/helm/v3/pkg/action#Upgrade
-const DefaultUpdateTimeout = 300000000000
+const DefaultUpdateTimeout = 5 * time.Minute
 
 // Implementer - generic helm implementer used to abstract actual implementation
 type Implementer interface {

--- a/provider/helm3/implementer.go
+++ b/provider/helm3/implementer.go
@@ -21,7 +21,6 @@ import (
 
 // #595 - DefaultUpdateTimeout is in ns
 // Per https://pkg.go.dev/helm.sh/helm/v3/pkg/action#Upgrade
-// Convert it to 300s (5m) and retrieve the ns duration
 const DefaultUpdateTimeout = 300000000000
 
 // Implementer - generic helm implementer used to abstract actual implementation

--- a/provider/helm3/implementer.go
+++ b/provider/helm3/implementer.go
@@ -3,6 +3,7 @@ package helm3
 import (
 	"os"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v3/pkg/chart"
 

--- a/provider/helm3/implementer.go
+++ b/provider/helm3/implementer.go
@@ -19,7 +19,10 @@ import (
 // * update to latest chart package
 // * udpate the paramateres for the function
 
-const DefaultUpdateTimeout = 300
+// #595 - DefaultUpdateTimeout is in ns
+// Per https://pkg.go.dev/helm.sh/helm/v3/pkg/action#Upgrade
+// Convert it to 300s (5m) and retrieve the ns duration
+const DefaultUpdateTimeout = 300000000000
 
 // Implementer - generic helm implementer used to abstract actual implementation
 type Implementer interface {


### PR DESCRIPTION
Per #595, the default timeout appears to be intended as `300s`, but the conversion to `time.Duration` reads it as `300ns`, causing helm3 chart updates to fail.