### PR TITLE
Align image-volume opt-in updates

### DIFF
--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -31,7 +31,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 	containerFilterFunc := GetMonitorContainersFromMeta(resource.GetAnnotations(), resource.GetLabels())
 	volumeFilterFunc := GetMonitorVolumesFromMeta(resource.GetAnnotations(), resource.GetLabels())
 
-	if track, ok := resource.GetAnnotations()[types.KeelImageVolumeAnnotation]; ok && track == "true" {
+	if getImageVolumeTrackingFromMeta(resource.GetLabels(), resource.GetAnnotations()) {
 		for idx, vol := range resource.Volumes() {
 			if vol.Image == nil || vol.Image.Reference == "" {
 				continue

--- a/provider/kubernetes/updates_test.go
+++ b/provider/kubernetes/updates_test.go
@@ -23,6 +23,94 @@ func mustParseGlob(str string) policy.Policy {
 	return p
 }
 
+func TestProvider_checkForUpdateImageVolumeOptIn(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		wantUpdate  bool
+	}{
+		{
+			name:       "canonical label only",
+			labels:     map[string]string{types.KeelImageVolumeAnnotation: "true"},
+			wantUpdate: true,
+		},
+		{
+			name:        "case variant annotation",
+			annotations: map[string]string{"Keel.sh/ImageVolumes": "true"},
+			wantUpdate:  true,
+		},
+		{
+			name:        "canonical annotation",
+			annotations: map[string]string{types.KeelImageVolumeAnnotation: "true"},
+			wantUpdate:  true,
+		},
+		{
+			name:       "no opt-in",
+			labels:     map[string]string{},
+			wantUpdate: false,
+		},
+		{
+			name:        "label takes precedence over annotation",
+			labels:      map[string]string{types.KeelImageVolumeAnnotation: "false"},
+			annotations: map[string]string{types.KeelImageVolumeAnnotation: "true"},
+			wantUpdate:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := MustParseGR(&apps_v1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:        "dep-1",
+					Namespace:   "xxxx",
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+				Spec: apps_v1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name: "oci-config",
+									VolumeSource: v1.VolumeSource{
+										Image: &v1.ImageVolumeSource{
+											Reference: "gcr.io/v2-namespace/hello-world:1.1.1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			plan, updated, err := checkForUpdate(
+				policy.NewForcePolicy(false),
+				&types.Repository{Name: "gcr.io/v2-namespace/hello-world", Tag: "1.1.2"},
+				resource,
+			)
+			if err != nil {
+				t.Fatalf("checkForUpdate() error = %v", err)
+			}
+			if updated != tt.wantUpdate {
+				t.Fatalf("checkForUpdate() updated = %v, want %v", updated, tt.wantUpdate)
+			}
+
+			wantReference := "gcr.io/v2-namespace/hello-world:1.1.1"
+			if tt.wantUpdate {
+				wantReference = "gcr.io/v2-namespace/hello-world:1.1.2"
+				if plan.Resource != resource {
+					t.Errorf("checkForUpdate() did not return the updated resource")
+				}
+			}
+			if got := resource.Volumes()[0].Image.Reference; got != wantReference {
+				t.Errorf("image volume reference = %q, want %q", got, wantReference)
+			}
+		})
+	}
+}
+
 func TestProvider_checkForUpdate(t *testing.T) {
 
 	timeutil.Now = func() time.Time {

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,16 @@ spec:
             pullPolicy: IfNotPresent
 ```
 
-Requires the `ImageVolume` feature gate on your cluster.
+Image volumes require Kubernetes 1.31 or later and a container runtime that
+supports image volumes. Kubernetes compatibility is:
+
+- 1.31-1.34: the `ImageVolume` feature gate must be explicitly enabled;
+- 1.35: the feature is beta and enabled by default;
+- 1.36+: the feature is stable (GA).
+
+See the official Kubernetes [feature-gate table](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+and [image-volume documentation](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
+for cluster configuration details.
 
 ### Documentation
 

--- a/types/types.go
+++ b/types/types.go
@@ -45,7 +45,8 @@ const KeelInitContainerAnnotation = "keel.sh/initContainers"
 
 // KeelImageVolumeAnnotation - label or annotation to track OCI image volume
 // sources (spec.volumes[].image.reference), defaults to false for backward
-// compatibility. Requires Kubernetes 1.31+ with the ImageVolume feature gate.
+// compatibility. Requires Kubernetes 1.31+ and container-runtime image-volume
+// support; ImageVolume feature-gate defaults vary by Kubernetes version.
 const KeelImageVolumeAnnotation = "keel.sh/imageVolumes"
 
 // KeelMonitorContainers - you can only have one keel settings per object type, but some of them might have multiple containers. Use this setting to


### PR DESCRIPTION
## Summary

Make image-volume rewrites honor the same label and case-insensitive annotation opt-ins used during discovery, and correct Kubernetes compatibility guidance.

## Changes

- Reuse the existing metadata helper in `checkForUpdate` with label-first precedence.
- Add update-path regressions for label-only, case-variant, annotation, disabled, and precedence cases.
- Document the Kubernetes 1.31-1.34, 1.35, and 1.36+ feature states and runtime requirement.

## Testing

- `gofmt` on changed Go files.
- Focused `provider/kubernetes` update tests pass.
- `internal/k8s` tests pass.
- `go test ./... -run '^$'` passes all-package compilation.
- Full provider and repository test execution is blocked by the existing SQLite fixture because this environment has `CGO_ENABLED=0` and no C compiler; `go-sqlite3` cannot start.
