### PR TITLE
updated teams webhook returns 202

### DIFF
--- a/extension/notification/teams/teams.go
+++ b/extension/notification/teams/teams.go
@@ -130,9 +130,9 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
+	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202) {
 		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201", resp.StatusCode)
+			return fmt.Errorf("got status %d, expected 200/201/202", resp.StatusCode)
 		}
 		return err
 	}


### PR DESCRIPTION
Microsoft made changes to webhooks and re-added support for MessageCard to their new setup.
https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/

Keel can fire off webhooks to the new webhooks urls, and the message is received successfully in Teams, but keel receives a 202 and retries (successfully) 10 times.
This adds 202 support to Teams.