### PR TITLE
Honor webhook-only trigger without polling rollback

### DIFF
--- a/.test/e2e-k3s.sh
+++ b/.test/e2e-k3s.sh
@@ -282,7 +282,10 @@ seed_fixture_repositories() {
   for destination in \
     "${RUN_ID}/webhook:1.0.0" "${RUN_ID}/webhook:1.0.1" \
     "${RUN_ID}/polling:1.0.0" "${RUN_ID}/polling:1.0.1" \
-    "${RUN_ID}/negative:1.0.0" "${RUN_ID}/negative:1.1.0"; do
+    "${RUN_ID}/negative:1.0.0" "${RUN_ID}/negative:1.1.0" \
+    "${RUN_ID}/webhook-regression:main_0000000000000000000000000000000000000000" \
+    "${RUN_ID}/webhook-regression:main_1111111111111111111111111111111111111111" \
+    "${RUN_ID}/webhook-regression:main_ffffffffffffffffffffffffffffffffffffffff"; do
     ctr images tag "${FIXTURE_IMAGE}" "${REGISTRY_ADDRESS}/${destination}"
     ctr images push --plain-http "${REGISTRY_ADDRESS}/${destination}"
   done

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -349,7 +349,7 @@ func (p *Provider) startInternal() error {
 }
 
 func (p *Provider) processEvent(event *types.Event) (updated []*k8s.GenericResource, err error) {
-	plans, err := p.createUpdatePlans(&event.Repository)
+	plans, err := p.createUpdatePlansForEvent(event)
 	if err != nil {
 		return nil, err
 	}
@@ -522,12 +522,26 @@ func getDesiredImage(delta map[string]string, currentImage string) (string, erro
 
 // createUpdatePlans - impacted deployments by changed repository
 func (p *Provider) createUpdatePlans(repo *types.Repository) ([]*UpdatePlan, error) {
+	return p.createUpdatePlansForTrigger(repo, "")
+}
+
+func (p *Provider) createUpdatePlansForEvent(event *types.Event) ([]*UpdatePlan, error) {
+	return p.createUpdatePlansForTrigger(&event.Repository, event.TriggerName)
+}
+
+func (p *Provider) createUpdatePlansForTrigger(repo *types.Repository, triggerName string) ([]*UpdatePlan, error) {
 	impacted := []*UpdatePlan{}
 
 	for _, resource := range p.cache.Values() {
 
 		labels := resource.GetLabels()
 		annotations := resource.GetAnnotations()
+		// Poll events are broadcast by repository, so apply them only to the
+		// resources that explicitly opted into polling.
+		if triggerName == types.TriggerTypePoll.String() &&
+			policies.GetTriggerPolicy(labels, annotations) != types.TriggerTypePoll {
+			continue
+		}
 
 		plc := policy.GetPolicyFromLabelsOrAnnotations(labels, annotations)
 		if plc.Type() == types.PolicyTypeNone {

--- a/provider/kubernetes/trigger_regression_test.go
+++ b/provider/kubernetes/trigger_regression_test.go
@@ -1,0 +1,182 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	regressionRepository = "registry.example.com/team/app"
+	regressionInitialTag = "main_0000000000000000000000000000000000000000"
+	regressionWebhookTag = "main_1111111111111111111111111111111111111111"
+	regressionPollTag    = "main_ffffffffffffffffffffffffffffffffffffffff"
+	regressionPolicy     = `regexp:^main_[a-fA-F0-9]{40}$`
+)
+
+func regressionStatefulSet(trigger string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-statefulset",
+			Namespace: "default",
+			Annotations: map[string]string{
+				types.KeelPolicyLabel:             regressionPolicy,
+				types.KeelTriggerLabel:            trigger,
+				types.KeelInitContainerAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "tracked-init", Image: regressionRepository + ":" + regressionInitialTag}},
+			Containers:     []corev1.Container{{Name: "app", Image: "busybox:1.36"}},
+		}}},
+	}
+}
+
+func regressionDeployment(trigger string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "poll-deployment",
+			Namespace: "default",
+			Annotations: map[string]string{
+				types.KeelPolicyLabel:  regressionPolicy,
+				types.KeelTriggerLabel: trigger,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: regressionRepository + ":" + regressionInitialTag}},
+		}}},
+	}
+}
+
+func TestWebhookStatefulSetInitContainerIsNotRolledBackByPollEvent(t *testing.T) {
+	statefulSet, err := k8s.NewGenericResource(regressionStatefulSet("webhook"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pollDeployment, err := k8s.NewGenericResource(regressionDeployment("poll"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := &k8s.GenericResourceCache{}
+	cache.Add(statefulSet, pollDeployment)
+	approvalsManager, teardown := approver()
+	defer teardown()
+	implementer := &fakeImplementer{}
+	p, err := NewProvider(implementer, &fakeSender{}, approvalsManager, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	webhookUpdated, err := p.processEvent(&types.Event{
+		Repository:  types.Repository{Name: regressionRepository, Tag: regressionWebhookTag},
+		TriggerName: "native",
+	})
+	if err != nil {
+		t.Fatalf("webhook processEvent() error = %v", err)
+	}
+	if got := len(webhookUpdated); got != 2 {
+		t.Fatalf("webhook updated %d resources, want 2", got)
+	}
+	cache.Add(webhookUpdated...) // informer resync after the webhook update
+
+	pollUpdated, err := p.processEvent(&types.Event{
+		Repository:  types.Repository{Name: regressionRepository, Tag: regressionPollTag},
+		TriggerName: types.TriggerTypePoll.String(),
+	})
+	if err != nil {
+		t.Fatalf("poll processEvent() error = %v", err)
+	}
+	if got := len(pollUpdated); got != 1 {
+		t.Fatalf("poll updated %d resources, want only the explicit poll resource", got)
+	}
+	if got := pollUpdated[0].Name; got != "poll-deployment" {
+		t.Fatalf("poll updated %q, want poll-deployment", got)
+	}
+
+	for _, resource := range cache.Values() {
+		if resource.Name != "webhook-statefulset" {
+			continue
+		}
+		if got, want := resource.InitContainers()[0].Image, regressionRepository+":"+regressionWebhookTag; got != want {
+			t.Fatalf("webhook-selected init image changed after poll/resync: got %q, want %q", got, want)
+		}
+		return
+	}
+	t.Fatal("webhook StatefulSet missing from cache")
+}
+
+func TestPollEventTriggerIsolationAcrossWorkloadKinds(t *testing.T) {
+	workloads := map[string]func(metav1.ObjectMeta, corev1.PodSpec) interface{}{
+		"deployment": func(meta metav1.ObjectMeta, podSpec corev1.PodSpec) interface{} {
+			return &appsv1.Deployment{ObjectMeta: meta, Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+		},
+		"statefulset": func(meta metav1.ObjectMeta, podSpec corev1.PodSpec) interface{} {
+			return &appsv1.StatefulSet{ObjectMeta: meta, Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+		},
+		"daemonset": func(meta metav1.ObjectMeta, podSpec corev1.PodSpec) interface{} {
+			return &appsv1.DaemonSet{ObjectMeta: meta, Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+		},
+		"cronjob": func(meta metav1.ObjectMeta, podSpec corev1.PodSpec) interface{} {
+			return &batchv1.CronJob{ObjectMeta: meta, Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}}
+		},
+	}
+
+	for kind, workload := range workloads {
+		for _, tt := range []struct {
+			trigger string
+			want    int
+		}{{trigger: "webhook", want: 0}, {trigger: "poll", want: 1}} {
+			t.Run(kind+"/"+tt.trigger, func(t *testing.T) {
+				meta := metav1.ObjectMeta{
+					Name:      kind + "-" + tt.trigger,
+					Namespace: "default",
+					Annotations: map[string]string{
+						types.KeelPolicyLabel:             regressionPolicy,
+						types.KeelTriggerLabel:            tt.trigger,
+						types.KeelInitContainerAnnotation: "true",
+					},
+				}
+				podSpec := corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init", Image: regressionRepository + ":" + regressionInitialTag}},
+					Containers:     []corev1.Container{{Name: "app", Image: regressionRepository + ":" + regressionInitialTag}},
+				}
+				resource, err := k8s.NewGenericResource(workload(meta, podSpec))
+				if err != nil {
+					t.Fatal(err)
+				}
+				cache := &k8s.GenericResourceCache{}
+				cache.Add(resource)
+				p, err := NewProvider(&fakeImplementer{}, &fakeSender{}, nil, cache)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				plans, err := p.createUpdatePlansForEvent(&types.Event{
+					Repository:  types.Repository{Name: regressionRepository, Tag: regressionPollTag},
+					TriggerName: types.TriggerTypePoll.String(),
+				})
+				if err != nil {
+					t.Fatalf("createUpdatePlansForEvent() error = %v", err)
+				}
+				if got := len(plans); got != tt.want {
+					t.Fatalf("poll plans = %d, want %d", got, tt.want)
+				}
+				if tt.want == 0 {
+					return
+				}
+				wantImage := regressionRepository + ":" + regressionPollTag
+				if got := plans[0].Resource.Containers()[0].Image; got != wantImage {
+					t.Fatalf("standard container image = %q, want %q", got, wantImage)
+				}
+				if got := plans[0].Resource.InitContainers()[0].Image; got != wantImage {
+					t.Fatalf("init container image = %q, want %q", got, wantImage)
+				}
+			})
+		}
+	}
+}

--- a/tests/e2e_helpers_test.go
+++ b/tests/e2e_helpers_test.go
@@ -148,6 +148,57 @@ func ensureDeploymentImageUnchanged(ctx context.Context, client kubernetes.Inter
 	}
 }
 
+func waitForStatefulSetInitImage(ctx context.Context, client kubernetes.Interface, namespace, name, desired string) error {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	last := "<not observed>"
+	for {
+		statefulSet, err := client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err == nil && len(statefulSet.Spec.Template.Spec.InitContainers) > 0 {
+			last = statefulSet.Spec.Template.Spec.InitContainers[0].Image
+			if last == desired {
+				return nil
+			}
+		} else if err != nil {
+			last = "get error: " + err.Error()
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("statefulset %s/%s: expected init image %q; last observed %q: %w", namespace, name, desired, last, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func ensureStatefulSetInitImageUnchanged(ctx context.Context, client kubernetes.Interface, namespace, name, expected string) error {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	last := "<not observed>"
+	for {
+		statefulSet, err := client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if ctx.Err() == nil {
+				last = "get error: " + err.Error()
+			}
+		} else if len(statefulSet.Spec.Template.Spec.InitContainers) == 0 {
+			last = "statefulset has no init containers"
+		} else {
+			last = statefulSet.Spec.Template.Spec.InitContainers[0].Image
+			if last != expected {
+				return fmt.Errorf("statefulset %s/%s: expected init image to remain %q; observed %q", namespace, name, expected, last)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded && last == expected {
+				return nil
+			}
+			return fmt.Errorf("statefulset %s/%s: could not verify unchanged init image %q; last observed %q: %w", namespace, name, expected, last, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
 func (s *E2ESuite) requireRegistryTags(repository string, expected ...string) {
 	response, err := (&http.Client{Timeout: 5 * time.Second}).Get("http://" + s.cfg.registry + "/v2/" + s.cfg.runID + "/" + repository + "/tags/list")
 	s.Require().NoError(err, "query tags for isolated repository %s", repository)

--- a/tests/e2e_scenarios_test.go
+++ b/tests/e2e_scenarios_test.go
@@ -82,9 +82,99 @@ func (s *E2ESuite) TestPollingRejectsIneligibleImage() {
 	s.Require().NoError(ensureDeploymentImageUnchanged(ctx, s.client, s.testNamespace, "negative", current))
 }
 
+func (s *E2ESuite) TestWebhookStatefulSetInitContainerRemainsIsolatedFromPolling() {
+	const (
+		initialTag = "main_0000000000000000000000000000000000000000"
+		webhookTag = "main_1111111111111111111111111111111111111111"
+		pollTag    = "main_ffffffffffffffffffffffffffffffffffffffff"
+		policy     = `regexp:^main_[a-fA-F0-9]{40}$`
+	)
+	s.requireRegistryTags("webhook-regression", initialTag, webhookTag, pollTag)
+	repository := s.cfg.repositoryPrefix + "/webhook-regression"
+	initial := repository + ":" + initialTag
+	webhookSelected := repository + ":" + webhookTag
+	pollSelected := repository + ":" + pollTag
+
+	labels := map[string]string{"app": "webhook-regression", e2eRunLabel: s.cfg.runID}
+	_, err := s.client.AppsV1().StatefulSets(s.testNamespace).Create(context.Background(), &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-regression",
+			Namespace: s.testNamespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				types.KeelPolicyLabel:             policy,
+				types.KeelTriggerLabel:            "webhook",
+				types.KeelInitContainerAnnotation: "true",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			ServiceName: "webhook-regression",
+			Replicas:    ptrTo(int32(1)),
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name:    "tracked-init",
+						Image:   initial,
+						Command: []string{"sh", "-c", "true"},
+					}},
+					Containers: []corev1.Container{{
+						Name:    "fixture",
+						Image:   initial,
+						Command: []string{"sh", "-c", "sleep 3600"},
+					}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+
+	// A legitimate poll consumer shares the repository. Its watcher must not
+	// select tags for, or apply poll events to, the webhook-only StatefulSet.
+	s.createWorkload("webhook-regression-poll", initial, policy, true)
+
+	payload := map[string]any{"events": []map[string]any{{
+		"action":  "push",
+		"target":  map[string]any{"repository": s.cfg.runID + "/webhook-regression", "tag": webhookTag, "digest": "sha256:e2e"},
+		"request": map[string]any{"host": s.cfg.registry},
+	}}}
+	body, err := json.Marshal(payload)
+	s.Require().NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	for {
+		response, postErr := http.Post(keelForwardURL+"/v1/webhooks/registry", "application/json", bytes.NewReader(body))
+		if postErr == nil {
+			_ = response.Body.Close()
+		}
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, 3*time.Second)
+		waitErr := waitForStatefulSetInitImage(attemptCtx, s.client, s.testNamespace, "webhook-regression", webhookSelected)
+		attemptCancel()
+		if waitErr == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			s.Require().NoError(waitErr)
+		case <-time.After(time.Second):
+		}
+	}
+
+	s.Require().NoError(waitForDeploymentImage(ctx, s.client, s.testNamespace, "webhook-regression-poll", pollSelected))
+	unchangedCtx, unchangedCancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer unchangedCancel()
+	s.Require().NoError(ensureStatefulSetInitImageUnchanged(unchangedCtx, s.client, s.testNamespace, "webhook-regression", webhookSelected))
+	s.T().Logf("poll control advanced to %s while webhook StatefulSet init image remained %s", pollSelected, webhookSelected)
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
+}
+
 func (s *E2ESuite) createWorkload(name, image, policy string, polling bool) {
-	labels := map[string]string{"app": name, types.KeelPolicyLabel: policy, e2eRunLabel: s.cfg.runID}
-	annotations := map[string]string{}
+	labels := map[string]string{"app": name, e2eRunLabel: s.cfg.runID}
+	annotations := map[string]string{types.KeelPolicyLabel: policy}
 	if polling {
 		labels[types.KeelTriggerLabel] = "poll"
 		annotations[types.KeelPollScheduleAnnotation] = "@every 2s"

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -146,9 +146,12 @@ func exists(tag string, events []types.Event) bool {
 }
 
 func getRelatedTrackedImages(ours *types.TrackedImage, all []*types.TrackedImage) []*types.TrackedImage {
-	b := all[:0]
+	b := make([]*types.TrackedImage, 0, len(all))
 	for _, x := range all {
-		if getImageIdentifier(x.Image, x.Policy.KeepTag()) == getImageIdentifier(ours.Image, ours.Policy.KeepTag()) {
+		// A repository watcher may be shared, but webhook consumers must not
+		// influence the tag selected by its polling job.
+		if x.Trigger == types.TriggerTypePoll &&
+			getImageIdentifier(x.Image, x.Policy.KeepTag()) == getImageIdentifier(ours.Image, ours.Policy.KeepTag()) {
 			b = append(b, x)
 		}
 	}

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -72,8 +72,9 @@ func testRunHelper(testCases []runTestCase, availableTags []string, t *testing.T
 	for _, testCase := range testCases {
 		reference, _ := image.Parse("foo/bar:" + testCase.currentTag)
 		testImages = append(testImages, &types.TrackedImage{
-			Image:  reference,
-			Policy: testCase.bumpPolicy,
+			Image:   reference,
+			Trigger: types.TriggerTypePoll,
+			Policy:  testCase.bumpPolicy,
 		})
 	}
 	fp := &fakeProvider{

--- a/trigger/poll/trigger_regression_test.go
+++ b/trigger/poll/trigger_regression_test.go
@@ -1,0 +1,104 @@
+package poll
+
+import (
+	"testing"
+
+	"github.com/keel-hq/keel/approvals"
+	"github.com/keel-hq/keel/internal/policy"
+	"github.com/keel-hq/keel/provider"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+func trackedImageForTrigger(t *testing.T, name string, trigger types.TriggerType, imagePolicy policy.Policy) *types.TrackedImage {
+	t.Helper()
+	ref, err := image.Parse(name)
+	if err != nil {
+		t.Fatalf("parse image %q: %v", name, err)
+	}
+	return &types.TrackedImage{
+		Image:        ref,
+		PollSchedule: "@every 10m",
+		Trigger:      trigger,
+		Provider:     "fakeProvider",
+		Policy:       imagePolicy,
+	}
+}
+
+func TestRepositoryWatcherDoesNotRegisterWebhookOnlyImage(t *testing.T) {
+	regexpPolicy, err := policy.NewRegexpPolicy(`regexp:^main_[a-fA-F0-9]{40}$`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	webhookImage := trackedImageForTrigger(t,
+		"registry.example.com/team/app:main_0000000000000000000000000000000000000000",
+		types.TriggerTypeDefault,
+		regexpPolicy,
+	)
+	fp := &fakeProvider{images: []*types.TrackedImage{webhookImage}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{digestToReturn: "sha256:current"}
+	watcher := NewRepositoryWatcher(providers, registryClient)
+
+	for range 2 { // initial scan plus a resource resync/restart scan
+		if err := watcher.Watch(fp.images...); err != nil {
+			t.Fatalf("Watch() error = %v", err)
+		}
+	}
+
+	if got := len(watcher.watched); got != 0 {
+		t.Fatalf("registered %d polling watcher(s) for webhook-only image", got)
+	}
+	if registryClient.digestCalls != 0 || registryClient.getCalls != 0 {
+		t.Fatalf("webhook-only image executed registry polling: digest=%d get=%d", registryClient.digestCalls, registryClient.getCalls)
+	}
+}
+
+func TestRepositoryWatcherSharedRepositoryUsesOnlyPollingConsumers(t *testing.T) {
+	webhookPolicy, err := policy.NewRegexpPolicy(`regexp:^main_f{40}$`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pollPolicy, err := policy.NewRegexpPolicy(`regexp:^main_1{40}$`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	webhookImage := trackedImageForTrigger(t,
+		"registry.example.com/team/app:main_0000000000000000000000000000000000000000",
+		types.TriggerTypeDefault,
+		webhookPolicy,
+	)
+	pollImage := trackedImageForTrigger(t,
+		"registry.example.com/team/app:main_0000000000000000000000000000000000000000",
+		types.TriggerTypePoll,
+		pollPolicy,
+	)
+	fp := &fakeProvider{images: []*types.TrackedImage{webhookImage, pollImage}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{
+		digestToReturn: "sha256:current",
+		tagsToReturn: []string{
+			"main_1111111111111111111111111111111111111111",
+			"main_ffffffffffffffffffffffffffffffffffffffff",
+		},
+	}
+	watcher := NewRepositoryWatcher(providers, registryClient)
+
+	if err := watcher.Watch(webhookImage, pollImage); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	if got := len(watcher.watched); got != 1 {
+		t.Fatalf("registered %d polling watchers, want 1", got)
+	}
+	if got := len(fp.submitted); got != 1 {
+		t.Fatalf("submitted %d poll events, want 1", got)
+	}
+	if got, want := fp.submitted[0].Repository.Tag, "main_1111111111111111111111111111111111111111"; got != want {
+		t.Fatalf("poll event tag = %q, want polling consumer tag %q", got, want)
+	}
+}

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -31,7 +31,9 @@ func mustParse(img string, schedule string) *types.TrackedImage {
 
 // ======== fake registry client for testing =======
 type fakeRegistryClient struct {
-	opts registry.Opts // opts set if anything called Digest(opts Opts)
+	opts        registry.Opts // opts set if anything called Digest(opts Opts)
+	digestCalls int
+	getCalls    int
 
 	digestToReturn string
 
@@ -41,6 +43,7 @@ type fakeRegistryClient struct {
 }
 
 func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, error) {
+	c.getCalls++
 	c.opts = opts
 	return &registry.Repository{
 		Name: opts.Name,
@@ -49,6 +52,7 @@ func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, erro
 }
 
 func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err error) {
+	c.digestCalls++
 	c.opts = opts
 	return c.digestToReturn, c.digestErrToReturn
 }
@@ -226,8 +230,9 @@ func TestWatchAllTagsJob(t *testing.T) {
 	fp := &fakeProvider{
 		images: []*types.TrackedImage{
 			{
-				Image:  reference,
-				Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
+				Image:   reference,
+				Trigger: types.TriggerTypePoll,
+				Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true),
 			},
 		},
 	}
@@ -270,8 +275,9 @@ func TestWatchAllTagsJobCurrentLatest(t *testing.T) {
 	fp := &fakeProvider{
 		images: []*types.TrackedImage{
 			{
-				Image:  reference,
-				Policy: policy.NewForcePolicy(true),
+				Image:   reference,
+				Trigger: types.TriggerTypePoll,
+				Policy:  policy.NewForcePolicy(true),
 			},
 		},
 	}

--- a/util/policies/policies_test.go
+++ b/util/policies/policies_test.go
@@ -1,0 +1,36 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/keel-hq/keel/types"
+)
+
+func TestGetTriggerPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		want        types.TriggerType
+	}{
+		{name: "unset defaults to webhook events", want: types.TriggerTypeDefault},
+		{name: "webhook annotation", annotations: map[string]string{types.KeelTriggerLabel: "webhook"}, want: types.TriggerTypeDefault},
+		{name: "poll annotation", annotations: map[string]string{types.KeelTriggerLabel: "poll"}, want: types.TriggerTypePoll},
+		{name: "webhook label", labels: map[string]string{types.KeelTriggerLabel: "webhook"}, want: types.TriggerTypeDefault},
+		{name: "poll label", labels: map[string]string{types.KeelTriggerLabel: "poll"}, want: types.TriggerTypePoll},
+		{
+			name:        "annotation takes precedence over label",
+			labels:      map[string]string{types.KeelTriggerLabel: "poll"},
+			annotations: map[string]string{types.KeelTriggerLabel: "webhook"},
+			want:        types.TriggerTypeDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetTriggerPolicy(tt.labels, tt.annotations); got != tt.want {
+				t.Fatalf("GetTriggerPolicy() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
GitHub issue: https://github.com/keel-hq/keel/issues/860

Outcome:
Fix the regression reported after upgrading from Keel 1.0.5 to chart/application 1.2.0 where a StatefulSet configured with keel.sh/trigger: webhook is also polled and a webhook-selected commit tag is quickly rolled back to a different regexp-matching tag.

Required work and constraints:
- Reproduce on current master with a StatefulSet, init-container tracking, regexp:^main_[a-fA-F0-9]{40}$ policy, and webhook-only trigger.
- Identify why a polling watcher or equivalent reconciliation path is activated despite the explicit webhook trigger.
- Ensure explicit trigger configuration is honored consistently across Deployments, StatefulSets, DaemonSets, CronJobs, standard containers, and opted-in init containers where the shared code applies.
- Keep current API, annotations, webhook payloads, and legitimate polling behavior compatible.
- Do not weaken policy validation or add product behavior beyond correcting the trigger regression.
- No release, deployment, merge, or unrelated cleanup.

Acceptance criteria:
1. A resource explicitly configured for webhook triggering does not register or execute polling work solely because of its policy, init containers, restart, or resource resync.
2. A webhook update remains applied and is not rolled back by an unintended polling path.
3. Resources explicitly configured for polling continue to poll and update.
4. Mixed resources using the same repository but different trigger modes remain isolated.
5. Automated regression tests cover the reported StatefulSet/init-container/regexp configuration and the negative assertion that polling never fires.

Expected verification:
- Add focused unit tests for trigger parsing and watcher registration.
- Add an integration or e2e regression test that applies a webhook update, advances time/resyncs watchers, and proves the chosen image remains unchanged.
- Include a positive polling control and a shared-repository mixed-trigger case.
- Run relevant package tests, go test ./..., gofmt, and repository build/lint checks.
- Report root cause and before/after event or watcher evidence.

