### PR TITLE
Change README to reflect real default value of persistence.enabled

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -144,7 +144,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `dockerRegistry.key`                        | Docker registry secret key             |                                                           |
 | `secret.name`                               | Secret name                            |                                                           |
 | `secret.create`                             | Create secret                          | `true`                                                    |
-| `persistence.enabled`                       | Enable/disable audit log persistence   | `true`                                                    |
+| `persistence.enabled`                       | Enable/disable audit log persistence   | `false`                                                    |
 | `persistence.storageClass`                  | Storage Class for the Persistent Volume| `-`                                                       |
 | `persistence.size`                          | Persistent Volume size                 | `1Gi`                                                     |
 | `imagePullSecrets`                          | Image pull secrets                     | `[]`                                                      |


### PR DESCRIPTION
The value set by the default values of the chart (https://github.com/keel-hq/keel/blob/master/chart/keel/values.yaml#L250) for enabling persistence is false.

However, the README specifies it as true. This is misleading and leads to data loss due to pod restarts.

This PR fixes the README to show the real default value.