### PR TITLE
Feature/image volume support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,7 @@ Set via `keel.sh/approvals: "2"` annotation to require N approvals.
 | `keel.sh/imagePullSecret` | Registry credentials secret | `my-registry-secret` |
 | `keel.sh/releaseNotes` | Release notes URL | `https://...` |
 | `keel.sh/initContainers` | Track init containers | `true` |
+| `keel.sh/imageVolumes` | Track OCI image volume sources (Kubernetes 1.31+) | `true` |
 
 ## Environment Variables
 

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -17,6 +17,23 @@ func getContainerImages(containers []core_v1.Container, filter ContainerFilter) 
 	return images
 }
 
+// getImageVolumeReferences returns the image references from OCI image volume
+// sources (spec.volumes[].image.reference). Non-image volumes and volumes with
+// an empty image reference are skipped.
+func getImageVolumeReferences(volumes []core_v1.Volume, filter VolumeFilter) []string {
+	var images []string
+	for _, v := range volumes {
+		if v.Image == nil || v.Image.Reference == "" {
+			continue
+		}
+		if filter != nil && !filter(v) {
+			continue
+		}
+		images = append(images, v.Image.Reference)
+	}
+	return images
+}
+
 func getImagePullSecrets(imagePullSecrets []core_v1.LocalObjectReference) []string {
 	var secrets []string
 	for _, s := range imagePullSecrets {
@@ -39,6 +56,10 @@ func updateDeploymentInitContainer(d *apps_v1.Deployment, index int, image strin
 	d.Spec.Template.Spec.InitContainers[index].Image = image
 }
 
+func updateDeploymentImageVolume(d *apps_v1.Deployment, index int, image string) {
+	d.Spec.Template.Spec.Volumes[index].Image.Reference = image
+}
+
 // stateful sets https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/
 
 func getStatefulSetIdentifier(ss *apps_v1.StatefulSet) string {
@@ -51,6 +72,10 @@ func updateStatefulSetContainer(ss *apps_v1.StatefulSet, index int, image string
 
 func updateStatefulSetInitContainer(ss *apps_v1.StatefulSet, index int, image string) {
 	ss.Spec.Template.Spec.InitContainers[index].Image = image
+}
+
+func updateStatefulSetImageVolume(ss *apps_v1.StatefulSet, index int, image string) {
+	ss.Spec.Template.Spec.Volumes[index].Image.Reference = image
 }
 
 // daemonsets
@@ -67,6 +92,10 @@ func updateDaemonsetSetInitContainer(s *apps_v1.DaemonSet, index int, image stri
 	s.Spec.Template.Spec.InitContainers[index].Image = image
 }
 
+func updateDaemonsetSetImageVolume(s *apps_v1.DaemonSet, index int, image string) {
+	s.Spec.Template.Spec.Volumes[index].Image.Reference = image
+}
+
 // cron
 
 func getCronJobIdentifier(s *batch_v1.CronJob) string {
@@ -79,4 +108,8 @@ func updateCronJobContainer(s *batch_v1.CronJob, index int, image string) {
 
 func updateCronJobInitContainer(s *batch_v1.CronJob, index int, image string) {
 	s.Spec.JobTemplate.Spec.Template.Spec.InitContainers[index].Image = image
+}
+
+func updateCronJobImageVolume(s *batch_v1.CronJob, index int, image string) {
+	s.Spec.JobTemplate.Spec.Template.Spec.Volumes[index].Image.Reference = image
 }

--- a/internal/k8s/resource.go
+++ b/internal/k8s/resource.go
@@ -25,6 +25,10 @@ type genericResource []*GenericResource
 
 type ContainerFilter func(container core_v1.Container) bool
 
+// VolumeFilter is invoked for every volume of a resource; volumes for which
+// it returns false are skipped when collecting image references.
+type VolumeFilter func(volume core_v1.Volume) bool
+
 func (c genericResource) Len() int {
 	return len(c)
 }
@@ -347,6 +351,43 @@ func (r *GenericResource) UpdateInitContainer(index int, image string) {
 		updateDaemonsetSetInitContainer(obj, index, image)
 	case *batch_v1.CronJob:
 		updateCronJobInitContainer(obj, index, image)
+	}
+}
+
+// Volumes - returns the pod volumes managed by this resource
+func (r *GenericResource) Volumes() (volumes []core_v1.Volume) {
+	switch obj := r.obj.(type) {
+	case *apps_v1.Deployment:
+		return obj.Spec.Template.Spec.Volumes
+	case *apps_v1.StatefulSet:
+		return obj.Spec.Template.Spec.Volumes
+	case *apps_v1.DaemonSet:
+		return obj.Spec.Template.Spec.Volumes
+	case *batch_v1.CronJob:
+		return obj.Spec.JobTemplate.Spec.Template.Spec.Volumes
+	}
+	return
+}
+
+// GetImageVolumeReferences returns the OCI image references mounted as
+// volumes (spec.volumes[].image.reference). Non-image volumes and volumes
+// with an empty reference are excluded.
+func (r *GenericResource) GetImageVolumeReferences(filter VolumeFilter) (images []string) {
+	return getImageVolumeReferences(r.Volumes(), filter)
+}
+
+// UpdateImageVolume - updates an OCI image volume reference at the given
+// index in spec.volumes. The volume at that index must have an Image source.
+func (r *GenericResource) UpdateImageVolume(index int, image string) {
+	switch obj := r.obj.(type) {
+	case *apps_v1.Deployment:
+		updateDeploymentImageVolume(obj, index, image)
+	case *apps_v1.StatefulSet:
+		updateStatefulSetImageVolume(obj, index, image)
+	case *apps_v1.DaemonSet:
+		updateDaemonsetSetImageVolume(obj, index, image)
+	case *batch_v1.CronJob:
+		updateCronJobImageVolume(obj, index, image)
 	}
 }
 

--- a/internal/k8s/resource_test.go
+++ b/internal/k8s/resource_test.go
@@ -190,6 +190,74 @@ func TestStatefulSetMultipleContainers(t *testing.T) {
 	}
 }
 
+func TestDeploymentImageVolume(t *testing.T) {
+	d := &apps_v1.Deployment{
+		meta_v1.TypeMeta{},
+		meta_v1.ObjectMeta{
+			Name:      "dep-1",
+			Namespace: "xxxx",
+		},
+		apps_v1.DeploymentSpec{
+			Template: core_v1.PodTemplateSpec{
+				Spec: core_v1.PodSpec{
+					Containers: []core_v1.Container{
+						{Image: "gcr.io/v2-namespace/hello-world:1.1.1"},
+					},
+					Volumes: []core_v1.Volume{
+						{
+							Name: "config",
+							VolumeSource: core_v1.VolumeSource{
+								ConfigMap: &core_v1.ConfigMapVolumeSource{},
+							},
+						},
+						{
+							Name: "oci-config",
+							VolumeSource: core_v1.VolumeSource{
+								Image: &core_v1.ImageVolumeSource{
+									Reference:  "gcr.io/v2-namespace/oci-config:1.0.0",
+									PullPolicy: core_v1.PullIfNotPresent,
+								},
+							},
+						},
+						{
+							Name: "oci-empty",
+							VolumeSource: core_v1.VolumeSource{
+								Image: &core_v1.ImageVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		apps_v1.DeploymentStatus{},
+	}
+
+	gr, err := NewGenericResource(d)
+	if err != nil {
+		t.Fatalf("failed to create generic resource: %s", err)
+	}
+
+	refs := gr.GetImageVolumeReferences(nil)
+	if len(refs) != 1 || refs[0] != "gcr.io/v2-namespace/oci-config:1.0.0" {
+		t.Fatalf("unexpected image volume references: %v", refs)
+	}
+
+	gr.UpdateImageVolume(1, "gcr.io/v2-namespace/oci-config:1.1.0")
+
+	updated, ok := gr.GetResource().(*apps_v1.Deployment)
+	if !ok {
+		t.Fatalf("conversion failed")
+	}
+	if got := updated.Spec.Template.Spec.Volumes[1].Image.Reference; got != "gcr.io/v2-namespace/oci-config:1.1.0" {
+		t.Errorf("unexpected updated reference: %s", got)
+	}
+
+	filter := func(v core_v1.Volume) bool { return v.Name == "config" }
+	if refs := gr.GetImageVolumeReferences(filter); len(refs) != 0 {
+		t.Errorf("expected zero references when filter excludes image volume, got %v", refs)
+	}
+}
+
 func TestDaemonsetlSetMultipleContainers(t *testing.T) {
 	d := &apps_v1.DaemonSet{
 		meta_v1.TypeMeta{},

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -210,6 +210,35 @@ func getInitContainerTrackingFromMeta(labels map[string]string, annotations map[
 	return false
 }
 
+func getImageVolumeTrackingFromMeta(labels map[string]string, annotations map[string]string) bool {
+
+	searchKey := strings.ToLower(types.KeelImageVolumeAnnotation)
+
+	for k, v := range labels {
+		if strings.ToLower(k) == searchKey {
+			return v == "true"
+		}
+	}
+
+	for k, v := range annotations {
+		if strings.ToLower(k) == searchKey {
+			return v == "true"
+		}
+	}
+
+	return false
+}
+
+// GetMonitorVolumesFromMeta returns a VolumeFilter that matches volume names
+// against the keel.sh/monitorContainers regex (shared with containers so a
+// single annotation governs all image references on the resource).
+func GetMonitorVolumesFromMeta(labels map[string]string, annotations map[string]string) k8s.VolumeFilter {
+	monitorRegex := getMonitorContainersFromMeta(labels, annotations)
+	return func(volume v1.Volume) bool {
+		return monitorRegex.MatchString(volume.Name)
+	}
+}
+
 // TrackedImages returns a list of tracked images.
 func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 	var trackedImages []*types.TrackedImage
@@ -257,6 +286,10 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 		images := gr.GetImages(filterFunc)
 		if getInitContainerTrackingFromMeta(labels, annotations) {
 			images = append(images, gr.GetInitImages(filterFunc)...)
+		}
+		if getImageVolumeTrackingFromMeta(labels, annotations) {
+			volumeFilter := GetMonitorVolumesFromMeta(annotations, labels)
+			images = append(images, gr.GetImageVolumeReferences(volumeFilter)...)
 		}
 
 		for _, img := range images {
@@ -345,10 +378,14 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 		notificationChannels := types.ParseEventNotificationChannels(annotations)
 		containerFilterFunction := GetMonitorContainersFromMeta(labels, annotations)
 		trackInitContainers := getInitContainerTrackingFromMeta(labels, annotations)
+		trackImageVolumes := getImageVolumeTrackingFromMeta(labels, annotations)
 
 		images := resource.GetImages(containerFilterFunction)
 		if trackInitContainers {
 			images = append(images, resource.GetInitImages(containerFilterFunction)...)
+		}
+		if trackImageVolumes {
+			images = append(images, resource.GetImageVolumeReferences(GetMonitorVolumesFromMeta(labels, annotations))...)
 		}
 
 		p.sender.Send(types.EventNotification{

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -396,6 +396,188 @@ func TestGetImpactedInit(t *testing.T) {
 
 }
 
+func TestGetImpactedImageVolume(t *testing.T) {
+	fp := &fakeImplementer{}
+	fp.namespaces = &v1.NamespaceList{
+		Items: []v1.Namespace{
+			{
+				meta_v1.TypeMeta{},
+				meta_v1.ObjectMeta{Name: "xxxx"},
+				v1.NamespaceSpec{},
+				v1.NamespaceStatus{},
+			},
+		},
+	}
+
+	deps := []*apps_v1.Deployment{
+		{
+			meta_v1.TypeMeta{},
+			meta_v1.ObjectMeta{
+				Name:        "dep-with-image-volume",
+				Namespace:   "xxxx",
+				Annotations: map[string]string{types.KeelImageVolumeAnnotation: "true"},
+				Labels:      map[string]string{types.KeelPolicyLabel: "all"},
+			},
+			apps_v1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Image: "gcr.io/v2-namespace/sidecar:1.0.0"},
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "oci-config",
+								VolumeSource: v1.VolumeSource{
+									Image: &v1.ImageVolumeSource{
+										Reference: "gcr.io/v2-namespace/hello-world:1.1.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			apps_v1.DeploymentStatus{},
+		},
+		{
+			meta_v1.TypeMeta{},
+			meta_v1.ObjectMeta{
+				Name:        "dep-without-annotation",
+				Namespace:   "xxxx",
+				Annotations: map[string]string{},
+				Labels:      map[string]string{types.KeelPolicyLabel: "all"},
+			},
+			apps_v1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Image: "gcr.io/v2-namespace/sidecar:1.0.0"},
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "oci-config",
+								VolumeSource: v1.VolumeSource{
+									Image: &v1.ImageVolumeSource{
+										Reference: "gcr.io/v2-namespace/hello-world:1.1.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			apps_v1.DeploymentStatus{},
+		},
+	}
+
+	grs := MustParseGRS(deps)
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, &fakeSender{}, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	repo := &types.Repository{
+		Name: "gcr.io/v2-namespace/hello-world",
+		Tag:  "1.1.2",
+	}
+
+	plans, err := provider.createUpdatePlans(repo)
+	if err != nil {
+		t.Errorf("failed to get deployments: %s", err)
+	}
+
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 update plan, got %d", len(plans))
+	}
+
+	if plans[0].Resource.Name != "dep-with-image-volume" {
+		t.Fatalf("unexpected resource updated: %s", plans[0].Resource.Name)
+	}
+
+	vols := plans[0].Resource.Volumes()
+	if len(vols) != 1 || vols[0].Image == nil {
+		t.Fatalf("expected one image volume, got %v", vols)
+	}
+	if got := vols[0].Image.Reference; got != "gcr.io/v2-namespace/hello-world:1.1.2" {
+		t.Errorf("expected updated image volume reference, got %s", got)
+	}
+}
+
+func TestTrackedImagesIncludeImageVolumes(t *testing.T) {
+	fp := &fakeImplementer{}
+	fp.namespaces = &v1.NamespaceList{
+		Items: []v1.Namespace{
+			{
+				meta_v1.TypeMeta{},
+				meta_v1.ObjectMeta{Name: "xxxx"},
+				v1.NamespaceSpec{},
+				v1.NamespaceStatus{},
+			},
+		},
+	}
+
+	dep := &apps_v1.Deployment{
+		meta_v1.TypeMeta{},
+		meta_v1.ObjectMeta{
+			Name:        "dep-1",
+			Namespace:   "xxxx",
+			Annotations: map[string]string{types.KeelImageVolumeAnnotation: "true"},
+			Labels:      map[string]string{types.KeelPolicyLabel: "all"},
+		},
+		apps_v1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Image: "gcr.io/v2-namespace/sidecar:1.0.0"},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "oci-config",
+							VolumeSource: v1.VolumeSource{
+								Image: &v1.ImageVolumeSource{
+									Reference: "gcr.io/v2-namespace/oci-config:1.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		apps_v1.DeploymentStatus{},
+	}
+
+	grs := MustParseGRS([]*apps_v1.Deployment{dep})
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, &fakeSender{}, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	tracked, err := provider.TrackedImages()
+	if err != nil {
+		t.Fatalf("failed to get tracked images: %s", err)
+	}
+
+	found := false
+	for _, ti := range tracked {
+		if ti.Image.Remote() == "gcr.io/v2-namespace/oci-config:1.0.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected image volume reference to be tracked; got %v", tracked)
+	}
+}
+
 func TestGetImpactedPolicyAnnotations(t *testing.T) {
 	fp := &fakeImplementer{}
 	fp.namespaces = &v1.NamespaceList{

--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -29,6 +29,76 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 	shouldUpdateDeployment = false
 
 	containerFilterFunc := GetMonitorContainersFromMeta(resource.GetAnnotations(), resource.GetLabels())
+	volumeFilterFunc := GetMonitorVolumesFromMeta(resource.GetAnnotations(), resource.GetLabels())
+
+	if track, ok := resource.GetAnnotations()[types.KeelImageVolumeAnnotation]; ok && track == "true" {
+		for idx, vol := range resource.Volumes() {
+			if vol.Image == nil || vol.Image.Reference == "" {
+				continue
+			}
+			if !volumeFilterFunc(vol) {
+				continue
+			}
+
+			volumeImageRef, err := image.Parse(vol.Image.Reference)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"error":      err,
+					"image_name": vol.Image.Reference,
+				}).Error("provider.kubernetes: failed to parse image volume reference")
+				continue
+			}
+
+			log.WithFields(log.Fields{
+				"name":              resource.Name,
+				"namespace":         resource.Namespace,
+				"kind":              resource.Kind(),
+				"volume":            vol.Name,
+				"parsed_image_name": volumeImageRef.Remote(),
+				"target_image_name": repo.Name,
+				"target_tag":        repo.Tag,
+				"policy":            plc.Name(),
+				"image":             vol.Image.Reference,
+			}).Debug("provider.kubernetes: checking image volume")
+
+			if volumeImageRef.Repository() != eventRepoRef.Repository() {
+				log.WithFields(log.Fields{
+					"parsed_image_name": volumeImageRef.Remote(),
+					"target_image_name": repo.Name,
+				}).Debug("provider.kubernetes: image volume reference does not match, ignoring")
+				continue
+			}
+
+			shouldUpdateVolume, err := plc.ShouldUpdate(volumeImageRef.Tag(), eventRepoRef.Tag())
+			if err != nil {
+				log.WithFields(log.Fields{
+					"error":             err,
+					"parsed_image_name": volumeImageRef.Remote(),
+					"target_image_name": repo.Name,
+					"policy":            plc.Name(),
+				}).Error("provider.kubernetes: failed to check whether image volume should be updated")
+				continue
+			}
+
+			if !shouldUpdateVolume {
+				continue
+			}
+
+			setUpdateTime(resource)
+
+			if volumeImageRef.Registry() == image.DefaultRegistryHostname {
+				resource.UpdateImageVolume(idx, fmt.Sprintf("%s:%s", volumeImageRef.ShortName(), repo.Tag))
+			} else {
+				resource.UpdateImageVolume(idx, fmt.Sprintf("%s:%s", volumeImageRef.Repository(), repo.Tag))
+			}
+
+			shouldUpdateDeployment = true
+
+			updatePlan.CurrentVersion = volumeImageRef.Tag()
+			updatePlan.NewVersion = repo.Tag
+			updatePlan.Resource = resource
+		}
+	}
 
 	if schedule, ok := resource.GetAnnotations()[types.KeelInitContainerAnnotation]; ok && schedule == "true" {
 		for idx, c := range resource.InitContainers() {

--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,35 @@ spec:
 
 No additional configuration is required. Enabling continuous delivery for your workloads has never been this easy!
 
+#### Tracking OCI image volumes (Kubernetes 1.31+)
+
+Keel can also watch and update [OCI image volume sources](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
+(`spec.volumes[].image.reference`). It is opt-in per resource, mirroring
+`keel.sh/initContainers`:
+
+```yaml
+metadata:
+  annotations:
+    keel.sh/policy: minor
+    keel.sh/imageVolumes: "true" # <-- also track image volume references
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: karolisr/webhook-demo:0.0.8
+          volumeMounts:
+            - name: oci-config
+              mountPath: /etc/config
+      volumes:
+        - name: oci-config
+          image:
+            reference: karolisr/webhook-demo:0.0.8
+            pullPolicy: IfNotPresent
+```
+
+Requires the `ImageVolume` feature gate on your cluster.
+
 ### Documentation
 
 Documentation is viewable on the Keel Website:

--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,11 @@ const KeelPollScheduleAnnotation = "keel.sh/pollSchedule"
 // KeelInitContainerAnnotation - label or annotation to track init containers, defaults to false for backward compatibility
 const KeelInitContainerAnnotation = "keel.sh/initContainers"
 
+// KeelImageVolumeAnnotation - label or annotation to track OCI image volume
+// sources (spec.volumes[].image.reference), defaults to false for backward
+// compatibility. Requires Kubernetes 1.31+ with the ImageVolume feature gate.
+const KeelImageVolumeAnnotation = "keel.sh/imageVolumes"
+
 // KeelMonitorContainers - you can only have one keel settings per object type, but some of them might have multiple containers. Use this setting to
 // specify with a regular expression which containers should be monitored. If empty, all containers will be monitored.
 // It is currently a limitation that all containers in the same object will share the same configuration (pollSchedule, etc.).


### PR DESCRIPTION
## Summary

Implements #849 — adds opt-in support for tracking and updating
[OCI image volume sources](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
(`spec.volumes[].image.reference`, Kubernetes 1.31+ with the
`ImageVolume` feature gate).

- New annotation `keel.sh/imageVolumes: "true"` — mirrors the existing
  `keel.sh/initContainers` annotation (off by default, set per-resource).
- Volume names are filtered with the existing
  `keel.sh/monitorContainers` regex, so one annotation governs all image
  references on the resource (containers + init containers + image
  volumes).
- Supported on Deployments, StatefulSets, DaemonSets and CronJobs via
  the existing `GenericResource` abstraction.

### Example

```yaml
metadata:
  annotations:
    keel.sh/policy: minor
    keel.sh/imageVolumes: "true"
spec:
  template:
    spec:
      containers:
        - name: app
          image: karolisr/webhook-demo:0.0.8
          volumeMounts:
            - { name: oci-config, mountPath: /etc/config }
      volumes:
        - name: oci-config
          image:
            reference: karolisr/webhook-demo:0.0.8
            pullPolicy: IfNotPresent
```

### Files changed

- `types/types.go` — new `KeelImageVolumeAnnotation` constant
- `internal/k8s/{resource,converter}.go` — `VolumeFilter` type plus
  `Volumes()`, `GetImageVolumeReferences()`, `UpdateImageVolume()` on
  `GenericResource`, wired through all four supported kinds
- `provider/kubernetes/kubernetes.go` — `getImageVolumeTrackingFromMeta`
  + `GetMonitorVolumesFromMeta`; `TrackedImages()` and
  `updateDeployments()` include image-volume references when the
  annotation is set
- `provider/kubernetes/updates.go` — new loop in `checkForUpdate` that
  parses each image volume reference, applies the policy, and rewrites
  it in place
- `ARCHITECTURE.md` + `readme.md` — documentation for the new
  annotation

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (no new warnings)
- [x] `go test ./internal/k8s/... ./provider/kubernetes/...` passes
- [x] New unit tests cover both `TrackedImages` discovery and the
  `checkForUpdate` rewrite path for image volumes (resource_test.go,
  kubernetes_test.go)
- [ ] Manual verification on a Kubernetes 1.31+ cluster with the
  `ImageVolume` feature gate enabled

Closes #849
