### PR TITLE
fix(credentialshelper): correct GCR OAuth scope and enforce deterministic helper ordering

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -249,7 +249,7 @@ func main() {
 	secretsGetter := secrets.NewGetter(implementer, dockerConfig)
 
 	ch := secretsCredentialsHelper.New(secretsGetter)
-	credentialshelper.RegisterCredentialsHelper("secrets", ch)
+	credentialshelper.RegisterCredentialsHelper(credentialshelper.HelperNameSecrets, ch)
 
 	// trigger setup
 	// teardownTriggers := setupTriggers(ctx, providers, approvalsManager, &t.GenericResourceCache, implementer)

--- a/extension/credentialshelper/aws/aws.go
+++ b/extension/credentialshelper/aws/aws.go
@@ -28,7 +28,7 @@ const AWSCredentialsExpiry = 2 * time.Hour
 var registryRegxp *regexp.Regexp
 
 func init() {
-	credentialshelper.RegisterCredentialsHelper("aws", New())
+	credentialshelper.RegisterCredentialsHelper(credentialshelper.HelperNameAWS, New())
 	registryRegxp = regexp.MustCompile(`(?P<registryID>\d+)\.dkr\.ecr\.(?P<region>\S+)\.amazonaws\.com`)
 }
 
@@ -117,7 +117,7 @@ func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Cr
 			"token":            *ad.AuthorizationToken,
 			"registry":         registry,
 		}).Debug("checking registry")
