### PR TITLE
Upgrade Keel to Go 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26.5"
 
       - name: Run tests
         run: make test
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26.5"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-alpine AS go-build
+FROM golang:1.26.5-alpine AS go-build
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM golang:1.23.4
+FROM golang:1.26.5
 COPY . /go/src/github.com/keel-hq/keel
 WORKDIR /go/src/github.com/keel-hq/keel
 RUN make build

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:1.23.4
+FROM golang:1.26.5
 COPY . /go/src/github.com/keel-hq/keel
 WORKDIR /go/src/github.com/keel-hq/keel
 RUN make install-debug
@@ -10,7 +10,7 @@ RUN yarn
 RUN yarn run lint --no-fix
 RUN yarn run build
 
-FROM golang:1.22.8
+FROM golang:1.26.5
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM golang:1.23.4
+FROM golang:1.26.5
 
 # Install tparse and go-junit-report
 RUN go install github.com/mfridman/tparse@latest && \

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Go 1.23
+- Go 1.26.5
 - GNU Make
 - Docker (for OpenAPI Generator v7.22.0 and Spectral v6.16.1)
 - Node.js 16.20 and Yarn 1.x for UI verification

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keel-hq/keel
 
-go 1.23
+go 1.26.5
 
 replace (
 	k8s.io/api => k8s.io/api v0.31.3

--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ We use pull requests, so:
 
 ### Developing Keel
 
-If you wish to work on Keel itself, you will need Go 1.12+ installed. Make sure you put Keel into correct Gopath and `go build` (dependency management is done through [dep](https://github.com/golang/dep)). 
+If you wish to work on Keel itself, install Go 1.26.5 and use the module-based build from this repository checkout.
 
 To test Keel while developing:
 


### PR DESCRIPTION
## Summary

Upgrade Keel's active Go toolchain declarations to the latest stable Go 1.26 patch, verified as 1.26.5 in the official Go releases feed.

## Changes

- Pin Go 1.26.5 in `go.mod`, GitHub Actions, and all active Go-based Docker stages.
- Update contributor prerequisites and replace obsolete GOPATH/dep guidance with the existing module workflow.
- Leave dependencies, application source, generated artifacts, and historical webhook payload fixtures unchanged.

## Testing

- Passed Go 1.26.5 package compilation, binary build, focused API contract testing, pinned API regeneration/lint, and clean generated-artifact checks.
- Passed the default `linux/amd64` and `linux/arm64` image build plus AMD64 debug and test image builds.
- Full tests require CGO and an unavailable C compiler; e2e requires an unavailable Kubernetes cluster. Existing formatting/vet findings remain outside this change.
- The Debian image reaches its Go 1.26.5 builder but its unchanged runtime stage fails because `debian:latest` lacks `addgroup`.

