### PR TITLE
Update the deployment templates to have extraEnv

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -187,6 +187,10 @@ spec:
             - name: AWS_REGION
               value: "{{ .Values.aws.region }}"
 {{- end }}
+{{- range .Values.extraEnv }}
+            - name: {{ .name }}
+              value: "{{ .value }}"
+{{- end }}
 {{- if or .Values.secret.create .Values.secret.name }}
           envFrom:
             - secretRef:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -10,6 +10,9 @@ image:
 # Image pull secrets
 imagePullSecrets: []
 
+# Extra enviroment values
+extraEnv: []
+
 # Enable insecure registries
 insecureRegistry: false
 


### PR DESCRIPTION
## Description:

This PR updates the Helm chart's deployment template to support additional environment variables through the extraEnv field in values.yaml.

## Changes:

deployment.yaml: Injects values from extraEnv into the pod environment configuration.
values.yaml: Adds a new configurable field extraEnv (default: empty list).

## Suppresses:

Closes #686 
Closes #660 

Let me know if you'd like this styled differently or something changed