### PR TITLE
Fix github webhook payload detection logic

### DIFF
--- a/pkg/http/github_webhook_trigger.go
+++ b/pkg/http/github_webhook_trigger.go
@@ -120,9 +120,9 @@ func (s *TriggerServer) githubHandler(resp http.ResponseWriter, req *http.Reques
 			return
 		}
 
-		if payload.RegistryPackage.PackageType != "docker" {
+		if payload.RegistryPackage.PackageType != "CONTAINER" {
 			resp.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintf(resp, "registry package type was not docker")
+			fmt.Fprintf(resp, "registry package type was not CONTAINER")
 		}
 
 		if payload.Repository.FullName == "" { // github package name

--- a/pkg/http/github_webhook_trigger_test.go
+++ b/pkg/http/github_webhook_trigger_test.go
@@ -13,7 +13,7 @@ var fakeGithubPackageWebhook = `{
   "registry_package": {
     "id": 35087,
     "name": "server",
-    "package_type": "docker",
+    "package_type": "CONTAINER",
     "html_url": "https://github.com/DingGGu/UtaiteBOX/packages/35087",
     "created_at": "2019-10-11T18:18:58Z",
     "updated_at": "2019-10-11T18:18:58Z",


### PR DESCRIPTION
The correct value for "package_type" seems to be `"CONTAINER"` instead of `"docker"`

I'm not sure how the original author came up with the value "docker", perhaps that was deprecated/obsoleted by GitHub sometime ago? The documentation at https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#registry_package doesn't mention anything about potential values.

This was a quick-fix to make GitHub webhook works again but I think if there's time, we should change the detection code to be a bit more robust w/r to GitHub changes (i.e. checks on a well-documented key instead)