### PR TITLE
Ntfy notification support

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
 {{- end }}
 {{- if .Values.ntfy.enabled }}
             # Enable webhook endpoint
-            - name: WEBHOOK_ENDPOINT
+            - name: NTFY_WEBHOOK_URL
               value: "{{ .Values.ntfy.webhookUrl }}"
 {{- end }}
 {{- if .Values.mattermost.enabled }}

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -113,6 +113,11 @@ spec:
             - name: WEBHOOK_ENDPOINT
               value: "{{ .Values.webhook.endpoint }}"
 {{- end }}
+{{- if .Values.ntfy.enabled }}
+            # Enable webhook endpoint
+            - name: WEBHOOK_ENDPOINT
+              value: "{{ .Values.ntfy.webhookUrl }}"
+{{- end }}
 {{- if .Values.mattermost.enabled }}
             # Enable mattermost endpoint
             - name: MATTERMOST_ENDPOINT

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -98,6 +98,11 @@ discord:
   enabled: false
   webhookUrl: ""
 
+# ntfy notifications
+ntfy:
+  enabled: false
+  webhookUrl: ""
+
 # Mail notifications
 mail:
   enabled: false

--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/keel-hq/keel/extension/notification/hipchat"
 	_ "github.com/keel-hq/keel/extension/notification/mail"
 	_ "github.com/keel-hq/keel/extension/notification/mattermost"
