### PR TITLE
Improve notifications for the same docker label

### DIFF
--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -314,10 +314,10 @@ func TestGetImpactedInit(t *testing.T) {
 		{
 			meta_v1.TypeMeta{},
 			meta_v1.ObjectMeta{
-				Name:      "dep-1",
-				Namespace: "xxxx",
+				Name:        "dep-1",
+				Namespace:   "xxxx",
 				Annotations: map[string]string{types.KeelInitContainerAnnotation: "true"},
-				Labels:    map[string]string{types.KeelPolicyLabel: "all"},
+				Labels:      map[string]string{types.KeelPolicyLabel: "all"},
 			},
 			apps_v1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{
@@ -335,10 +335,10 @@ func TestGetImpactedInit(t *testing.T) {
 		{
 			meta_v1.TypeMeta{},
 			meta_v1.ObjectMeta{
-				Name:      "dep-2",
-				Namespace: "xxxx",
+				Name:        "dep-2",
+				Namespace:   "xxxx",
 				Annotations: map[string]string{types.KeelInitContainerAnnotation: "false"},
-				Labels:    map[string]string{"whatever": "all"},
+				Labels:      map[string]string{"whatever": "all"},
 			},
 			apps_v1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{

--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -86,6 +86,8 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 
 			updatePlan.CurrentVersion = containerImageRef.Tag()
 			updatePlan.NewVersion = repo.Tag
+			updatePlan.CurrentVersionFull = fmt.Sprintf("%s:%s", containerImageRef.Tag(), repo.Digest)
+			updatePlan.NewVersionFull = fmt.Sprintf("%s:%s", repo.Tag, repo.NewDigest)
 			updatePlan.Resource = resource
 		}
 	}
@@ -147,6 +149,8 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 
 		updatePlan.CurrentVersion = containerImageRef.Tag()
 		updatePlan.NewVersion = repo.Tag
+		updatePlan.CurrentVersionFull = fmt.Sprintf("%s:%s", containerImageRef.Tag(), repo.Digest)
+		updatePlan.NewVersionFull = fmt.Sprintf("%s:%s", repo.Tag, repo.NewDigest)
 		updatePlan.Resource = resource
 	}
 

--- a/trigger/poll/single_tag_watcher.go
+++ b/trigger/poll/single_tag_watcher.go
@@ -67,9 +67,10 @@ func (j *WatchTagJob) Run() {
 
 		event := types.Event{
 			Repository: types.Repository{
-				Name:   j.details.trackedImage.Image.Repository(),
-				Tag:    j.details.trackedImage.Image.Tag(),
-				Digest: currentDigest,
+				Name:      j.details.trackedImage.Image.Repository(),
+				Tag:       j.details.trackedImage.Image.Tag(),
+				Digest:    currentDigest,
+				NewDigest: j.details.digest,
 			},
 			TriggerName: types.TriggerTypePoll.String(),
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -77,10 +77,11 @@ func init() {
 // Repository - represents main docker repository fields that
 // keel cares about
 type Repository struct {
-	Host   string `json:"host"`
-	Name   string `json:"name"`
-	Tag    string `json:"tag"`
-	Digest string `json:"digest"` // optional digest field
+	Host      string `json:"host"`
+	Name      string `json:"name"`
+	Tag       string `json:"tag"`
+	Digest    string `json:"digest"`     // optional digest field
+	NewDigest string `json:"new_digest"` // optional field for new digest
 }
 
 // String gives you [host/]team/repo[:tag] identifier


### PR DESCRIPTION
Sometimes it happens that a docker label is overwritten and thus the digest changes, but the label stays the same. The notification will then say the change is for example `latest -> latest`

This commit introduces an alternative format - if the label is the same, it will now use a label with a digest