### PR TITLE
Decrease initialDelaySeconds of (liveness|readiness)Probe

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -190,13 +190,13 @@ spec:
             httpGet:
               path: /healthz
               port: 9300
-            initialDelaySeconds: 30
+            initialDelaySeconds: 5
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: 9300
-            initialDelaySeconds: 30
+            initialDelaySeconds: 5
             timeoutSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
keel doesn't need 30s to start. Decreasing initialDelaySeconds ensure the container is faster in 'Ready' state.