### PR TITLE
Update the deployment templates to comply with the slack bot changes

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -96,7 +96,8 @@ The following table lists has the main configurable parameters (polling, trigger
 | `webhook.endpoint`                          | Remote webhook endpoint                |                                                           |
 | `slack.enabled`                             | Enable/disable Slack Notification      | `false`                                                   |
 | `slack.botName`                             | Name of the Slack bot                  |                                                           |
-| `slack.token`                               | Slack token                            |                                                           |
+| `slack.botToken`                            | Slack bot token                        |                                                           |
+| `slack.appToken`                            | Slack application level token          |                                                           |
 | `slack.channel`                             | Slack channel                          |                                                           |
 | `slack.approvalsChannel`                    | Slack channel for approvals            |                                                           |
 | `teams.enabled`                             | Enable/disable MS Teams Notification   | `false`                                                   |

--- a/chart/keel/templates/secret.yaml
+++ b/chart/keel/templates/secret.yaml
@@ -15,7 +15,8 @@ data:
   AWS_SECRET_ACCESS_KEY:  {{ .Values.ecr.secretAccessKey | b64enc }}
 {{- end }}
 {{- if .Values.slack.enabled }}
-  SLACK_TOKEN: {{ .Values.slack.token | b64enc }}
+  SLACK_BOT_TOKEN: {{ .Values.slack.botToken | b64enc }}
+  SLACK_APP_TOKEN: {{ .Values.slack.appToken | b64enc }}
 {{- end }}
 {{- if .Values.googleApplicationCredentials }}
   google-application-credentials.json: {{ .Values.googleApplicationCredentials }}

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -69,7 +69,8 @@ webhook:
 slack:
   enabled: false
   botName: ""
-  token: ""
+  appToken: ""
+  botToken: ""
   channel: ""
   approvalsChannel: ""
 

--- a/deployment/deployment-template.yaml
+++ b/deployment/deployment-template.yaml
@@ -185,8 +185,10 @@ spec:
             # Enable MS Teams webhook endpoint
             - name: TEAMS_WEBHOOK_URL
               value: "{{ .teams_webhook_url }}"
-            - name: SLACK_TOKEN
-              value: "{{ .slack_token }}"
+            - name: SLACK_APP_TOKEN
+              value: "{{ .slack_app_token }}"
+            - name: SLACK_BOT_TOKEN
+              value: "{{ .slack_bot_token }}"
             - name: SLACK_CHANNELS
               value: "{{ .slack_channel | default "general" }}"
             - name: SLACK_APPROVALS_CHANNEL


### PR DESCRIPTION
The latest slack bot changes introduce two environment variables (bot token and app token). Take that changes into account for deployment
 manifests.

I will also fix the documentation PR: https://github.com/keel-hq/keel.sh/pull/53