### PR TITLE
fix(notification): accept all 2xx status codes in webhook notifiers

### DIFF
--- a/extension/notification/discord/discord.go
+++ b/extension/notification/discord/discord.go
@@ -97,9 +97,9 @@ func (s *sender) Send(event types.EventNotification) error {
 	}
 
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonMessage))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 204) {
+	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/204", resp.StatusCode)
+			return fmt.Errorf("got status %d, expected 2xx", resp.StatusCode)
 		}
 		return err
 	}

--- a/extension/notification/mattermost/mattermost.go
+++ b/extension/notification/mattermost/mattermost.go
@@ -100,9 +100,9 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
+	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201", resp.StatusCode)
+			return fmt.Errorf("got status %d, expected 2xx", resp.StatusCode)
 		}
 		return err
 	}

--- a/extension/notification/teams/teams.go
+++ b/extension/notification/teams/teams.go
@@ -130,9 +130,9 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 202) {
+	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201/202", resp.StatusCode)
+			return fmt.Errorf("got status %d, expected 2xx", resp.StatusCode)
 		}
 		return err
 	}

--- a/extension/notification/webhook/webhook.go
+++ b/extension/notification/webhook/webhook.go
@@ -78,9 +78,9 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
+	if err != nil || resp == nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201", resp.StatusCode)
+			return fmt.Errorf("got status %d, expected 2xx", resp.StatusCode)
 		}
 		return err
 	}

--- a/extension/notification/webhook/webhook_test.go
+++ b/extension/notification/webhook/webhook_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,4 +57,56 @@ func TestWebhookRequest(t *testing.T) {
 		Type:      types.NotificationPreDeploymentUpdate,
 		Level:     types.LevelDebug,
 	})
+}
+
+func TestWebhookAccepts2xxStatusCodes(t *testing.T) {
+	for _, code := range []int{200, 201, 202, 204} {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer ts.Close()
+
+			s := &sender{
+				endpoint: ts.URL,
+				client:   &http.Client{},
+			}
+
+			err := s.Send(types.EventNotification{
+				Name:    "test",
+				Message: "test",
+				Type:    types.NotificationPreDeploymentUpdate,
+				Level:   types.LevelDebug,
+			})
+			if err != nil {
+				t.Errorf("expected status %d to be accepted, got error: %v", code, err)
+			}
+		})
+	}
+}
+
+func TestWebhookRejectsNon2xxStatusCodes(t *testing.T) {
+	for _, code := range []int{400, 500} {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer ts.Close()
+
+			s := &sender{
+				endpoint: ts.URL,
+				client:   &http.Client{},
+			}
+
+			err := s.Send(types.EventNotification{
+				Name:    "test",
+				Message: "test",
+				Type:    types.NotificationPreDeploymentUpdate,
+				Level:   types.LevelDebug,
+			})
+			if err == nil {
+				t.Errorf("expected status %d to be rejected, got no error", code)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Webhook, mattermost, and discord notifiers only accept specific HTTP status codes (200/201 or 200/204), rejecting valid 2xx responses like 202 Accepted. Teams already accepts 202 but uses explicit enumeration. Changed all notifiers to accept any 2xx status code (200-299) per HTTP semantics, and added tests verifying 200/201/202/204 are accepted while 400/500 are rejected.

Fixes #827