### PR TITLE
feat: add 'newest' policy - sort tags by image build date

### DIFF
--- a/internal/policy/newest.go
+++ b/internal/policy/newest.go
@@ -1,0 +1,52 @@
+package policy
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/keel-hq/keel/types"
+)
+
+// NewestPolicy filters tags by regexp but relies on the watcher to sort by image creation date.
+// Configured via annotation: keel.sh/policy: "newest:<regexp>"
+type NewestPolicy struct {
+	policy string
+	regexp *regexp.Regexp
+}
+
+func NewNewestPolicy(policy string) (*NewestPolicy, error) {
+	if strings.Contains(policy, ":") {
+		parts := strings.SplitN(policy, ":", 2)
+		if len(parts) == 2 {
+			rx, err := regexp.Compile(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse regexp pattern, error: %s", err)
+			}
+			return &NewestPolicy{
+				regexp: rx,
+				policy: policy,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid newest policy: %s", policy)
+}
+
+func (p *NewestPolicy) ShouldUpdate(current, new string) (bool, error) {
+	return p.regexp.MatchString(new), nil
+}
+
+// Filter returns matching tags without sorting — the watcher sorts by build date.
+func (p *NewestPolicy) Filter(tags []string) []string {
+	filtered := []string{}
+	for _, tag := range tags {
+		if p.regexp.MatchString(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
+func (p *NewestPolicy) Name() string           { return p.policy }
+func (p *NewestPolicy) Type() types.PolicyType { return types.PolicyTypeNewest }
+func (p *NewestPolicy) KeepTag() bool          { return false }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -73,6 +73,16 @@ func GetPolicy(policyName string, options *Options) Policy {
 			return &NilPolicy{}
 		}
 		return p
+	case strings.HasPrefix(policyName, "newest:"):
+		p, err := NewNewestPolicy(policyName)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":  err,
+				"policy": policyName,
+			}).Error("failed to parse newest policy, check your deployment configuration")
+			return &NilPolicy{}
+		}
+		return p
 	}
 
 	switch policyName {

--- a/registry/docker/manifest.go
+++ b/registry/docker/manifest.go
@@ -1,9 +1,12 @@
 package docker
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	manifestv2 "github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/opencontainers/go-digest"
@@ -40,6 +43,67 @@ func (r *Registry) ManifestDigest(repository, reference string) (digest.Digest, 
 		return "", err
 	}
 	return digest.FromBytes(body), nil
+}
+
+// manifestResponse is used to extract the config digest from a v2 manifest.
+type manifestResponse struct {
+	Config struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+}
+
+// configResponse is used to extract the creation timestamp from an image config blob.
+type configResponse struct {
+	Created time.Time `json:"created"`
+}
+
+// ImageCreatedAt fetches the image creation timestamp by reading the config blob.
+func (r *Registry) ImageCreatedAt(repository, reference string) (time.Time, error) {
+	// Fetch the manifest to get the config digest
+	url := r.url("/v2/%s/manifests/%s", repository, reference)
+	r.Logf("registry.manifest.createdAt url=%s repository=%s reference=%s", url, repository, reference)
+
+	resp, err := r.request("GET", url)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var manifest manifestResponse
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return time.Time{}, err
+	}
+
+	if manifest.Config.Digest == "" {
+		return time.Time{}, fmt.Errorf("no config digest in manifest for %s:%s", repository, reference)
+	}
+
+	// Fetch the config blob to get the creation date
+	blobURL := r.url("/v2/%s/blobs/%s", repository, manifest.Config.Digest)
+	r.Logf("registry.blob.get url=%s", blobURL)
+
+	blobResp, err := r.Client.Get(blobURL)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer blobResp.Body.Close()
+
+	blobBody, err := io.ReadAll(blobResp.Body)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var config configResponse
+	if err := json.Unmarshal(blobBody, &config); err != nil {
+		return time.Time{}, err
+	}
+
+	return config.Created, nil
 }
 
 // request performs a request against a url

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/keel-hq/keel/registry/docker"
 
@@ -30,6 +31,7 @@ type Repository struct {
 type Client interface {
 	Get(opts Opts) (*Repository, error)
 	Digest(opts Opts) (string, error)
+	CreatedAt(opts Opts) (time.Time, error)
 }
 
 // New - new registry client
@@ -145,4 +147,28 @@ INIT_CLIENT:
 	}
 
 	return manifestDigest.String(), nil
+}
+
+// CreatedAt - get image creation timestamp
+func (c *DefaultClient) CreatedAt(opts Opts) (time.Time, error) {
+	if opts.Tag == "" {
+		return time.Time{}, ErrTagNotSupplied
+	}
+
+INIT_CLIENT:
+	hub, err := c.getRegistryClient(opts.Registry, opts.Username, opts.Password)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	createdAt, err := hub.ImageCreatedAt(opts.Name, opts.Tag)
+	if err != nil {
+		if strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") && strings.HasPrefix(opts.Registry, "https://") && c.insecure {
+			opts.Registry = strings.Replace(opts.Registry, "https://", "http://", 1)
+			goto INIT_CLIENT
+		}
+		return time.Time{}, err
+	}
+
+	return createdAt, nil
 }

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -1,6 +1,9 @@
 package poll
 
 import (
+	"sort"
+	"time"
+
 	"github.com/keel-hq/keel/extension/credentialshelper"
 	"github.com/keel-hq/keel/provider"
 	"github.com/keel-hq/keel/registry"
@@ -101,6 +104,11 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 		// to calculate the tags here for each image.
 		filteredTags = trackedImage.Policy.Filter(tags)
 
+		// For newest policy, sort by image creation date instead of string comparison
+		if trackedImage.Policy.Type() == types.PolicyTypeNewest && len(filteredTags) > 1 {
+			filteredTags = j.sortByCreationDate(trackedImage, filteredTags)
+		}
+
 		for _, tag := range filteredTags {
 
 			update, err := trackedImage.Policy.ShouldUpdate(trackedImage.Image.Tag(), tag)
@@ -143,6 +151,57 @@ func exists(tag string, events []types.Event) bool {
 		}
 	}
 	return false
+}
+
+type tagWithDate struct {
+	tag       string
+	createdAt time.Time
+}
+
+func (j *WatchRepositoryTagsJob) sortByCreationDate(trackedImage *types.TrackedImage, tags []string) []string {
+	reg := trackedImage.Image.Scheme() + "://" + trackedImage.Image.Registry()
+	registryOpts := registry.Opts{
+		Registry: reg,
+		Name:     trackedImage.Image.ShortName(),
+	}
+
+	creds, err := credentialshelper.GetCredentials(trackedImage)
+	if err == nil {
+		registryOpts.Username = creds.Username
+		registryOpts.Password = creds.Password
+	}
+
+	var tagsWithDates []tagWithDate
+	for _, tag := range tags {
+		opts := registryOpts
+		opts.Tag = tag
+		createdAt, err := j.registryClient.CreatedAt(opts)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+				"tag":   tag,
+				"image": trackedImage.Image.Repository(),
+			}).Warn("trigger.poll.WatchRepositoryTagsJob: failed to get creation date, skipping tag")
+			continue
+		}
+		tagsWithDates = append(tagsWithDates, tagWithDate{tag: tag, createdAt: createdAt})
+	}
+
+	sort.Slice(tagsWithDates, func(i, j int) bool {
+		return tagsWithDates[i].createdAt.After(tagsWithDates[j].createdAt)
+	})
+
+	sorted := make([]string, len(tagsWithDates))
+	for i, t := range tagsWithDates {
+		sorted[i] = t.tag
+	}
+
+	log.WithFields(log.Fields{
+		"image":       trackedImage.Image.Repository(),
+		"sorted_tags": sorted,
+	}).Debug("trigger.poll.WatchRepositoryTagsJob: tags sorted by creation date")
+
+	return sorted
 }
 
 func getRelatedTrackedImages(ours *types.TrackedImage, all []*types.TrackedImage) []*types.TrackedImage {

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/keel-hq/keel/approvals"
 	// "github.com/keel-hq/keel/cache/memory"
@@ -51,6 +52,11 @@ func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, erro
 func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err error) {
 	c.opts = opts
 	return c.digestToReturn, c.digestErrToReturn
+}
+
+func (c *fakeRegistryClient) CreatedAt(opts registry.Opts) (time.Time, error) {
+	c.opts = opts
+	return time.Now(), nil
 }
 
 // ======== fake provider for testing =======

--- a/types/types.go
+++ b/types/types.go
@@ -387,4 +387,5 @@ const (
 	PolicyTypeForce
 	PolicyTypeGlob
 	PolicyTypeRegexp
+	PolicyTypeNewest
 )


### PR DESCRIPTION
The `regexp` policy sorts matching tags lexicographically, which doesn't work for non-semver tags like git commit hashes - `fffdf40` sorts higher than `ddc5ad3` even though it was built earlier.

This adds a `newest` policy that filters tags by regexp (same as `regexp`) but sorts by the image build date from the registry config blob instead of string comparison. For each matching tag, it fetches the `created` timestamp from the image config blob and picks the most recently built one. Same approach as ArgoCD Image Updater's `newest-build` strategy.

Usage:
```yaml
keel.sh/policy: "newest:^[a-f0-9]{7}$"       # git short hashes
keel.sh/policy: "newest:^build-.*"             # build-prefixed tags
keel.sh/policy: "newest:.*"                    # any tag
```