### PR TITLE
Do not output confusing image names when setting up watcher jobs + fix multiwatcher stuck with initial policy

### DIFF
--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -99,7 +99,7 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 
 		// The fact that they are related, does not mean they share the exact same Policy configuration, so wee need
 		// to calculate the tags here for each image.
-		filteredTags = j.details.trackedImage.Policy.Filter(tags)
+		filteredTags = trackedImage.Policy.Filter(tags)
 
 		for _, tag := range filteredTags {
 

--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -271,8 +271,8 @@ func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) erro
 	job := NewWatchRepositoryTagsJob(w.providers, w.registryClient, details)
 	log.WithFields(log.Fields{
 		"job_name": key,
-		"image":    ti.Image.String(),
-		"digest":   digest,
+		"image":    ti.Image.Registry() + "/" + ti.Image.ShortName(), // A watcher can be shared, so it makes little sense to specify tag depth here
+		"digest":   "",                                               // A watcher can be shared, so it makes little sense to specify here a specific image digest used by one of the consumers
 		"schedule": schedule,
 	}).Info("trigger.poll.RepositoryWatcher: new watch repository tags job added")
 	job.Run()


### PR DESCRIPTION
Watchers can be shared between different policies and K8S objects. The fact that the first seen K8S object that sets up the watcher is sent to console might be confusing because not all deployments using the watcher might be sharing the same image details.