### PR TITLE
[Feature] New updateScheduleCronTabs annotation

### DIFF
--- a/.run/go build github.com_keel-hq_keel_cmd_keel.run.xml
+++ b/.run/go build github.com_keel-hq_keel_cmd_keel.run.xml
@@ -1,0 +1,18 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="go build github.com/keel-hq/keel/cmd/keel" type="GoApplicationRunConfiguration" factoryName="Go Application" nameIsGenerated="true">
+    <module name="keel" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="--no-incluster" />
+    <envs>
+      <env name="HOME" value="C:\Users\DavidGarcíaGarcía" />
+      <env name="KUBERNETES_CONTEXT" value="aks-dev" />
+      <env name="NOTIFICATION_LEVEL" value="DEBUG" />
+      <env name="XDG_DATA_HOME" value="C:\Users\DavidGarcíaGarcía\AppData\Roaming" />
+    </envs>
+    <kind value="DIRECTORY" />
+    <package value="github.com/keel-hq/keel" />
+    <directory value="$PROJECT_DIR$/cmd/keel" />
+    <filePath value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -1,0 +1,175 @@
+package schedule
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keel-hq/keel/types"
+	"github.com/rusenask/cron"
+)
+
+// UpdateSchedule represents the update schedule configuration
+type UpdateSchedule struct {
+	CronTabs []string
+	Duration string
+	CoolDown string
+}
+
+// ParseUpdateSchedule parses the update schedule from annotations
+func ParseUpdateSchedule(annotations map[string]string) (*UpdateSchedule, error) {
+	if annotations == nil {
+		return nil, nil
+	}
+
+	schedule := &UpdateSchedule{
+		CronTabs: strings.Split(annotations[types.KeelUpdateScheduleCronTabs], ","),
+		Duration: annotations[types.KeelUpdateScheduleDurationMinutes],
+		CoolDown: annotations[types.KeelUpdateScheduleCoolDownMinutes],
+	}
+
+	// If no schedule is configured, return nil
+	if len(schedule.CronTabs) == 0 || schedule.CronTabs[0] == "" {
+		return nil, nil
+	}
+
+	// Validate cron schedules
+	for _, cronStr := range schedule.CronTabs {
+		cronStr = strings.TrimSpace(cronStr)
+		if cronStr == "" {
+			continue
+		}
+		_, err := cron.Parse(cronStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cron schedule '%s': %v", cronStr, err)
+		}
+	}
+
+	// Validate duration if provided
+	if schedule.Duration != "" {
+		_, err := time.ParseDuration(schedule.Duration)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration: %v", err)
+		}
+	}
+
+	// Validate cooldown if provided
+	if schedule.CoolDown != "" {
+		_, err := time.ParseDuration(schedule.CoolDown)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cooldown: %v", err)
+		}
+	}
+
+	return schedule, nil
+}
+
+// findPrevScheduledTime finds the most recent time before now that matches the schedule
+// I like 0 this convergent algorithm, but I'd rather use this and rely on a robust and maintained Next()
+// than write my own Prev(). Plus performance is not that bad, it does converge fast enough.
+func findPrevScheduledTime(schedule cron.Schedule, now time.Time) (time.Time, error) {
+	if schedule == nil {
+		return time.Time{}, nil
+	}
+
+	maxLookback := 7 * 24 * time.Hour
+
+	startPoint := now.Add(-time.Second)
+
+	minimum := now.Add(-maxLookback)
+	maximum := now
+
+	// Calculate the midpoint between now and minimum
+	current := startPoint
+
+	var lastFound time.Time
+
+	shortCircuit := 30
+	loopCount := 0
+
+	for {
+		loopCount++
+
+		if loopCount > shortCircuit {
+			return time.Time{}, fmt.Errorf("schedule prev() algorithm did not converge soon enough (or at all)")
+		}
+
+		next := schedule.Next(current)
+
+		if next == now {
+			return next, nil
+		}
+
+		if maximum.Sub(minimum) < 1*time.Minute {
+			return lastFound, nil
+		}
+
+		if next.Before(now) {
+			lastFound = next
+			newCurrent := minimum.Add(maximum.Sub(minimum) / 2)
+			minimum = current
+			current = newCurrent
+			continue
+		}
+
+		if next.After(now) {
+			maximum = current
+			newCurrent := current.Add(-current.Sub(minimum) / 2)
+			current = newCurrent
+			continue
+		}
+	}
+}
+
+// IsUpdateAllowed checks if an update is allowed based on the schedule and last update time
+func (s *UpdateSchedule) IsUpdateAllowed(lastUpdateTime time.Time) (bool, error) {
+	if s == nil {
+		return true, nil
+	}
+
+	// Check cooldown period
+	if s.CoolDown != "" {
+		cooldown, _ := time.ParseDuration(s.CoolDown)
+		if time.Since(lastUpdateTime) < cooldown {
+			return false, nil
+		}
+	}
+
+	// Check each cron schedule
+	now := time.Now()
+
+	for _, cronStr := range s.CronTabs {
+		cronStr = strings.TrimSpace(cronStr)
+		if cronStr == "" {
+			continue
+		}
+
+		// Parse cron schedule
+		schedule, err := cron.Parse(cronStr)
+		if err != nil {
+			return false, fmt.Errorf("invalid cron schedule '%s': %v", cronStr, err)
+		}
+
+		// Get previous run time
+		prevRun, _ := findPrevScheduledTime(schedule, now)
+		if prevRun.IsZero() {
+			continue
+		}
+
+		// Check if we're within the update window
+		if s.Duration != "" {
+			duration, _ := time.ParseDuration(s.Duration)
+			windowEnd := prevRun.Add(duration)
+			if now.After(prevRun) && now.Before(windowEnd) {
+				return true, nil
+			}
+		} else {
+			// If no duration specified, only allow updates at the exact cron time
+			if now.Equal(prevRun) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -1,0 +1,210 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rusenask/cron"
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParseTime(layout, value string) time.Time {
+	t, _ := time.Parse(layout, value)
+	return t
+}
+
+func TestFindPrevScheduledTime(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		cronSchedule string
+		now          time.Time
+		expected     string // Expected previous time in RFC3339 format
+	}{
+		{
+			name:         "hourly schedule",
+			cronSchedule: "0 0 * * * *", // Every hour at minute 0
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T14:00:00Z", // Same day at 14:00
+		},
+		{
+			name:         "every 15 minutes",
+			cronSchedule: "0 */15 * * * *", // Every 15 minutes
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:25Z"),
+			expected:     "2023-05-15T14:30:00Z", // Same day at 14:15
+		},
+		{
+			name:         "every 15 minutes II",
+			cronSchedule: "0 */15 * * * *", // Every 15 minutes
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:29:00Z"),
+			expected:     "2023-05-15T14:15:00Z", // Same day at 14:15
+		},
+		{
+			name:         "daily schedule",
+			cronSchedule: "0 0 0 * * *", // Midnight every day
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T00:00:00Z", // Same day at midnight
+		},
+		{
+			name:         "weekly schedule",
+			cronSchedule: "0 0 0 * * 0", // Midnight every Sunday
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-14T00:00:00Z", // Previous Sunday
+		},
+		{
+			name:         "monthly schedule",
+			cronSchedule: "0 0 0 1 * *", // 1st day of month
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "", // 1st of May
+		},
+		{
+			name:         "specific weekday",
+			cronSchedule: "0 0 12 * * 1", // Monday at noon
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T12:00:00Z", // Same Monday at noon (this is in the future from now)
+		},
+		{
+			name:         "specific time of day",
+			cronSchedule: "0 30 9 * * *", // 9:30 every day
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T09:30:00Z", // Same day at 9:30
+		},
+		{
+			name:         "schedule with seconds",
+			cronSchedule: "0 15 */10 * * *", // 15 seconds past every 10 minutes
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T10:15:00Z",
+		},
+		{
+			name:         "no previous occurrences",
+			cronSchedule: "0 0 0 31 2 *", // February 31st (impossible date)
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "", // Should return zero time
+		},
+		{
+			name:         "exactly at scheduled time",
+			cronSchedule: "0 30 14 15 5 *", // 14:30 on May 15
+			now:          mustParseTime(time.RFC3339, "2023-05-15T14:30:00Z"),
+			expected:     "2023-05-15T14:30:00Z", // Exactly now
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule, err := cron.Parse(tt.cronSchedule)
+			if err != nil && tt.expected != "" {
+				t.Fatalf("Failed to parse cron schedule: %v", err)
+			}
+
+			var expectedTime time.Time
+			if tt.expected != "" {
+				expectedTime, _ = time.Parse(time.RFC3339, tt.expected)
+			}
+
+			result, _ := findPrevScheduledTime(schedule, tt.now)
+
+			if tt.expected == "" {
+				assert.True(t, result.IsZero(), "Expected zero time for %s", tt.name)
+			} else {
+				assert.Equal(t, expectedTime, result, "Incorrect previous time for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestFindPrevScheduledTime_ActualImplementation(t *testing.T) {
+	// This test runs against the real system clock and cron implementation
+	tests := []struct {
+		name         string
+		cronSchedule string
+		checkFunc    func(time.Time) bool
+	}{
+		{
+			name:         "hourly schedule within past day",
+			cronSchedule: "0 0 * * * *", // Every hour at minute 0
+			checkFunc: func(result time.Time) bool {
+				now := time.Now()
+				// Should be within the past day
+				return result.Before(now) &&
+					now.Sub(result) < 24*time.Hour &&
+					result.Minute() == 0 &&
+					result.Second() == 0
+			},
+		},
+		{
+			name:         "daily schedule within past week",
+			cronSchedule: "0 0 0 * * *", // Midnight every day
+			checkFunc: func(result time.Time) bool {
+				now := time.Now()
+				// Should be within the past week, at midnight
+				return result.Before(now) &&
+					now.Sub(result) < 7*24*time.Hour &&
+					result.Hour() == 0 &&
+					result.Minute() == 0 &&
+					result.Second() == 0
+			},
+		},
+		{
+			name:         "recent 15-minute mark",
+			cronSchedule: "0 */15 * * * *", // Every 15 minutes
+			checkFunc: func(result time.Time) bool {
+				now := time.Now()
+				// Should be within the past hour, and minute should be 0, 15, 30, or 45
+				return result.Before(now) &&
+					now.Sub(result) < time.Hour &&
+					(result.Minute() == 0 || result.Minute() == 15 ||
+						result.Minute() == 30 || result.Minute() == 45) &&
+					result.Second() == 0
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule, err := cron.Parse(tt.cronSchedule)
+			if err != nil {
+				t.Fatalf("Failed to parse cron schedule: %v", err)
+			}
+
+			result, _ := findPrevScheduledTime(schedule, time.Now())
+
+			assert.False(t, result.IsZero(), "Should not return zero time for %s", tt.name)
+			assert.True(t, tt.checkFunc(result), "Result time didn't meet expectations for %s: %v", tt.name, result)
+		})
+	}
+}
+
+// Test for edge cases and performance
+func TestFindPrevScheduledTime_EdgeCases(t *testing.T) {
+	// Lookback beyond our 7-day window
+	t.Run("schedule beyond lookback window", func(t *testing.T) {
+		now := time.Now()
+		cronStr := "0 0 1 1 *" // January 1st at midnight
+
+		if now.Month() == time.January && now.Day() <= 8 {
+			t.Skip("Skipping test as we're too close to January 1st")
+		}
+
+		schedule, _ := cron.Parse(cronStr)
+		result, _ := findPrevScheduledTime(schedule, now)
+
+		// If now is not in January or we're past Jan 8th, the previous Jan 1st
+		// would be beyond our 7-day lookback
+		assert.True(t, result.IsZero(), "Expected zero time for schedule beyond lookback")
+	})
+
+	// Performance test for frequently occurring schedule
+	t.Run("performance for frequent schedule", func(t *testing.T) {
+		cronStr := "* * * * *" // Every minute
+		schedule, _ := cron.Parse(cronStr)
+		now := time.Now()
+
+		start := time.Now()
+		result, _ := findPrevScheduledTime(schedule, now)
+		duration := time.Since(start)
+
+		assert.False(t, result.IsZero(), "Should find a result for every minute schedule")
+		assert.True(t, duration < 100*time.Millisecond,
+			"Finding prev time took too long: %v", duration)
+	})
+}

--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -23,7 +23,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 			"error":     err,
 			"name":      resource.Name,
 			"namespace": resource.Namespace,
-		}).Error("provider.kubernetes: failed to parse update schedule")
+		}).Error("provider.kubernetes.updates.checkForUpdate: failed to parse update schedule")
 		return nil, false, err
 	}
 
@@ -38,7 +38,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 					"error":     err,
 					"name":      resource.Name,
 					"namespace": resource.Namespace,
-				}).Error("provider.kubernetes: failed to parse last update time")
+				}).Error("provider.kubernetes.updates.checkForUpdate: failed to parse last update time")
 				return nil, false, err
 			}
 		}
