### PR TITLE
Use non-root user for keel container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23.4
+FROM golang:1.23.4 as go-build
 COPY . /go/src/github.com/keel-hq/keel
 WORKDIR /go/src/github.com/keel-hq/keel
 RUN make install
 
-FROM node:16.20.2-alpine
+FROM node:16.20.2-alpine as yarn-build
 WORKDIR /app
 COPY ui /app
 RUN yarn
@@ -11,12 +11,22 @@ RUN yarn run lint --no-fix
 RUN yarn run build
 
 FROM alpine:3.20.3
+ARG USERNAME=keel
+ARG USER_ID=666
+ARG GROUP_ID=$USER_ID
+
 RUN apk --no-cache add ca-certificates
+RUN addgroup --gid $GROUP_ID $USERNAME \
+    && adduser --home /data --ingroup $USERNAME --disabled-password --uid $USER_ID $USERNAME \
+    && mkdir -p /data && chown $USERNAME:0 /data && chmod g=u /data
+
+COPY --from=go-build /go/bin/keel /bin/keel
+COPY --from=yarn-build /app/dist /www
+
+USER $USER_ID
 
 VOLUME /data
 ENV XDG_DATA_HOME /data
 
-COPY --from=0 /go/bin/keel /bin/keel
-COPY --from=1 /app/dist /www
 ENTRYPOINT ["/bin/keel"]
 EXPOSE 9300

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,11 +4,21 @@ WORKDIR /go/src/github.com/keel-hq/keel
 RUN make build
 
 FROM debian:latest
+ARG USERNAME=keel
+ARG USER_ID=666
+ARG GROUP_ID=$USER_ID
+
 RUN apt-get update && apt-get install -y \
   ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
+RUN addgroup --gid $GROUP_ID $USERNAME \
+    && adduser --home /data --ingroup $USERNAME --disabled-password --uid $USER_ID $USERNAME \
+    && mkdir -p /data && chown $USERNAME:0 /data && chmod g=u /data
+
 COPY --from=0 /go/src/github.com/keel-hq/keel/cmd/keel/keel /bin/keel
+
+USER $USER_ID
 ENTRYPOINT ["/bin/keel"]
 
 EXPOSE 9300


### PR DESCRIPTION
This commit drops unnesessary broad permissions for the keel container.

Fixes #679