### PR TITLE
Update Go to 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1
+FROM golang:1.20.5
 COPY . /go/src/github.com/keel-hq/keel
 WORKDIR /go/src/github.com/keel-hq/keel
 RUN make install


### PR DESCRIPTION
We are seeing a handful of vulnerabilities flagged by scanners in Go 1.20 prior to 1.20.5:

- https://nvd.nist.gov/vuln/detail/CVE-2023-29402
- https://nvd.nist.gov/vuln/detail/CVE-2023-29404
- https://nvd.nist.gov/vuln/detail/CVE-2023-29405