### PR TITLE
Guard resp.Body.Close against a nil http.Response

### DIFF
--- a/registry/docker/json.go
+++ b/registry/docker/json.go
@@ -38,7 +38,9 @@ func (r *Registry) getPaginatedJSON(url string, response interface{}) (string, e
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(response)

--- a/trigger/pubsub/util.go
+++ b/trigger/pubsub/util.go
@@ -42,7 +42,9 @@ func getClusterName(metadataEndpoint string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
`Client.Get` and `Client.Do` return a nil `*http.Response` alongside the error when the request never completes (DNS failure, connection refused, timeout), so the deferred `resp.Body.Close()` dereferences a nil pointer and panics. Both call sites now close the body only when `resp` is non-nil, matching the guard already used in `registry.go`.