### PR TITLE
Remove webhook log path (which contains sig signing secret) from logs, unless in debug mode

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -84,9 +84,6 @@ const (
 	EnvKubernetesContext   = "KUBERNETES_CONTEXT"
 )
 
-// EnvDebug - set to 1 or anything else to enable debug logging
-const EnvDebug = "DEBUG"
-
 func main() {
 	ver := version.GetKeelVersion()
 
@@ -107,7 +104,7 @@ func main() {
 		"arch":       ver.Arch,
 	}).Info("keel starting...")
 
-	if os.Getenv(EnvDebug) == "true" {
+	if os.Getenv(constants.EnvDebug) == "true" {
 		log.SetLevel(log.DebugLevel)
 	}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -45,6 +45,9 @@ const (
 	EnvMailSmtpPort   = "MAIL_SMTP_PORT"
 	EnvMailSmtpUser   = "MAIL_SMTP_USER"
 	EnvMailSmtpPass   = "MAIL_SMTP_PASS"
+
+	// EnvDebug - set to 1 or anything else to enable debug logging
+	EnvDebug = "DEBUG"
 )
 
 // EnvNotificationLevel - minimum level for notifications, defaults to info

--- a/extension/notification/teams/teams.go
+++ b/extension/notification/teams/teams.go
@@ -58,9 +58,15 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		Timeout:   timeout,
 	}
 
+	webhookLog := s.endpoint
+	if os.Getenv(constants.EnvDebug) != "true" {
+		if u, err := url.Parse(s.endpoint); err == nil {
+			webhookLog = u.Scheme + "://" + u.Host
+		}
+	}
 	log.WithFields(log.Fields{
-		"name":     "teams",
-		"webhook": s.endpoint,
+		"name":    "teams",
+		"webhook": webhookLog,
 	}).Info("extension.notification.teams: sender configured")
 
 	return true, nil
@@ -140,3 +146,4 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	return nil
 }
+


### PR DESCRIPTION
This seemed to be the easiest way to keep the full webhook string out of the logs but also provide something helpful.