+	_ "github.com/keel-hq/keel/extension/notification/ntfy"
 	_ "github.com/keel-hq/keel/extension/notification/slack"
 	_ "github.com/keel-hq/keel/extension/notification/teams"
 	_ "github.com/keel-hq/keel/extension/notification/webhook"

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -37,7 +37,7 @@ const (
 	// Discord webhook url, see https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 	EnvDiscordWebhookUrl = "DISCORD_WEBHOOK_URL"
 
-	// Discord webhook url, see https://docs.ntfy.sh/publish/
+	// ntfy webhook url, see https://docs.ntfy.sh/publish/
 	EnvNtfyWebhookUrl = "NTFY_WEBHOOK_URL"
 
 	// Mail notification settings

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -37,6 +37,9 @@ const (
 	// Discord webhook url, see https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 	EnvDiscordWebhookUrl = "DISCORD_WEBHOOK_URL"
 
+	// Discord webhook url, see https://docs.ntfy.sh/publish/
+	EnvNtfyWebhookUrl = "NTFY_WEBHOOK_URL"
+
 	// Mail notification settings
 	EnvMailTo         = "MAIL_TO"
 	EnvMailFrom       = "MAIL_FROM"

--- a/deployment/deployment-template.yaml
+++ b/deployment/deployment-template.yaml
@@ -185,6 +185,9 @@ spec:
             # Enable MS Teams webhook endpoint
             - name: TEAMS_WEBHOOK_URL
               value: "{{ .teams_webhook_url }}"
+            # Enable ntfy webhook endpoint 
+            - name: NTFY_WEBHOOK_URL
+              value: "{{ .ntfy_webhook_url }}"
             - name: SLACK_TOKEN
               value: "{{ .slack_token }}"
             - name: SLACK_CHANNELS

--- a/extension/notification/ntfy/ntfy.go
+++ b/extension/notification/ntfy/ntfy.go
@@ -1,0 +1,82 @@
+package discord
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/keel-hq/keel/constants"
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/types"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const timeout = 5 * time.Second
+
+type sender struct {
+	endpoint string
+	client   *http.Client
+}
+
+// Config represents the configuration of a Discord Webhook Sender.
+type Config struct {
+	Endpoint string
+}
+
+func init() {
+	notification.RegisterSender("ntfy", &sender{})
+}
+
+func (s *sender) Configure(config *notification.Config) (bool, error) {
+	// Get configuration
+	var httpConfig Config
+
+	if os.Getenv(constants.EnvNtfyWebhookUrl) != "" {
+		httpConfig.Endpoint = os.Getenv(constants.EnvNtfyWebhookUrl)
+	} else {
+		return false, nil
+	}
+	// Validate endpoint URL.
+	if httpConfig.Endpoint == "" {
+		return false, nil
+	}
+	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
+		return false, fmt.Errorf("could not parse endpoint URL: %s", err)
+	}
+	s.endpoint = httpConfig.Endpoint
+
+	// Setup HTTP client
+	s.client = &http.Client{
+		Transport: http.DefaultTransport,
+		Timeout:   timeout,
+	}
+
+	log.WithFields(log.Fields{
+		"name":     "ntfy",
+		"endpoint": s.endpoint,
+	}).Info("extension.notification.ntfy: sender configured")
+	return true, nil
+}
+
+func (s *sender) Send(event types.EventNotification) error {
+
+	req, _ := http.NewRequest("POST", s.endpoint, strings.NewReader(event.Message))
+	req.Header.Set("Title", fmt.Sprintf("%s: %s", event.Type.String(), event.Name))
+	req.Header.Set("Tags", "keel")
+	http.DefaultClient.Do(req)
+
+	resp, err := s.client.Do(req)
+	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 204) {
+		if resp != nil {
+			return fmt.Errorf("got status %d, expected 200/204", resp.StatusCode)
+		}
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/extension/notification/ntfy/ntfy.go
+++ b/extension/notification/ntfy/ntfy.go
@@ -64,10 +64,10 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 
 func (s *sender) Send(event types.EventNotification) error {
 
-	req, _ := http.NewRequest("POST", s.endpoint, strings.NewReader(event.Message))
-	req.Header.Set("Title", fmt.Sprintf("%s: %s", event.Type.String(), event.Name))
+	req, _ := http.NewRequest("POST", s.endpoint, strings.NewReader(fmt.Sprintf("%s: %s", event.Type.String(), event.Name)))
+	req.Header.Set("Title", event.Message)
 	req.Header.Set("Tags", "keel")
-	http.DefaultClient.Do(req)
+	req.Header.Set("X-Icon", constants.KeelLogoURL)
 
 	resp, err := s.client.Do(req)
 	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 204) {

--- a/extension/notification/ntfy/ntfy_test.go
+++ b/extension/notification/ntfy/ntfy_test.go
@@ -1,0 +1,59 @@
+package discord
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keel-hq/keel/types"
+)
+
+func TestNtfyWebhookRequest(t *testing.T) {
+	currentTime := time.Now()
+	handler := func(resp http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to parse body: %s", err)
+		}
+
+		bodyStr := string(body)
+
+		if !strings.Contains(req.Header.Get("Title"), types.NotificationPreDeploymentUpdate.String()) {
+			t.Errorf("missing deployment type")
+		}
+
+		if !strings.Contains(req.Header.Get("Title"), "update deployment") {
+			t.Errorf("missing deployment type")
+		}
+
+		if !strings.Contains(req.Header.Get("Tags"), "keel") {
+			t.Errorf("missing deployment type")
+		}
+
+		if !strings.Contains(bodyStr, "message here") {
+			t.Errorf("missing message")
+		}
+
+		t.Log(bodyStr)
+	}
+
+	// create test server with handler
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	s := &sender{
+		endpoint: ts.URL,
+		client:   &http.Client{},
+	}
+
+	s.Send(types.EventNotification{
+		Name:      "update deployment",
+		Message:   "message here",
+		CreatedAt: currentTime,
+		Type:      types.NotificationPreDeploymentUpdate,
+		Level:     types.LevelDebug,
+	})
+}


### PR DESCRIPTION
This changes adds support for native NTFY notifications.

Here is a screenshot of the notification in NTFY:
![image](https://github.com/keel-hq/keel/assets/36499798/fcacf1de-2ab0-4955-ae54-697bc26aacc2)

The upper notification was triggered via this new implementation. The below one is triggered by the already existing webhook notification.

This change also makes the necessary additions to the helm chart values and template.

Unit tests are created and fine.
Disclaimer: i did not get the e2e Tests to work, however i am pretty sure that this is due to an issue with my setup. I am on a windows machine and in windows it did not work, in WSL it did run, but i think due to the ARM hosts in my homelab cluster it did never finish.

closes #746 