-		if strings.SplitN(u.Host,".",2)[1] == strings.SplitN(registry,".",2)[1] {
+		if strings.SplitN(u.Host, ".", 2)[1] == strings.SplitN(registry, ".", 2)[1] {
 			username, password, err := decodeBase64Secret(*ad.AuthorizationToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode authentication token: %s, error: %s", *ad.AuthorizationToken, err)

--- a/extension/credentialshelper/credentialshelper.go
+++ b/extension/credentialshelper/credentialshelper.go
@@ -2,6 +2,7 @@ package credentialshelper
 
 import (
 	"errors"
+	"sort"
 	"sync"
 
 	"github.com/keel-hq/keel/types"
@@ -20,6 +21,13 @@ type CredentialsHelper interface {
 var (
 	ErrCredentialsNotAvailable = errors.New("no credentials available for this registry")
 	ErrUnsupportedRegistry     = errors.New("unsupported registry")
+)
+
+// Well-known helper names used at registration and for call-order priority.
+const (
+	HelperNameSecrets = "secrets"
+	HelperNameAWS     = "aws"
+	HelperNameGCR     = "gcr"
 )
 
 var (
@@ -63,17 +71,44 @@ func UnregisterCredentialsHelper(name string) {
 	delete(credHelpers, name)
 }
 
-// GetCredentials - generic function for getting credentials
-// func (ch *CredentialsHelpers) GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
+// helperCallOrder returns helper names in a stable, intentional order. Map iteration
+// in Go is randomised; without this, cloud ADC helpers (e.g. gcr) could run before
+// the Kubernetes secrets helper and win with workload-identity tokens even when the
+// tracked image references imagePullSecrets (e.g. docker-registries), causing flaky
+// 403 responses against private registries.
+func helperCallOrder(helpers map[string]CredentialsHelper) []string {
+	priority := []string{HelperNameSecrets, HelperNameAWS, HelperNameGCR}
+	seen := make(map[string]struct{}, len(helpers))
+	out := make([]string, 0, len(helpers))
+	for _, name := range priority {
+		if _, ok := helpers[name]; ok {
+			out = append(out, name)
+			seen[name] = struct{}{}
+		}
+	}
+	rest := make([]string, 0, len(helpers))
+	for name := range helpers {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		rest = append(rest, name)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+// GetCredentials iterates registered helpers in priority order and returns the
+// first successful credentials, or ErrCredentialsNotAvailable if none match.
 func GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
 	credHelpersM.RLock()
 	defer credHelpersM.RUnlock()
 
-	for name, credHelper := range credHelpers {
+	for _, name := range helperCallOrder(credHelpers) {
+		credHelper := credHelpers[name]
 		if credHelper.IsEnabled() {
 			foundCredentials, err := credHelper.GetCredentials(image)
 			if err != nil {
-				if err == ErrUnsupportedRegistry {
+				if errors.Is(err, ErrUnsupportedRegistry) {
 					log.WithFields(log.Fields{
 						"helper":        name,
 						"error":         err,

--- a/extension/credentialshelper/credentialshelper_test.go
+++ b/extension/credentialshelper/credentialshelper_test.go
@@ -1,0 +1,145 @@
+package credentialshelper
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+type stubCredentialsHelper struct {
+	enabled bool
+	creds   *types.Credentials
+	err     error
+}
+
+func (s stubCredentialsHelper) IsEnabled() bool { return s.enabled }
+
+func (s stubCredentialsHelper) GetCredentials(*types.TrackedImage) (*types.Credentials, error) {
+	return s.creds, s.err
+}
+
+func mustTrackedImage(t *testing.T, ref string) *types.TrackedImage {
+	t.Helper()
+	img, err := image.Parse(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &types.TrackedImage{Image: img}
+}
+
+func TestGetCredentials_prefersKubernetesSecretsBeforeGCR(t *testing.T) {
+	gcrCreds := &types.Credentials{Username: "gcr", Password: "gcr"}
+	secretCreds := &types.Credentials{Username: "secret", Password: "secret"}
+
+	RegisterCredentialsHelper(HelperNameGCR, stubCredentialsHelper{enabled: true, creds: gcrCreds})
+	RegisterCredentialsHelper(HelperNameSecrets, stubCredentialsHelper{enabled: true, creds: secretCreds})
+	t.Cleanup(func() {
+		UnregisterCredentialsHelper(HelperNameGCR)
+		UnregisterCredentialsHelper(HelperNameSecrets)
+	})
+
+	creds, err := GetCredentials(mustTrackedImage(t, "europe-west4-docker.pkg.dev/proj/repo/img:1"))
+	if err != nil {
+		t.Fatalf("GetCredentials: %v", err)
+	}
+	if creds.Username != "secret" {
+		t.Fatalf("want secret helper to win, got username %q", creds.Username)
+	}
+}
+
+func TestGetCredentials_secretsSkippedOnUnsupportedRegistryFallsThroughToGCR(t *testing.T) {
+	gcrCreds := &types.Credentials{Username: "gcr", Password: "tok"}
+
+	RegisterCredentialsHelper(HelperNameSecrets, stubCredentialsHelper{enabled: true, err: ErrUnsupportedRegistry})
+	RegisterCredentialsHelper(HelperNameGCR, stubCredentialsHelper{enabled: true, creds: gcrCreds})
+	t.Cleanup(func() {
+		UnregisterCredentialsHelper(HelperNameSecrets)
+		UnregisterCredentialsHelper(HelperNameGCR)
+	})
+
+	creds, err := GetCredentials(mustTrackedImage(t, "europe-west4-docker.pkg.dev/proj/repo/img:1"))
+	if err != nil {
+		t.Fatalf("GetCredentials: %v", err)
+	}
+	if creds.Username != "gcr" {
+		t.Fatalf("want gcr helper after secrets unsupported, got username %q", creds.Username)
+	}
+}
+
+func TestHelperCallOrder(t *testing.T) {
+	helpers := map[string]CredentialsHelper{
+		"zebra":           stubCredentialsHelper{enabled: true},
+		HelperNameGCR:     stubCredentialsHelper{enabled: true},
+		HelperNameSecrets: stubCredentialsHelper{enabled: true},
+		HelperNameAWS:     stubCredentialsHelper{enabled: true},
+		"auxiliary":       stubCredentialsHelper{enabled: true},
+	}
+	got := helperCallOrder(helpers)
+	want := []string{HelperNameSecrets, HelperNameAWS, HelperNameGCR, "auxiliary", "zebra"}
+	if len(got) != len(want) {
+		t.Fatalf("len got %d want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %q want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestGetCredentials_nonPriorityHelpersAreOrderedLexicographically(t *testing.T) {
+	RegisterCredentialsHelper("zebra-extra", stubCredentialsHelper{
+		enabled: true,
+		creds:   &types.Credentials{Username: "from-zebra", Password: "z"},
+	})
+	RegisterCredentialsHelper("aaa-extra", stubCredentialsHelper{
+		enabled: true,
+		creds:   &types.Credentials{Username: "from-aaa", Password: "a"},
+	})
+	t.Cleanup(func() {
+		UnregisterCredentialsHelper("zebra-extra")
+		UnregisterCredentialsHelper("aaa-extra")
+	})
+
+	creds, err := GetCredentials(mustTrackedImage(t, "example.com/foo:1"))
+	if err != nil {
+		t.Fatalf("GetCredentials: %v", err)
+	}
+	if creds.Username != "from-aaa" {
+		t.Fatalf("expected aaa-extra before zebra-extra, got username %q", creds.Username)
+	}
+}
+
+func TestGetCredentials_disabledHelperSkipped(t *testing.T) {
+	RegisterCredentialsHelper(HelperNameSecrets, stubCredentialsHelper{
+		enabled: false,
+		creds:   &types.Credentials{Username: "no", Password: "no"},
+	})
+	RegisterCredentialsHelper(HelperNameGCR, stubCredentialsHelper{
+		enabled: true,
+		creds:   &types.Credentials{Username: "yes", Password: "yes"},
+	})
+	t.Cleanup(func() {
+		UnregisterCredentialsHelper(HelperNameSecrets)
+		UnregisterCredentialsHelper(HelperNameGCR)
+	})
+
+	creds, err := GetCredentials(mustTrackedImage(t, "gcr.io/p/i:1"))
+	if err != nil {
+		t.Fatalf("GetCredentials: %v", err)
+	}
+	if creds.Username != "yes" {
+		t.Fatalf("disabled secrets should be skipped: got %q", creds.Username)
+	}
+}
+
+func TestGetCredentials_allFailReturnsErrCredentialsNotAvailable(t *testing.T) {
+	RegisterCredentialsHelper(HelperNameSecrets, stubCredentialsHelper{enabled: true, err: errors.New("nope")})
+	t.Cleanup(func() { UnregisterCredentialsHelper(HelperNameSecrets) })
+
+	_, err := GetCredentials(mustTrackedImage(t, "docker.io/library/nginx:latest"))
+	if !errors.Is(err, ErrCredentialsNotAvailable) {
+		t.Fatalf("got err=%v want ErrCredentialsNotAvailable", err)
+	}
+}

--- a/extension/credentialshelper/gcr/gcr.go
+++ b/extension/credentialshelper/gcr/gcr.go
@@ -1,82 +1,99 @@
 package gcr
 
 import (
-        "context"
-        "errors"
-        "fmt"
-        "os"
-        "strings"
-    
-        "cloud.google.com/go/storage"
-        "github.com/keel-hq/keel/extension/credentialshelper"
-        "github.com/keel-hq/keel/types"
-        "golang.org/x/oauth2/google"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/keel-hq/keel/extension/credentialshelper"
+	"github.com/keel-hq/keel/types"
+	"golang.org/x/oauth2/google"
 )
 
+// tokenSourceProvider obtains an oauth2.TokenSource for workload identity or
+// application default credentials. In production this is google.DefaultTokenSource;
+// tests assign a stub here so the package can be exercised without calling GCP.
+var tokenSourceProvider = google.DefaultTokenSource
+
+// scopeCloudPlatform is the OAuth 2.0 scope we request for registry access when
+// no JSON key is available. Google documents
+// https://www.googleapis.com/auth/cloud-platform for the Artifact Registry API;
+// the narrower Cloud Storage scope (devstorage.read_only) is not sufficient for
+// Docker Registry HTTP API v2 manifest calls against *.docker.pkg.dev (e.g. HTTP
+// 403 on HEAD .../manifests/...). See “OAuth 2.0 Scopes for Google APIs”.
+const scopeCloudPlatform = "https://www.googleapis.com/auth/cloud-platform"
+
+// oauth2TokenUsername is the registry username used with a bearer access token for
+// GKE workload identity / ADC (see also Artifact Registry “access token” auth).
+// This is separate from "_json_key", which is used with a service account JSON file.
+const oauth2TokenUsername = "_token"
+
 func init() {
-        credentialshelper.RegisterCredentialsHelper("gcr", New())
+	credentialshelper.RegisterCredentialsHelper("gcr", New())
 }
 
 type CredentialsHelper struct {
-        enabled bool
+	enabled bool
 }
 
 func New() *CredentialsHelper {
-        return &CredentialsHelper{
-            enabled: true,
-        }
+	return &CredentialsHelper{
+		enabled: true,
+	}
 }
 
 func (h *CredentialsHelper) IsEnabled() bool {
-        return h.enabled
+	return h.enabled
 }
 
 func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
-        if !h.enabled {
-            return nil, errors.New("not initialised")
-        }
-    
-        if !strings.HasPrefix(image.Image.Registry(), "gcr.io") && !strings.Contains(image.Image.Registry(), "pkg.dev") {
-            return nil, credentialshelper.ErrUnsupportedRegistry
-        }
-    
-        if credentials, err := readCredentialsFromFile(); err == nil {
-            return credentials, nil
-        }
-    
-        return getWorkloadIdentityTokenCredentials()
+	if !h.enabled {
+		return nil, errors.New("not initialised")
+	}
+
+	if !strings.HasPrefix(image.Image.Registry(), "gcr.io") && !strings.Contains(image.Image.Registry(), "pkg.dev") {
+		return nil, credentialshelper.ErrUnsupportedRegistry
+	}
+
+	if credentials, err := readCredentialsFromFile(); err == nil {
+		return credentials, nil
+	}
+
+	return getWorkloadIdentityTokenCredentials()
 }
 
 func readCredentialsFromFile() (*types.Credentials, error) {
-        credentialsFile, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
-        if !ok {
-            return nil, errors.New("GOOGLE_APPLICATION_CREDENTIALS environment variable not set")
-        }
-    
-        credentials, err := os.ReadFile(credentialsFile)
-        if err != nil {
-            return nil, fmt.Errorf("failed to read credentials file: %w", err)
-        }
-    
-        return &types.Credentials{
-            Username: "_json_key",
-            Password: string(credentials),
-        }, nil
+	credentialsFile, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
+	if !ok {
+		return nil, errors.New("GOOGLE_APPLICATION_CREDENTIALS environment variable not set")
+	}
+
+	credentials, err := os.ReadFile(credentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read credentials file: %w", err)
+	}
+
+	return &types.Credentials{
+		Username: "_json_key",
+		Password: string(credentials),
+	}, nil
 }
 
 func getWorkloadIdentityTokenCredentials() (*types.Credentials, error) {
-        ctx := context.Background()
-        tokenSource, err := google.DefaultTokenSource(ctx, storage.ScopeReadOnly)
-        if err != nil {
-            return nil, fmt.Errorf("failed to get default token source: %w", err)
-        }
-        token, err := tokenSource.Token()
-        if err != nil {
-            return nil, fmt.Errorf("failed to get token: %w", err)
-        }
-    
-        return &types.Credentials{
-            Username: "_token",
-            Password: token.AccessToken,
-        }, nil
+	ctx := context.Background()
+	tokenSource, err := tokenSourceProvider(ctx, scopeCloudPlatform)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default token source: %w", err)
+	}
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+
+	return &types.Credentials{
+		Username: oauth2TokenUsername,
+		Password: token.AccessToken,
+	}, nil
 }

--- a/extension/credentialshelper/gcr/gcr.go
+++ b/extension/credentialshelper/gcr/gcr.go
@@ -10,11 +10,14 @@ import (
 	"github.com/keel-hq/keel/extension/credentialshelper"
 	"github.com/keel-hq/keel/types"
 	"golang.org/x/oauth2/google"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // tokenSourceProvider obtains an oauth2.TokenSource for workload identity or
 // application default credentials. In production this is google.DefaultTokenSource;
 // tests assign a stub here so the package can be exercised without calling GCP.
+// Not safe for use with t.Parallel() — tests must run sequentially.
 var tokenSourceProvider = google.DefaultTokenSource
 
 // scopeCloudPlatform is the OAuth 2.0 scope we request for registry access when
@@ -22,32 +25,42 @@ var tokenSourceProvider = google.DefaultTokenSource
 // https://www.googleapis.com/auth/cloud-platform for the Artifact Registry API;
 // the narrower Cloud Storage scope (devstorage.read_only) is not sufficient for
 // Docker Registry HTTP API v2 manifest calls against *.docker.pkg.dev (e.g. HTTP
-// 403 on HEAD .../manifests/...). See “OAuth 2.0 Scopes for Google APIs”.
+// 403 on HEAD .../manifests/...). See "OAuth 2.0 Scopes for Google APIs".
 const scopeCloudPlatform = "https://www.googleapis.com/auth/cloud-platform"
 
-// oauth2TokenUsername is the registry username used with a bearer access token for
-// GKE workload identity / ADC (see also Artifact Registry “access token” auth).
-// This is separate from "_json_key", which is used with a service account JSON file.
+// jsonKeyUsername is the Docker registry username for service account JSON key
+// authentication (GOOGLE_APPLICATION_CREDENTIALS).
+const jsonKeyUsername = "_json_key"
+
+// oauth2TokenUsername is the Docker registry username for bearer access tokens
+// obtained via GKE workload identity or application default credentials.
 const oauth2TokenUsername = "_token"
 
 func init() {
-	credentialshelper.RegisterCredentialsHelper("gcr", New())
+	credentialshelper.RegisterCredentialsHelper(credentialshelper.HelperNameGCR, New())
 }
 
+// CredentialsHelper provides Docker registry credentials for gcr.io and
+// Artifact Registry (*.pkg.dev) images.
 type CredentialsHelper struct {
 	enabled bool
 }
 
+// New creates a new GCR/Artifact Registry credentials helper.
 func New() *CredentialsHelper {
 	return &CredentialsHelper{
 		enabled: true,
 	}
 }
 
+// IsEnabled returns whether this credentials helper is active.
 func (h *CredentialsHelper) IsEnabled() bool {
 	return h.enabled
 }
 
+// GetCredentials returns registry credentials for gcr.io and *.pkg.dev images.
+// It tries a JSON key file (GOOGLE_APPLICATION_CREDENTIALS) first, then falls
+// back to a workload-identity / ADC bearer token.
 func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Credentials, error) {
 	if !h.enabled {
 		return nil, errors.New("not initialised")
@@ -57,8 +70,15 @@ func (h *CredentialsHelper) GetCredentials(image *types.TrackedImage) (*types.Cr
 		return nil, credentialshelper.ErrUnsupportedRegistry
 	}
 
-	if credentials, err := readCredentialsFromFile(); err == nil {
-		return credentials, nil
+	creds, err := readCredentialsFromFile()
+	if err == nil {
+		return creds, nil
+	}
+
+	if _, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Warn("extension.credentialshelper.gcr: GOOGLE_APPLICATION_CREDENTIALS set but not usable, falling back to workload identity")
 	}
 
 	return getWorkloadIdentityTokenCredentials()
@@ -76,7 +96,7 @@ func readCredentialsFromFile() (*types.Credentials, error) {
 	}
 
 	return &types.Credentials{
-		Username: "_json_key",
+		Username: jsonKeyUsername,
 		Password: string(credentials),
 	}, nil
 }

--- a/extension/credentialshelper/gcr/gcr_test.go
+++ b/extension/credentialshelper/gcr/gcr_test.go
@@ -1,0 +1,199 @@
+package gcr
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keel-hq/keel/extension/credentialshelper"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+	"golang.org/x/oauth2"
+)
+
+func mustParseRef(t *testing.T, ref string) *image.Reference {
+	t.Helper()
+	img, err := image.Parse(ref)
+	if err != nil {
+		t.Fatalf("image.Parse: %v", err)
+	}
+	return img
+}
+
+func tracked(img *image.Reference) *types.TrackedImage {
+	return &types.TrackedImage{Image: img}
+}
+
+func TestCredentialsHelper_IsEnabled(t *testing.T) {
+	h := New()
+	if !h.IsEnabled() {
+		t.Fatal("expected helper enabled")
+	}
+}
+
+func TestCredentialsHelper_GetCredentials_errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		h       func() *CredentialsHelper
+		ref     string
+		wantErr string
+		wantIs  error
+	}{
+		{
+			name: "disabled",
+			h: func() *CredentialsHelper {
+				return &CredentialsHelper{enabled: false}
+			},
+			ref:     "gcr.io/project/image:1.0",
+			wantErr: "not initialised",
+		},
+		{
+			name: "unsupported registry",
+			h: func() *CredentialsHelper {
+				return New()
+			},
+			ref:    "docker.io/library/nginx:latest",
+			wantIs: credentialshelper.ErrUnsupportedRegistry,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.h().GetCredentials(tracked(mustParseRef(t, tt.ref)))
+			if tt.wantIs != nil {
+				if !errors.Is(err, tt.wantIs) {
+					t.Fatalf("got err=%v want %v", err, tt.wantIs)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("got err=%v want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCredentialsHelper_GetCredentials_jsonKeyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	jsonKey := `{"type":"service_account","project_id":"p"}`
+	if err := os.WriteFile(path, []byte(jsonKey), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{
+			name: "gcr.io",
+			ref:  "gcr.io/myproject/myimage:latest",
+		},
+		{
+			name: "artifact registry",
+			ref:  "europe-west4-docker.pkg.dev/myproj/myrepo/img:3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New()
+			creds, err := h.GetCredentials(tracked(mustParseRef(t, tt.ref)))
+			if err != nil {
+				t.Fatalf("GetCredentials: %v", err)
+			}
+			if creds.Username != "_json_key" || creds.Password != jsonKey {
+				t.Fatalf("unexpected creds: username=%q passwordLen=%d", creds.Username, len(creds.Password))
+			}
+		})
+	}
+}
+
+func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
+	if err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS"); err != nil {
+		t.Fatal(err)
+	}
+
+	origTS := tokenSourceProvider
+	t.Cleanup(func() { tokenSourceProvider = origTS })
+
+	errTokenRefresh := errors.New("token refresh failed")
+
+	tests := []struct {
+		name     string
+		ref      string
+		provider func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error)
+		check    func(t *testing.T, creds *types.Credentials, err error)
+	}{
+		{
+			name: "requests cloud platform scope and returns bearer creds",
+			ref:  "europe-west4-docker.pkg.dev/prj/repo/img:3",
+			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
+				var gotScopes []string
+				t.Cleanup(func() {
+					if len(gotScopes) != 1 || gotScopes[0] != scopeCloudPlatform {
+						t.Errorf("token source scopes: got %v want single scope %q", gotScopes, scopeCloudPlatform)
+					}
+				})
+				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+					gotScopes = append([]string(nil), scopes...)
+					return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake-wi-token"}), nil
+				}
+			},
+			check: func(t *testing.T, creds *types.Credentials, err error) {
+				if err != nil {
+					t.Fatalf("GetCredentials: %v", err)
+				}
+				if creds.Username != oauth2TokenUsername || creds.Password != "fake-wi-token" {
+					t.Fatalf("unexpected WI creds: %+v", creds)
+				}
+			},
+		},
+		{
+			name: "token source error",
+			ref:  "gcr.io/x/y:1",
+			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
+				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+					return nil, errors.New("no metadata server")
+				}
+			},
+			check: func(t *testing.T, creds *types.Credentials, err error) {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+			},
+		},
+		{
+			name: "token error from Token()",
+			ref:  "gcr.io/x/y:1",
+			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
+				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+					return errTokenSource{err: errTokenRefresh}, nil
+				}
+			},
+			check: func(t *testing.T, creds *types.Credentials, err error) {
+				if err == nil {
+					t.Fatal("expected error from Token()")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenSourceProvider = tt.provider(t)
+			h := New()
+			creds, err := h.GetCredentials(tracked(mustParseRef(t, tt.ref)))
+			tt.check(t, creds, err)
+		})
+	}
+}
+
+type errTokenSource struct {
+	err error
+}
+
+func (e errTokenSource) Token() (*oauth2.Token, error) {
+	return nil, e.err
+}

--- a/extension/credentialshelper/gcr/gcr_test.go
+++ b/extension/credentialshelper/gcr/gcr_test.go
@@ -103,17 +103,25 @@ func TestCredentialsHelper_GetCredentials_jsonKeyFromFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetCredentials: %v", err)
 			}
-			if creds.Username != "_json_key" || creds.Password != jsonKey {
+			if creds.Username != jsonKeyUsername || creds.Password != jsonKey {
 				t.Fatalf("unexpected creds: username=%q passwordLen=%d", creds.Username, len(creds.Password))
 			}
 		})
 	}
 }
 
-func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
-	if err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS"); err != nil {
+func unsetEnvWithRestore(t *testing.T, key string) {
+	t.Helper()
+	if orig, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { os.Setenv(key, orig) })
+	}
+	if err := os.Unsetenv(key); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
+	unsetEnvWithRestore(t, "GOOGLE_APPLICATION_CREDENTIALS")
 
 	origTS := tokenSourceProvider
 	t.Cleanup(func() { tokenSourceProvider = origTS })
@@ -123,23 +131,17 @@ func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
 	tests := []struct {
 		name     string
 		ref      string
-		provider func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error)
+		provider func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error)
 		check    func(t *testing.T, creds *types.Credentials, err error)
 	}{
 		{
 			name: "requests cloud platform scope and returns bearer creds",
 			ref:  "europe-west4-docker.pkg.dev/prj/repo/img:3",
-			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
-				var gotScopes []string
-				t.Cleanup(func() {
-					if len(gotScopes) != 1 || gotScopes[0] != scopeCloudPlatform {
-						t.Errorf("token source scopes: got %v want single scope %q", gotScopes, scopeCloudPlatform)
-					}
-				})
-				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-					gotScopes = append([]string(nil), scopes...)
-					return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake-wi-token"}), nil
+			provider: func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+				if len(scopes) != 1 || scopes[0] != scopeCloudPlatform {
+					return nil, errors.New("unexpected scopes: want single scope " + scopeCloudPlatform)
 				}
+				return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake-wi-token"}), nil
 			},
 			check: func(t *testing.T, creds *types.Credentials, err error) {
 				if err != nil {
@@ -153,10 +155,8 @@ func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
 		{
 			name: "token source error",
 			ref:  "gcr.io/x/y:1",
-			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
-				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-					return nil, errors.New("no metadata server")
-				}
+			provider: func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+				return nil, errors.New("no metadata server")
 			},
 			check: func(t *testing.T, creds *types.Credentials, err error) {
 				if err == nil {
@@ -167,10 +167,8 @@ func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
 		{
 			name: "token error from Token()",
 			ref:  "gcr.io/x/y:1",
-			provider: func(t *testing.T) func(context.Context, ...string) (oauth2.TokenSource, error) {
-				return func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
-					return errTokenSource{err: errTokenRefresh}, nil
-				}
+			provider: func(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+				return errTokenSource{err: errTokenRefresh}, nil
 			},
 			check: func(t *testing.T, creds *types.Credentials, err error) {
 				if err == nil {
@@ -182,7 +180,7 @@ func TestCredentialsHelper_GetCredentials_workloadIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokenSourceProvider = tt.provider(t)
+			tokenSourceProvider = tt.provider
 			h := New()
 			creds, err := h.GetCredentials(tracked(mustParseRef(t, tt.ref)))
 			tt.check(t, creds, err)


### PR DESCRIPTION
Summary of the changes:

- OAuth scope: replace `storage.ScopeReadOnly` (`devstorage.read_only`) with `cloud-platform` in `google.DefaultTokenSource` so workload-identity tokens can authenticate against Artifact Registry (`*.docker.pkg.dev`) Docker Registry HTTP API v2 endpoints. The narrower scope causes HTTP 403 on `HEAD .../manifests/<ref>` during poll triggers.
- Helper ordering: iterate credential helpers in a fixed priority (`secrets` => `aws` => `gcr`) instead of random Go map order. Without this, workload-identity tokens from the `gcr` helper can win over explicit `imagePullSecrets` resolved by the `secrets` helper, causing flaky 403 responses against private registries.
- Hardening: extract `HelperNameSecrets`, `HelperNameAWS`, `HelperNameGCR` constants so helper names are compile-time checked; add `jsonKeyUsername` constant alongside `oauth2TokenUsername`. Warn on `GOOGLE_APPLICATION_CREDENTIALS` only when the env var is set but the file is unreadable (silent on the normal workload-identity path); use `errors.Is` for sentinel error comparison.

Resolves #854.

**Note**: `go fmt` reformatted indentation in `gcr.go` and a spacing fix in `aws.go` to conform to Go coding standards.