@@ -49,7 +49,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 				"error":     err,
 				"name":      resource.Name,
 				"namespace": resource.Namespace,
-			}).Error("provider.kubernetes: failed to check update schedule")
+			}).Error("provider.kubernetes.updates.checkForUpdate: failed to check update schedule")
 			return nil, false, err
 		}
 
@@ -57,7 +57,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 			log.WithFields(log.Fields{
 				"name":      resource.Name,
 				"namespace": resource.Namespace,
-			}).Info("provider.kubernetes: update not allowed by schedule")
+			}).Debug("provider.kubernetes.updates.checkForUpdate: update not allowed by schedule")
 			return nil, false, nil
 		}
 	}
@@ -72,7 +72,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 		"namespace": resource.Namespace,
 		"kind":      resource.Kind(),
 		"policy":    plc.Name(),
-	}).Debug("provider.kubernetes.checkVersionedDeployment: keel policy found, checking resource...")
+	}).Debug("provider.kubernetes.updates.checkForUpdate: keel policy found, checking resource...")
 	shouldUpdateDeployment = false
 
 	containerFilterFunc := GetMonitorContainersFromMeta(resource.GetAnnotations(), resource.GetLabels())
@@ -87,7 +87,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 				log.WithFields(log.Fields{
 					"error":      err,
 					"image_name": c.Image,
-				}).Error("provider.kubernetes: failed to parse image name")
+				}).Error("provider.kubernetes.updates.checkForUpdate: failed to parse image name")
 				continue
 			}
 

