### PR TITLE
feat: allow poll trigger to work with glob and regexp

### DIFF
--- a/internal/policy/force.go
+++ b/internal/policy/force.go
@@ -17,6 +17,10 @@ func (fp *ForcePolicy) ShouldUpdate(current, new string) (bool, error) {
 	return true, nil
 }
 
+func (fp *ForcePolicy) Filter(tags []string) []string {
+	return append([]string{}, tags...)
+}
+
 func (fp *ForcePolicy) Name() string {
 	return "force"
 }

--- a/internal/policy/glob.go
+++ b/internal/policy/glob.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ryanuber/go-glob"
@@ -28,6 +29,23 @@ func NewGlobPolicy(policy string) (*GlobPolicy, error) {
 
 func (p *GlobPolicy) ShouldUpdate(current, new string) (bool, error) {
 	return glob.Glob(p.pattern, new), nil
+}
+
+func (p *GlobPolicy) Filter(tags []string) []string {
+	filtered := []string{}
+
+	for _, tag := range tags {
+		if glob.Glob(p.pattern, tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+
+	// sort desc alphabetically
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i] > filtered[j]
+	})
+
+	return filtered
 }
 
 func (p *GlobPolicy) Name() string     { return p.policy }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -22,6 +22,7 @@ type Policy interface {
 	ShouldUpdate(current, new string) (bool, error)
 	Name() string
 	Type() PolicyType
+	Filter(tags []string) []string
 }
 
 type NilPolicy struct{}
@@ -29,6 +30,7 @@ type NilPolicy struct{}
 func (np *NilPolicy) ShouldUpdate(c, n string) (bool, error) { return false, nil }
 func (np *NilPolicy) Name() string                           { return "nil policy" }
 func (np *NilPolicy) Type() PolicyType                       { return PolicyTypeNone }
+func (np *NilPolicy) Filter(tags []string) []string          { return append([]string{}, tags...) }
 
 // GetPolicyFromLabelsOrAnnotations - gets policy from k8s labels or annotations
 func GetPolicyFromLabelsOrAnnotations(labels map[string]string, annotations map[string]string) Policy {

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -2,12 +2,10 @@ package poll
 
 import (
 	"errors"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/Masterminds/semver"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/keel-hq/keel/approvals"
@@ -185,27 +183,39 @@ func TestWatchAllTagsMixed(t *testing.T) {
 	testRunHelper(testCases, availableTags, t)
 }
 
+func TestWatchGlobTagsMixed(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "build-1694132169", "build-1696801785", "build-1695801785"}
+	policy, _ := policy.NewGlobPolicy("glob:build-*")
+	testCases := []runTestCase{
+		{"1.0.0", "build-1696801785", policy},
+	}
+	testRunHelper(testCases, availableTags, t)
+}
+
+func TestWatchRegexpTagsCompareMixed(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "build-2a3560ef-1694132169", "build-1a3560ef-1696801785", "build-3a3560ef-1695801785"}
+	policy, _ := policy.NewRegexpPolicy("regexp:^build-.*-(?P<compare>.+)$")
+	testCases := []runTestCase{
+		{"1.0.0", "build-1a3560ef-1696801785", policy},
+	}
+	testRunHelper(testCases, availableTags, t)
+}
+
+func TestWatchRegexpTagsMixed(t *testing.T) {
+	availableTags := []string{"1.3.0-dev", "build-2a3560ef-1694132169", "build-1a3560ef-1696801785", "build-3a3560ef-1695801785"}
+	policy, _ := policy.NewRegexpPolicy("regexp:^build-.*$")
+	testCases := []runTestCase{
+		{"1.0.0", "build-3a3560ef-1695801785", policy},
+	}
+	testRunHelper(testCases, availableTags, t)
+}
+
 func TestWatchAllTagsMixedPolicyAll(t *testing.T) {
 	availableTags := []string{"1.3.0-dev", "1.5.0", "1.8.0-alpha"}
 	testCases := []runTestCase{
 		{"1.0.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)},
 		{"1.6.0-alpha", "1.8.0-alpha", policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true)}}
 	testRunHelper(testCases, availableTags, t)
-}
-
-func Test_semverSort(t *testing.T) {
-	tags := []string{"1.3.0", "aa1.0.0", "zzz", "1.3.0-dev", "1.5.0", "2.0.0-alpha", "1.3.0-dev1", "1.8.0-alpha", "1.3.1-dev", "123", "1.2.3-rc.1.2+meta"}
-	expectedTags := []string{"2.0.0-alpha", "1.8.0-alpha", "1.5.0", "1.3.1-dev", "1.3.0", "1.3.0-dev1", "1.3.0-dev", "1.2.3-rc.1.2+meta"}
-	expectedVersions := make([]*semver.Version, len(expectedTags))
-	for i, tag := range expectedTags {
-		v, _ := semver.NewVersion(tag)
-		expectedVersions[i] = v
-	}
-	sortedTags := semverSort(tags)
-
-	if !reflect.DeepEqual(sortedTags, expectedVersions) {
-		t.Errorf("Invalid sorted tags; expected: %s; got: %s", expectedVersions, sortedTags)
-	}
 }
 
 type testingCredsHelper struct {

--- a/types/tracked_images.go
+++ b/types/tracked_images.go
@@ -30,6 +30,7 @@ type TrackedImage struct {
 type Policy interface {
 	ShouldUpdate(current, new string) (bool, error)
 	Name() string
+	Filter(tags []string) []string
 }
 
 func (i TrackedImage) String() string {


### PR DESCRIPTION
This change allows the poll trigger to work with glob and regexp.

Regexp optionally has the option to specify which part of the pattern to be used as a comparison.

closes https://github.com/keel-hq/keel/issues/600