### PR TITLE
Prevent event loss under Keel buffer saturation

### DIFF
--- a/internal/k8s/watcher.go
+++ b/internal/k8s/watcher.go
@@ -1,22 +1,60 @@
 package k8s
 
 import (
+	"container/list"
+	"fmt"
 	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/keel-hq/keel/constants"
 	"github.com/keel-hq/keel/internal/workgroup"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+var (
+	bufferEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kubernetes_event_buffer_events_total",
+		Help: "Kubernetes resource events received by the event buffer.",
+	}, []string{"event"})
+	bufferCoalesced = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kubernetes_event_buffer_coalesced_total",
+		Help: "Kubernetes resource events merged into an already pending event for the same resource.",
+	}, []string{"event"})
+	bufferBackpressure = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kubernetes_event_buffer_backpressure_total",
+		Help: "Kubernetes resource events that waited because the distinct-resource queue was full.",
+	})
+	bufferDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kubernetes_event_buffer_dropped_total",
+		Help: "Kubernetes resource states discarded by the event buffer.",
+	}, []string{"reason"})
+	bufferQueueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubernetes_event_buffer_queue_depth",
+		Help: "Current number of distinct Kubernetes resources waiting in the event buffer.",
+	})
+	bufferQueueCapacity = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubernetes_event_buffer_queue_capacity",
+		Help: "Maximum number of distinct Kubernetes resources in the event buffer.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(bufferEvents, bufferCoalesced, bufferBackpressure, bufferDropped, bufferQueueDepth, bufferQueueCapacity)
+}
 
 // WatchDeployments creates a SharedInformer for apps/v1.Deployments and registers it with g.
 func WatchDeployments(g *workgroup.Group, client *kubernetes.Clientset, log logrus.FieldLogger, rs ...cache.ResourceEventHandler) {
@@ -65,9 +103,24 @@ func watch(g *workgroup.Group, c cache.Getter, log logrus.FieldLogger, resource 
 }
 
 type buffer struct {
-	ev chan interface{}
-	logrus.StdLogger
-	rh cache.ResourceEventHandler
+	mu                sync.Mutex
+	queue             *list.List
+	pending           map[string]*list.Element
+	capacity          int
+	wake              chan struct{}
+	space             *sync.Cond
+	done              chan struct{}
+	stopOnce          sync.Once
+	sequence          uint64
+	lastSaturationLog time.Time
+
+	log logrus.FieldLogger
+	rh  cache.ResourceEventHandler
+}
+
+type queuedEvent struct {
+	key string
+	ev  interface{}
 }
 
 type addEvent struct {
@@ -83,37 +136,94 @@ type deleteEvent struct {
 	obj interface{}
 }
 
-// NewBuffer returns a ResourceEventHandler which buffers and serialises ResourceEventHandler events.
+// NewBuffer returns a ResourceEventHandler which buffers and serialises events.
+// Pending events for the same Kubernetes resource are coalesced to its latest
+// state. Once size distinct resources are pending, producers apply backpressure.
 func NewBuffer(g *workgroup.Group, rh cache.ResourceEventHandler, log logrus.FieldLogger, size int) cache.ResourceEventHandler {
-	buf := &buffer{
-		ev:        make(chan interface{}, size),
-		StdLogger: log.WithField("context", "buffer"),
-		rh:        rh,
+	if size < 1 {
+		size = 1
 	}
+	buf := &buffer{
+		queue:    list.New(),
+		pending:  make(map[string]*list.Element, size),
+		capacity: size,
+		wake:     make(chan struct{}, 1),
+		done:     make(chan struct{}),
+		log:      log.WithField("context", "buffer"),
+		rh:       rh,
+	}
+	buf.space = sync.NewCond(&buf.mu)
+	bufferQueueCapacity.Set(float64(size))
 	g.Add(buf.loop)
 	return buf
 }
 
 func (b *buffer) loop(stop <-chan struct{}) {
-	b.Println("started")
-	defer b.Println("stopped")
+	b.log.Info("started")
+	defer b.log.Info("stopped")
+	go func() {
+		<-stop
+		b.shutdown()
+	}()
 
 	for {
 		select {
-		case ev := <-b.ev:
-			switch ev := ev.(type) {
-			case *addEvent:
-				b.rh.OnAdd(ev.obj, ev.isInInitialList)
-			case *updateEvent:
-				b.rh.OnUpdate(ev.oldObj, ev.newObj)
-			case *deleteEvent:
-				b.rh.OnDelete(ev.obj)
-			default:
-				b.Printf("unhandled event type: %T: %v", ev, ev)
+		case <-b.wake:
+			for {
+				ev, ok := b.pop()
+				if !ok {
+					break
+				}
+				b.handle(ev)
 			}
-		case <-stop:
+		case <-b.done:
 			return
 		}
+	}
+}
+
+func (b *buffer) shutdown() {
+	b.stopOnce.Do(func() {
+		b.mu.Lock()
+		pending := b.queue.Len()
+		b.queue.Init()
+		clear(b.pending)
+		close(b.done)
+		b.space.Broadcast()
+		b.mu.Unlock()
+		if pending > 0 {
+			b.log.WithField("pending", pending).Warn("discarding pending events during shutdown")
+			bufferDropped.WithLabelValues("shutdown").Add(float64(pending))
+		}
+		bufferQueueDepth.Set(0)
+	})
+}
+
+func (b *buffer) pop() (interface{}, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	elem := b.queue.Front()
+	if elem == nil {
+		return nil, false
+	}
+	queued := elem.Value.(*queuedEvent)
+	b.queue.Remove(elem)
+	delete(b.pending, queued.key)
+	bufferQueueDepth.Set(float64(b.queue.Len()))
+	b.space.Signal()
+	return queued.ev, true
+}
+
+func (b *buffer) handle(ev interface{}) {
+	switch ev := ev.(type) {
+	case *addEvent:
+		b.rh.OnAdd(ev.obj, ev.isInInitialList)
+	case *updateEvent:
+		b.rh.OnUpdate(ev.oldObj, ev.newObj)
+	case *deleteEvent:
+		b.rh.OnDelete(ev.obj)
+	default:
+		b.log.Errorf("unhandled event type: %T: %v", ev, ev)
 	}
 }
 
@@ -130,11 +240,129 @@ func (b *buffer) OnDelete(obj interface{}) {
 }
 
 func (b *buffer) send(ev interface{}) {
-	select {
-	case b.ev <- ev:
-		// all good
+	eventType := eventName(ev)
+	bufferEvents.WithLabelValues(eventType).Inc()
+	key, _ := b.eventKey(ev) // Unkeyed events remain bounded but cannot safely be coalesced.
+	waited := false
+	for {
+		b.mu.Lock()
+		select {
+		case <-b.done:
+			b.mu.Unlock()
+			bufferDropped.WithLabelValues("shutdown").Inc()
+			return
+		default:
+		}
+		if elem, ok := b.pending[key]; ok {
+			queued := elem.Value.(*queuedEvent)
+			queued.ev = coalesce(queued.ev, ev)
+			b.mu.Unlock()
+			bufferCoalesced.WithLabelValues(eventType).Inc()
+			return
+		}
+		if b.queue.Len() < b.capacity {
+			elem := b.queue.PushBack(&queuedEvent{key: key, ev: ev})
+			b.pending[key] = elem
+			bufferQueueDepth.Set(float64(b.queue.Len()))
+			b.mu.Unlock()
+			notify(b.wake)
+			return
+		}
+		if !waited {
+			waited = true
+			bufferBackpressure.Inc()
+			now := time.Now()
+			if b.lastSaturationLog.IsZero() || now.Sub(b.lastSaturationLog) >= time.Minute {
+				b.lastSaturationLog = now
+				b.log.WithFields(logrus.Fields{"capacity": b.capacity, "event": eventType}).Warn("event buffer saturated; applying backpressure")
+			}
+		}
+		b.space.Wait()
+		b.mu.Unlock()
+	}
+}
+
+func (b *buffer) eventKey(ev interface{}) (string, bool) {
+	obj := eventObject(ev)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	accessor, err := meta.Accessor(obj)
+	if err == nil {
+		typ := reflect.TypeOf(obj)
+		if uid := accessor.GetUID(); uid != "" {
+			return fmt.Sprintf("%v/uid/%s", typ, uid), true
+		}
+		if name := accessor.GetName(); name != "" {
+			return fmt.Sprintf("%v/name/%s/%s", typ, accessor.GetNamespace(), name), true
+		}
+	}
+	sequence := atomic.AddUint64(&b.sequence, 1)
+	return fmt.Sprintf("unkeyed/%d", sequence), false
+}
+
+func eventObject(ev interface{}) interface{} {
+	switch ev := ev.(type) {
+	case *addEvent:
+		return ev.obj
+	case *updateEvent:
+		return ev.newObj
+	case *deleteEvent:
+		return ev.obj
 	default:
-		b.Printf("event channel is full, len: %v, cap: %v", len(b.ev), cap(b.ev))
-		b.ev <- ev
+		return ev
+	}
+}
+
+func eventName(ev interface{}) string {
+	switch ev.(type) {
+	case *addEvent:
+		return "add"
+	case *updateEvent:
+		return "update"
+	case *deleteEvent:
+		return "delete"
+	default:
+		return "unknown"
+	}
+}
+
+func coalesce(previous, next interface{}) interface{} {
+	switch previous := previous.(type) {
+	case *addEvent:
+		switch next := next.(type) {
+		case *addEvent:
+			return &addEvent{obj: next.obj, isInInitialList: previous.isInInitialList}
+		case *updateEvent:
+			return &addEvent{obj: next.newObj, isInInitialList: previous.isInInitialList}
+		case *deleteEvent:
+			return next
+		}
+	case *updateEvent:
+		switch next := next.(type) {
+		case *addEvent:
+			return &updateEvent{oldObj: previous.oldObj, newObj: next.obj}
+		case *updateEvent:
+			return &updateEvent{oldObj: previous.oldObj, newObj: next.newObj}
+		case *deleteEvent:
+			return next
+		}
+	case *deleteEvent:
+		switch next := next.(type) {
+		case *addEvent:
+			return &updateEvent{oldObj: previous.obj, newObj: next.obj}
+		case *updateEvent:
+			return &updateEvent{oldObj: previous.obj, newObj: next.newObj}
+		case *deleteEvent:
+			return next
+		}
+	}
+	return next
+}
+
+func notify(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
 	}
 }

--- a/internal/k8s/watcher_test.go
+++ b/internal/k8s/watcher_test.go
@@ -1,0 +1,336 @@
+package k8s
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keel-hq/keel/internal/workgroup"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+const testTimeout = 5 * time.Second
+
+type observedEvent struct {
+	kind       string
+	name       string
+	oldVersion string
+	version    string
+}
+
+type recordingHandler struct {
+	mu          sync.Mutex
+	events      []observedEvent
+	latest      map[string]string
+	changed     chan struct{}
+	inFlight    int32
+	maxInFlight int32
+	before      func()
+}
+
+func newRecordingHandler() *recordingHandler {
+	return &recordingHandler{latest: make(map[string]string), changed: make(chan struct{}, 1)}
+}
+
+func (h *recordingHandler) enter() {
+	current := atomic.AddInt32(&h.inFlight, 1)
+	for {
+		maximum := atomic.LoadInt32(&h.maxInFlight)
+		if current <= maximum || atomic.CompareAndSwapInt32(&h.maxInFlight, maximum, current) {
+			break
+		}
+	}
+	if h.before != nil {
+		h.before()
+	}
+}
+
+func (h *recordingHandler) leave(event observedEvent) {
+	h.mu.Lock()
+	h.events = append(h.events, event)
+	h.latest[event.name] = event.version
+	h.mu.Unlock()
+	atomic.AddInt32(&h.inFlight, -1)
+	notify(h.changed)
+}
+
+func (h *recordingHandler) OnAdd(obj interface{}, _ bool) {
+	h.enter()
+	deployment := obj.(*appsv1.Deployment)
+	h.leave(observedEvent{kind: "add", name: deployment.Name, version: deployment.ResourceVersion})
+}
+
+func (h *recordingHandler) OnUpdate(oldObj, newObj interface{}) {
+	h.enter()
+	oldDeployment := oldObj.(*appsv1.Deployment)
+	newDeployment := newObj.(*appsv1.Deployment)
+	h.leave(observedEvent{kind: "update", name: newDeployment.Name, oldVersion: oldDeployment.ResourceVersion, version: newDeployment.ResourceVersion})
+}
+
+func (h *recordingHandler) OnDelete(obj interface{}) {
+	h.enter()
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	deployment := obj.(*appsv1.Deployment)
+	h.leave(observedEvent{kind: "delete", name: deployment.Name, version: deployment.ResourceVersion})
+}
+
+func (h *recordingHandler) waitLatest(t testing.TB, expected map[string]string) {
+	t.Helper()
+	deadline := time.NewTimer(testTimeout)
+	defer deadline.Stop()
+	for {
+		h.mu.Lock()
+		matches := len(h.latest) >= len(expected)
+		for name, version := range expected {
+			matches = matches && h.latest[name] == version
+		}
+		h.mu.Unlock()
+		if matches {
+			return
+		}
+		select {
+		case <-h.changed:
+		case <-deadline.C:
+			h.mu.Lock()
+			latest := make(map[string]string, len(h.latest))
+			for name, version := range h.latest {
+				latest[name] = version
+			}
+			h.mu.Unlock()
+			t.Fatalf("timed out waiting for latest states: got %v, want %v", latest, expected)
+		}
+	}
+}
+
+func deployment(name, uid, version string) *appsv1.Deployment {
+	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Namespace:       "default",
+		Name:            name,
+		UID:             types.UID(uid),
+		ResourceVersion: version,
+	}}
+}
+
+func startTestBuffer(t *testing.T, handler cache.ResourceEventHandler, capacity int, logger logrus.FieldLogger) (*buffer, chan struct{}) {
+	t.Helper()
+	var group workgroup.Group
+	b := NewBuffer(&group, handler, logger, capacity).(*buffer)
+	stop := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		b.loop(stop)
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-exited:
+		case <-time.After(testTimeout):
+			t.Error("buffer loop did not stop")
+		}
+	})
+	return b, stop
+}
+
+func TestBufferCapacityBurstCoalescesWithoutLosingLatestState(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls int32
+	handler := newRecordingHandler()
+	handler.before = func() {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+	}
+	var logs bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&logs)
+	b, _ := startTestBuffer(t, handler, 2, logger)
+
+	b.OnAdd(deployment("zero", "zero", "1"), false)
+	select {
+	case <-firstStarted:
+	case <-time.After(testTimeout):
+		t.Fatal("slow consumer did not start")
+	}
+	b.OnAdd(deployment("one", "one", "1"), false)
+	b.OnAdd(deployment("two", "two", "1"), false)
+
+	thirdQueued := make(chan struct{})
+	go func() {
+		b.OnAdd(deployment("three", "three", "1"), false)
+		close(thirdQueued)
+	}()
+	select {
+	case <-thirdQueued:
+		t.Fatal("a new resource bypassed backpressure at capacity")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	duplicateReturned := make(chan struct{})
+	go func() {
+		b.OnUpdate(deployment("two", "two", "1"), deployment("two", "two", "latest"))
+		close(duplicateReturned)
+	}()
+	select {
+	case <-duplicateReturned:
+	case <-time.After(testTimeout):
+		t.Fatal("duplicate resource did not coalesce while the queue was full")
+	}
+	close(releaseFirst)
+	select {
+	case <-thirdQueued:
+	case <-time.After(testTimeout):
+		t.Fatal("backpressured producer did not resume")
+	}
+
+	handler.waitLatest(t, map[string]string{"zero": "1", "one": "1", "two": "latest", "three": "1"})
+	if got := atomic.LoadInt32(&handler.maxInFlight); got != 1 {
+		t.Fatalf("handler ran concurrently: max in flight = %d", got)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("applying backpressure")) {
+		t.Fatalf("saturation warning missing from logs: %s", logs.String())
+	}
+}
+
+func TestBufferCoalescingPreservesStateTransitionsAndResourceIdentity(t *testing.T) {
+	handler := newRecordingHandler()
+	var group workgroup.Group
+	b := NewBuffer(&group, handler, logrus.New(), 8).(*buffer)
+
+	b.OnUpdate(deployment("app", "uid-1", "0"), deployment("app", "uid-1", "1"))
+	b.OnUpdate(deployment("app", "uid-1", "1"), deployment("app", "uid-1", "2"))
+	b.OnDelete(deployment("gone", "uid-2", "3"))
+	b.OnAdd(deployment("gone", "uid-2", "4"), false)
+	b.OnAdd(deployment("same-name", "old-uid", "1"), false)
+	b.OnAdd(deployment("same-name", "new-uid", "2"), false)
+
+	first := b.queue.Front().Value.(*queuedEvent).ev.(*updateEvent)
+	if oldVersion := first.oldObj.(*appsv1.Deployment).ResourceVersion; oldVersion != "0" {
+		t.Fatalf("coalesced update lost its original state: got %q", oldVersion)
+	}
+	if newVersion := first.newObj.(*appsv1.Deployment).ResourceVersion; newVersion != "2" {
+		t.Fatalf("coalesced update lost its latest state: got %q", newVersion)
+	}
+	second := b.queue.Front().Next().Value.(*queuedEvent).ev.(*updateEvent)
+	if second.oldObj.(*appsv1.Deployment).ResourceVersion != "3" || second.newObj.(*appsv1.Deployment).ResourceVersion != "4" {
+		t.Fatalf("delete/add transition was not preserved: %#v", second)
+	}
+	if got := b.queue.Len(); got != 4 {
+		t.Fatalf("different UIDs with the same name were coalesced: queue length = %d, want 4", got)
+	}
+	b.shutdown()
+}
+
+func TestBufferSustainedLoadEventuallyProcessesEveryResourceLatestState(t *testing.T) {
+	handler := newRecordingHandler()
+	handler.before = func() { time.Sleep(10 * time.Microsecond) }
+	b, _ := startTestBuffer(t, handler, 8, logrus.New())
+
+	const resources = 32
+	const versions = 200
+	var producers sync.WaitGroup
+	expected := make(map[string]string, resources)
+	for resource := 0; resource < resources; resource++ {
+		name := fmt.Sprintf("resource-%02d", resource)
+		expected[name] = fmt.Sprint(versions)
+		producers.Add(1)
+		go func(name string) {
+			defer producers.Done()
+			uid := "uid-" + name
+			b.OnAdd(deployment(name, uid, "0"), false)
+			for version := 1; version <= versions; version++ {
+				b.OnUpdate(deployment(name, uid, fmt.Sprint(version-1)), deployment(name, uid, fmt.Sprint(version)))
+			}
+		}(name)
+	}
+	producers.Wait()
+	handler.waitLatest(t, expected)
+	if got := atomic.LoadInt32(&handler.maxInFlight); got != 1 {
+		t.Fatalf("handler ran concurrently: max in flight = %d", got)
+	}
+	b.mu.Lock()
+	queued := b.queue.Len()
+	b.mu.Unlock()
+	if queued > b.capacity {
+		t.Fatalf("queue exceeded its bound: got %d, capacity %d", queued, b.capacity)
+	}
+}
+
+func TestBufferShutdownUnblocksBackpressuredProducer(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var once sync.Once
+	handler := newRecordingHandler()
+	handler.before = func() {
+		once.Do(func() {
+			close(firstStarted)
+			<-releaseFirst
+		})
+	}
+	b, stop := startTestBuffer(t, handler, 1, logrus.New())
+	b.OnAdd(deployment("active", "active", "1"), false)
+	select {
+	case <-firstStarted:
+	case <-time.After(testTimeout):
+		t.Fatal("consumer did not start")
+	}
+	b.OnAdd(deployment("queued", "queued", "1"), false)
+
+	producerReturned := make(chan struct{})
+	go func() {
+		b.OnAdd(deployment("blocked", "blocked", "1"), false)
+		close(producerReturned)
+	}()
+	select {
+	case <-producerReturned:
+		t.Fatal("producer was not backpressured")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(stop)
+	select {
+	case <-producerReturned:
+	case <-time.After(testTimeout):
+		t.Fatal("shutdown did not unblock producer")
+	}
+	close(releaseFirst)
+}
+
+func BenchmarkBufferSustainedLoad(b *testing.B) {
+	handler := newRecordingHandler()
+	var group workgroup.Group
+	queue := NewBuffer(&group, handler, logrus.New(), 128).(*buffer)
+	stop := make(chan struct{})
+	go queue.loop(stop)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resource := i % 256
+		name := fmt.Sprintf("resource-%03d", resource)
+		version := fmt.Sprint(i)
+		queue.OnUpdate(deployment(name, "uid-"+name, version), deployment(name, "uid-"+name, version))
+	}
+	b.StopTimer()
+	expected := make(map[string]string, min(b.N, 256))
+	for resource := 0; resource < min(b.N, 256); resource++ {
+		last := b.N - 1 - ((b.N - 1 - resource) % 256)
+		expected[fmt.Sprintf("resource-%03d", resource)] = fmt.Sprint(last)
+	}
+	handler.waitLatest(b, expected)
+	close(stop)
+	<-queue.done
+}


### PR DESCRIPTION
GitHub issue: https://github.com/keel-hq/keel/issues/443

Outcome:
Prevent Keel from losing or indefinitely delaying update events when clusters generate more events than the fixed 128-entry channel can hold.

Constraints and acceptance criteria:
- Reproduce saturation with a deterministic high-volume test and identify current drop/block/retry semantics.
- Design bounded backpressure, coalescing, batching, or queue behavior appropriate to image/resource events; do not merely increase a magic constant without evidence.
- Preserve ordering/idempotency requirements and prevent goroutine leaks, deadlocks, unbounded memory, and update storms.
- Expose actionable metrics/logging for saturation and dropped/coalesced events.
- Tests must cover capacity bursts, duplicate events, sustained load, shutdown/cancellation, slow consumers, and eventual processing of the latest state for every affected resource.
- Run race-enabled focused tests, load/stress tests, go test ./..., gofmt, build/lint, and report throughput/memory evidence.
- No unrelated concurrency rewrite, release, deployment, or merge.

LFG!