--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -43,7 +43,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 			}
 		}
 
-		allowed, err := schedule.IsUpdateAllowed(lastUpdate)
+		allowed, err := schedule.IsUpdateAllowed(lastUpdate, time.Now())
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error":     err,
@@ -243,7 +243,7 @@ func (p *Provider) checkForUpdate(resource k8s.GenericResource, repo *types.Repo
 			}
 		}
 
-		allowed, err := schedule.IsUpdateAllowed(lastUpdate)
+		allowed, err := schedule.IsUpdateAllowed(lastUpdate, time.Now())
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error":     err,
@@ -264,7 +264,7 @@ func (p *Provider) checkForUpdate(resource k8s.GenericResource, repo *types.Repo
 
 	// Get policy from labels/annotations
 	plc := policy.GetPolicyFromLabelsOrAnnotations(resource.GetLabels(), resource.GetAnnotations())
-	if plc.Type() == types.PolicyTypeNone {
+	if plc.Type() == policy.PolicyTypeNone {
 		return nil
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -76,13 +76,12 @@ const KeelApprovalDeadlineDefault = 24
 const KeelReleaseNotesURL = "keel.sh/releaseNotes"
 
 // Update schedule annotations
+// This allows us to decouple image polling VS image update.
+// Watcher is shared, so there is no real way of having independant polling/update shcedules
+// in different kubernetes objects that rely on using the same repository path
 const (
-	// KeelUpdateScheduleCronTabs - cron schedules for when updates are allowed
+	// KeelUpdateScheduleCronTabs - cron schedules for when updates are allowed, sepparated by commas
 	KeelUpdateScheduleCronTabs = "keel.sh/updateScheduleCronTabs"
-	// KeelUpdateScheduleDurationMinutes - how long the update window stays open
-	KeelUpdateScheduleDurationMinutes = "keel.sh/updateScheduleDurationMinutes"
-	// KeelUpdateScheduleCoolDownMinutes - cooldown period after an update
-	KeelUpdateScheduleCoolDownMinutes = "keel.sh/updateScheduleCoolDownMinutes"
 )
 
 func init() {

--- a/types/types.go
+++ b/types/types.go
@@ -75,6 +75,16 @@ const KeelApprovalDeadlineDefault = 24
 // KeelReleasePage - optional release notes URL passed on with notification
 const KeelReleaseNotesURL = "keel.sh/releaseNotes"
 
+// Update schedule annotations
+const (
+	// KeelUpdateScheduleCronTabs - cron schedules for when updates are allowed
+	KeelUpdateScheduleCronTabs = "keel.sh/updateScheduleCronTabs"
+	// KeelUpdateScheduleDurationMinutes - how long the update window stays open
+	KeelUpdateScheduleDurationMinutes = "keel.sh/updateScheduleDurationMinutes"
+	// KeelUpdateScheduleCoolDownMinutes - cooldown period after an update
+	KeelUpdateScheduleCoolDownMinutes = "keel.sh/updateScheduleCoolDownMinutes"
+)
+
 func init() {
 	value, found := os.LookupEnv("POLL_DEFAULTSCHEDULE")
 	if found {


### PR DESCRIPTION
This PR add a new Keel annotation :

keel.sh/updateScheduleCronTabs: 0 0 3 * * 0|60m

The purpose of this is to circunvent current limitations regarding control on when images are effective applied to K8S resources. The existing /schedule annotation is aimed at controlling watchers image polling. Because watchers are shared, you have little control on when images are effectively deployed.

This opens the door to new use cases, i.e. having update rings.