### PR TITLE
Refactor GCR Credentials Handling to Support Workload Identity authentification

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -86,8 +86,10 @@ spec:
             # Enable GCR with pub/sub support
             - name: PROJECT_ID
               value: "{{ .Values.gcr.projectId }}"
+  {{- if .Values.gcr.pubSub.enabled }}
             - name: PUBSUB
               value: "true"
+  {{- end }}
   {{- if .Values.gcr.clusterName }}
             # Customize the cluster name, mainly useful when outside of GKE
             - name: CLUSTER_NAME

--- a/extension/credentialshelper/gcr/gcr.go
+++ b/extension/credentialshelper/gcr/gcr.go
@@ -1,56 +1,83 @@
 package gcr
 
 import (
-	"errors"
-	"io/ioutil"
-	"os"
+    "context"
+    "errors"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "strings"
 
-	"github.com/keel-hq/keel/extension/credentialshelper"
-	"github.com/keel-hq/keel/types"
+    "cloud.google.com/go/storage"
+    "github.com/keel-hq/keel/extension/credentialshelper"
+    "github.com/keel-hq/keel/types"
+    "golang.org/x/oauth2/google"
 )
 
 func init() {
-	credentialshelper.RegisterCredentialsHelper("gcr", New())
+    credentialshelper.RegisterCredentialsHelper("gcr", New())
 }
 
 type CredentialsHelper struct {
-	enabled     bool
-	credentials string
+    enabled bool
 }
 
 func New() *CredentialsHelper {
-	ch := &CredentialsHelper{}
-
-	credentialsFile, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
-	if !ok {
-		return ch
-	}
-
-	credentials, err := ioutil.ReadFile(credentialsFile)
-	if err != nil {
-		return ch
-	}
-
-	ch.enabled = true
-	ch.credentials = string(credentials)
-	return ch
+    return &CredentialsHelper{
+        enabled: true,
+    }
 }
 
 func (h *CredentialsHelper) IsEnabled() bool {
-	return h.enabled
+    return h.enabled
 }
 
 func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
-	if !h.enabled {
-		return nil, errors.New("not initialised")
-	}
+    if !h.enabled {
+        return nil, errors.New("not initialised")
+    }
 
-	if image.Image.Registry() != "gcr.io" {
-		return nil, credentialshelper.ErrUnsupportedRegistry
-	}
+    if !strings.HasPrefix(image.Image.Registry(), "gcr.io") && !strings.Contains(image.Image.Registry(), "pkg.dev") {
+        return nil, credentialshelper.ErrUnsupportedRegistry
+    }
 
-	return &types.Credentials{
-		Username: "_json_key",
-		Password: h.credentials,
-	}, nil
+    if credentials, err := readCredentialsFromFile(); err == nil {
+        return credentials, nil
+    }
+
+    return getWorkloadIdentityTokenCredentials()
+}
+
+func readCredentialsFromFile() (*types.Credentials, error) {
+    credentialsFile, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
+    if !ok {
+        return nil, errors.New("GOOGLE_APPLICATION_CREDENTIALS environment variable not set")
+    }
+
+    credentials, err := ioutil.ReadFile(credentialsFile)
+    if err != nil {
+        return nil, fmt.Errorf("failed to read credentials file: %w", err)
+    }
+
+    return &types.Credentials{
+        Username: "_json_key",
+        Password: string(credentials),
+    }, nil
+}
+
+func getWorkloadIdentityTokenCredentials() (*types.Credentials, error) {
+    ctx := context.Background()
+    tokenSource, err := google.DefaultTokenSource(ctx, storage.ScopeReadOnly)
+    if err != nil {
+        return nil, fmt.Errorf("failed to get default token source: %w", err)
+    }
+    token, err := tokenSource.Token()
+    if err != nil {
+        return nil, fmt.Errorf("failed to get token: %w", err)
+    }
+
+    return &types.Credentials{
+        Username: "_token",
+        Password: token.AccessToken,
+    }, nil
 }


### PR DESCRIPTION
This commit updates the GCR (Google Container Registry) credentials handling in Keel's GCR extension to add support for Google Cloud's Workload Identity, while maintaining compatibility with the existing authentication method via the GOOGLE_APPLICATION_CREDENTIALS environment variable.

Changes include:
- Removed the `credentials` string field from the CredentialsHelper struct. Credentials are now determined dynamically based on the runtime environment.
- Added `readCredentialsFromFile()` and `getWorkloadIdentityTokenCredentials()` functions to abstract the credential reading and token obtaining processes.
- Updated `GetCredentials` method to try reading the GOOGLE_APPLICATION_CREDENTIALS file first, falling back to Workload Identity if necessary.
- Extended registry URL check in `GetCredentials` to support Google Container Registry (`gcr.io`) and Google Artifact Registry URLs (`pkg.dev`).
- Adding pubSub boolean check for activating pubSub.

These changes allow for the use of both JSON key files and Workload Identity for GCP authentication when polling (instead of using pubSub).