### PR TITLE
Prevent unsafe cross-platform image updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
 
   e2e:
     name: End-to-End Tests (k3s)
-    # Automatic PR/master gating remains opt-in pending runner-cost approval.
-    # Manual workflow_dispatch runs always; set KEEL_E2E_PR_GATE=true to enable current CI triggers.
-    if: github.event_name == 'workflow_dispatch' || vars.KEEL_E2E_PR_GATE == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -213,7 +213,9 @@ rbac:
         - ""
       resources:
         - namespaces
+        - nodes
       verbs:
+        - get
         - watch
         - list
     - apiGroups:

--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -324,8 +324,9 @@ type ProviderOpts struct {
 // provider map
 func setupProviders(opts *ProviderOpts) (providers provider.Providers) {
 	var enabledProviders []provider.Provider
+	platformResolver := k8s.NewPlatformResolver(opts.k8sImplementer)
 
-	k8sProvider, err := kubernetes.NewProvider(opts.k8sImplementer, opts.sender, opts.approvalsManager, opts.grc)
+	k8sProvider, err := kubernetes.NewProvider(opts.k8sImplementer, opts.sender, opts.approvalsManager, opts.grc, platformResolver)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
@@ -344,7 +345,7 @@ func setupProviders(opts *ProviderOpts) (providers provider.Providers) {
 
 	if os.Getenv(EnvHelm3Provider) == "1" || os.Getenv(EnvHelm3Provider) == "true" {
 		helm3Implementer := helm3.NewHelm3Implementer()
-		helm3Provider := helm3.NewProvider(helm3Implementer, opts.sender, opts.approvalsManager)
+		helm3Provider := helm3.NewProvider(helm3Implementer, opts.sender, opts.approvalsManager, helm3.WithWorkloadPlatforms(platformResolver, opts.grc))
 
 		go func() {
 			err := helm3Provider.Start()

--- a/internal/k8s/platform.go
+++ b/internal/k8s/platform.go
@@ -1,0 +1,227 @@
+package k8s
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/keel-hq/keel/types"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+const nodeCacheTTL = 30 * time.Second
+
+// NodeLister supplies Kubernetes node scheduling and platform metadata.
+type NodeLister interface {
+	Nodes() (*core_v1.NodeList, error)
+}
+
+type podLister interface {
+	Pods(namespace, labelSelector string) (*core_v1.PodList, error)
+}
+
+// PlatformResolver derives a conservative eligible platform set for workloads.
+type PlatformResolver struct {
+	nodes NodeLister
+
+	mu        sync.Mutex
+	cached    []core_v1.Node
+	expiresAt time.Time
+}
+
+// NewPlatformResolver creates a resolver backed by Kubernetes Node metadata.
+func NewPlatformResolver(nodes NodeLister) *PlatformResolver {
+	return &PlatformResolver{nodes: nodes}
+}
+
+// Resolve returns every platform on which the workload may be scheduled.
+func (r *PlatformResolver) Resolve(resource *GenericResource) ([]types.Platform, types.PlatformError) {
+	if resource == nil || resource.GetPodSpec() == nil {
+		return nil, types.PlatformErrorWorkloadMetadata
+	}
+	nodes, err := r.listNodes()
+	if err != nil {
+		return nil, types.PlatformErrorNodeMetadata
+	}
+
+	platforms := make(map[types.Platform]struct{})
+	nodesByName := make(map[string]*core_v1.Node, len(nodes))
+	for i := range nodes {
+		node := &nodes[i]
+		nodesByName[node.Name] = node
+		if node.Spec.Unschedulable || !nodeMatchesPod(node, resource.GetPodSpec()) {
+			continue
+		}
+		platform, ok := nodePlatform(node)
+		if !ok {
+			return nil, types.PlatformErrorNodeMetadata
+		}
+		platforms[platform] = struct{}{}
+	}
+	if pods, ok := r.nodes.(podLister); ok {
+		if selector, hasSelector := resource.GetPodSelector(); hasSelector {
+			podList, err := pods.Pods(resource.Namespace, selector)
+			if err == nil && podList != nil {
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+					if pod.Spec.NodeName == "" {
+						continue
+					}
+					node := nodesByName[pod.Spec.NodeName]
+					platform, found := nodePlatform(node)
+					if !found {
+						return nil, types.PlatformErrorNodeMetadata
+					}
+					platforms[platform] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(platforms) == 0 {
+		return nil, types.PlatformErrorNoEligibleNodes
+	}
+
+	result := make([]types.Platform, 0, len(platforms))
+	for platform := range platforms {
+		result = append(result, platform)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].OS != result[j].OS {
+			return result[i].OS < result[j].OS
+		}
+		if result[i].Architecture != result[j].Architecture {
+			return result[i].Architecture < result[j].Architecture
+		}
+		return result[i].Variant < result[j].Variant
+	})
+	return result, types.PlatformErrorNone
+}
+
+func (r *PlatformResolver) listNodes() ([]core_v1.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if time.Now().Before(r.expiresAt) {
+		return append([]core_v1.Node(nil), r.cached...), nil
+	}
+	list, err := r.nodes.Nodes()
+	if err != nil {
+		return nil, err
+	}
+	if list == nil {
+		return nil, fmt.Errorf("node list is nil")
+	}
+	r.cached = append(r.cached[:0], list.Items...)
+	r.expiresAt = time.Now().Add(nodeCacheTTL)
+	return append([]core_v1.Node(nil), r.cached...), nil
+}
+
+func nodePlatform(node *core_v1.Node) (types.Platform, bool) {
+	if node == nil {
+		return types.Platform{}, false
+	}
+	os := node.Status.NodeInfo.OperatingSystem
+	architecture := node.Status.NodeInfo.Architecture
+	if os == "" {
+		os = firstLabel(node.Labels, core_v1.LabelOSStable, "beta.kubernetes.io/os")
+	}
+	if architecture == "" {
+		architecture = firstLabel(node.Labels, core_v1.LabelArchStable, "beta.kubernetes.io/arch")
+	}
+	if os == "" || architecture == "" {
+		return types.Platform{}, false
+	}
+	return types.Platform{OS: os, Architecture: architecture}, true
+}
+
+func firstLabel(labels map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if labels[key] != "" {
+			return labels[key]
+		}
+	}
+	return ""
+}
+
+func nodeMatchesPod(node *core_v1.Node, pod *core_v1.PodSpec) bool {
+	if pod.NodeName != "" && pod.NodeName != node.Name {
+		return false
+	}
+	for key, value := range pod.NodeSelector {
+		if node.Labels[key] != value {
+			return false
+		}
+	}
+	if pod.OS != nil && pod.OS.Name != "" {
+		if platform, ok := nodePlatform(node); !ok || platform.OS != string(pod.OS.Name) {
+			return false
+		}
+	}
+
+	required := pod.Affinity
+	if required == nil || required.NodeAffinity == nil || required.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return true
+	}
+	terms := required.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	for _, term := range terms {
+		if nodeMatchesTerm(node, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeMatchesTerm(node *core_v1.Node, term core_v1.NodeSelectorTerm) bool {
+	for _, expression := range term.MatchExpressions {
+		if !matchesRequirement(node.Labels[expression.Key], expression.Operator, expression.Values) {
+			return false
+		}
+	}
+	for _, expression := range term.MatchFields {
+		if expression.Key != "metadata.name" {
+			continue
+		}
+		if !matchesRequirement(node.Name, expression.Operator, expression.Values) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesRequirement(value string, operator core_v1.NodeSelectorOperator, values []string) bool {
+	switch operator {
+	case core_v1.NodeSelectorOpIn:
+		return contains(values, value)
+	case core_v1.NodeSelectorOpNotIn:
+		return !contains(values, value)
+	case core_v1.NodeSelectorOpExists:
+		return value != ""
+	case core_v1.NodeSelectorOpDoesNotExist:
+		return value == ""
+	case core_v1.NodeSelectorOpGt, core_v1.NodeSelectorOpLt:
+		if len(values) != 1 {
+			return true
+		}
+		actual, actualErr := strconv.Atoi(value)
+		expected, expectedErr := strconv.Atoi(values[0])
+		if actualErr != nil || expectedErr != nil {
+			return true
+		}
+		if operator == core_v1.NodeSelectorOpGt {
+			return actual > expected
+		}
+		return actual < expected
+	default:
+		return true
+	}
+}
+
+func contains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/k8s/platform_test.go
+++ b/internal/k8s/platform_test.go
@@ -1,0 +1,261 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keel-hq/keel/types"
+	apps_v1 "k8s.io/api/apps/v1"
+	batch_v1 "k8s.io/api/batch/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakePlatformSource struct {
+	nodes *core_v1.NodeList
+	pods  *core_v1.PodList
+	err   error
+	calls int
+}
+
+func (f *fakePlatformSource) Nodes() (*core_v1.NodeList, error) {
+	f.calls++
+	return f.nodes, f.err
+}
+
+func (f *fakePlatformSource) Pods(_, _ string) (*core_v1.PodList, error) {
+	return f.pods, nil
+}
+
+func TestGenericResourceGetPodSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface{}
+	}{
+		{name: "deployment", obj: &apps_v1.Deployment{Spec: apps_v1.DeploymentSpec{Template: podTemplate("deployment-node")}}},
+		{name: "statefulset", obj: &apps_v1.StatefulSet{Spec: apps_v1.StatefulSetSpec{Template: podTemplate("statefulset-node")}}},
+		{name: "daemonset", obj: &apps_v1.DaemonSet{Spec: apps_v1.DaemonSetSpec{Template: podTemplate("daemonset-node")}}},
+		{name: "cronjob", obj: &batch_v1.CronJob{Spec: batch_v1.CronJobSpec{JobTemplate: batch_v1.JobTemplateSpec{Spec: batch_v1.JobSpec{Template: podTemplate("cronjob-node")}}}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resource, err := NewGenericResource(test.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := resource.GetPodSpec(); got == nil || got.NodeName != test.name+"-node" {
+				t.Fatalf("unexpected pod spec: %#v", got)
+			}
+		})
+	}
+}
+
+func podTemplate(nodeName string) core_v1.PodTemplateSpec {
+	return core_v1.PodTemplateSpec{Spec: core_v1.PodSpec{NodeName: nodeName}}
+}
+
+func TestPlatformResolverSchedulingMetadata(t *testing.T) {
+	nodes := &core_v1.NodeList{Items: []core_v1.Node{
+		testNode("amd", "linux", "amd64", map[string]string{"pool": "general", "generation": "3"}),
+		testNode("arm", "linux", "arm64", map[string]string{"pool": "edge", "generation": "2"}),
+		testNode("windows", "windows", "amd64", map[string]string{"pool": "general", "generation": "4"}),
+	}}
+	tests := []struct {
+		name string
+		spec core_v1.PodSpec
+		want []types.Platform
+	}{
+		{
+			name: "mixed unconstrained nodes",
+			want: []types.Platform{{OS: "linux", Architecture: "amd64"}, {OS: "linux", Architecture: "arm64"}, {OS: "windows", Architecture: "amd64"}},
+		},
+		{
+			name: "stable architecture selector",
+			spec: core_v1.PodSpec{NodeSelector: map[string]string{core_v1.LabelArchStable: "amd64", core_v1.LabelOSStable: "linux"}},
+			want: []types.Platform{{OS: "linux", Architecture: "amd64"}},
+		},
+		{
+			name: "legacy architecture selector",
+			spec: core_v1.PodSpec{NodeSelector: map[string]string{"beta.kubernetes.io/arch": "arm64"}},
+			want: []types.Platform{{OS: "linux", Architecture: "arm64"}},
+		},
+		{
+			name: "node name",
+			spec: core_v1.PodSpec{NodeName: "arm"},
+			want: []types.Platform{{OS: "linux", Architecture: "arm64"}},
+		},
+		{
+			name: "pod OS",
+			spec: core_v1.PodSpec{OS: &core_v1.PodOS{Name: core_v1.Windows}},
+			want: []types.Platform{{OS: "windows", Architecture: "amd64"}},
+		},
+		{
+			name: "required affinity",
+			spec: core_v1.PodSpec{Affinity: &core_v1.Affinity{
+				NodeAffinity: &core_v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &core_v1.NodeSelector{
+						NodeSelectorTerms: []core_v1.NodeSelectorTerm{{
+							MatchExpressions: []core_v1.NodeSelectorRequirement{
+								{Key: "pool", Operator: core_v1.NodeSelectorOpIn, Values: []string{"general"}},
+								{Key: "generation", Operator: core_v1.NodeSelectorOpGt, Values: []string{"3"}},
+							},
+						}},
+					},
+				},
+			}},
+			want: []types.Platform{{OS: "windows", Architecture: "amd64"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployment := &apps_v1.Deployment{Spec: apps_v1.DeploymentSpec{Template: core_v1.PodTemplateSpec{Spec: test.spec}}}
+			resource, err := NewGenericResource(deployment)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, resolutionErr := NewPlatformResolver(&fakePlatformSource{nodes: nodes}).Resolve(resource)
+			if resolutionErr != types.PlatformErrorNone || fmt.Sprint(got) != fmt.Sprint(test.want) {
+				t.Fatalf("got %v (%s), want %v", got, resolutionErr, test.want)
+			}
+		})
+	}
+}
+
+func TestPlatformResolverIncludesObservedPodPlatform(t *testing.T) {
+	deployment := &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: "default"},
+		Spec: apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": "example"}},
+			Template: core_v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{"app": "example"}},
+				Spec:       core_v1.PodSpec{NodeSelector: map[string]string{core_v1.LabelArchStable: "arm64"}},
+			},
+		},
+	}
+	resource, err := NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &fakePlatformSource{
+		nodes: &core_v1.NodeList{Items: []core_v1.Node{
+			testNode("amd", "linux", "amd64", nil),
+			testNode("arm", "linux", "arm64", nil),
+		}},
+		pods: &core_v1.PodList{Items: []core_v1.Pod{{Spec: core_v1.PodSpec{NodeName: "amd"}}}},
+	}
+	got, resolutionErr := NewPlatformResolver(source).Resolve(resource)
+	want := []types.Platform{{OS: "linux", Architecture: "amd64"}, {OS: "linux", Architecture: "arm64"}}
+	if resolutionErr != types.PlatformErrorNone || fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v (%s), want %v", got, resolutionErr, want)
+	}
+}
+
+func TestPlatformResolverFailsClosed(t *testing.T) {
+	resource, err := NewGenericResource(&apps_v1.Deployment{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		source *fakePlatformSource
+		want   types.PlatformError
+	}{
+		{name: "node API unavailable", source: &fakePlatformSource{err: fmt.Errorf("forbidden")}, want: types.PlatformErrorNodeMetadata},
+		{name: "nil node response", source: &fakePlatformSource{}, want: types.PlatformErrorNodeMetadata},
+		{name: "no nodes", source: &fakePlatformSource{nodes: &core_v1.NodeList{}}, want: types.PlatformErrorNoEligibleNodes},
+		{name: "missing node platform", source: &fakePlatformSource{nodes: &core_v1.NodeList{Items: []core_v1.Node{{}}}}, want: types.PlatformErrorNodeMetadata},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			platforms, resolutionErr := NewPlatformResolver(test.source).Resolve(resource)
+			if len(platforms) != 0 || resolutionErr != test.want {
+				t.Fatalf("got %v (%s), want no platforms and %s", platforms, resolutionErr, test.want)
+			}
+		})
+	}
+}
+
+func TestMatchesRequirementOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		operator core_v1.NodeSelectorOperator
+		values   []string
+		want     bool
+	}{
+		{name: "in", value: "edge", operator: core_v1.NodeSelectorOpIn, values: []string{"edge"}, want: true},
+		{name: "not in", value: "edge", operator: core_v1.NodeSelectorOpNotIn, values: []string{"general"}, want: true},
+		{name: "exists", value: "set", operator: core_v1.NodeSelectorOpExists, want: true},
+		{name: "does not exist", operator: core_v1.NodeSelectorOpDoesNotExist, want: true},
+		{name: "greater than", value: "3", operator: core_v1.NodeSelectorOpGt, values: []string{"2"}, want: true},
+		{name: "less than", value: "2", operator: core_v1.NodeSelectorOpLt, values: []string{"3"}, want: true},
+		{name: "invalid numeric is conservative", value: "unknown", operator: core_v1.NodeSelectorOpGt, values: []string{"3"}, want: true},
+		{name: "unknown operator is conservative", value: "anything", operator: core_v1.NodeSelectorOperator("Future"), want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := matchesRequirement(test.value, test.operator, test.values); got != test.want {
+				t.Fatalf("got %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlatformResolverAffinityTermsAreORed(t *testing.T) {
+	source := &fakePlatformSource{nodes: &core_v1.NodeList{Items: []core_v1.Node{
+		testNode("amd", "linux", "amd64", map[string]string{"pool": "general"}),
+		testNode("arm", "linux", "arm64", map[string]string{"pool": "edge"}),
+	}}}
+	deployment := &apps_v1.Deployment{Spec: apps_v1.DeploymentSpec{Template: core_v1.PodTemplateSpec{Spec: core_v1.PodSpec{
+		Affinity: &core_v1.Affinity{NodeAffinity: &core_v1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &core_v1.NodeSelector{
+			NodeSelectorTerms: []core_v1.NodeSelectorTerm{
+				{MatchExpressions: []core_v1.NodeSelectorRequirement{{Key: "pool", Operator: core_v1.NodeSelectorOpIn, Values: []string{"missing"}}}},
+				{MatchFields: []core_v1.NodeSelectorRequirement{{Key: "future.field", Operator: core_v1.NodeSelectorOpIn, Values: []string{"unknown"}}}},
+			},
+		}}},
+	}}}}
+	resource, err := NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	platforms, resolutionErr := NewPlatformResolver(source).Resolve(resource)
+	if resolutionErr != types.PlatformErrorNone || len(platforms) != 2 {
+		t.Fatalf("expected conservative mixed set, got %v (%s)", platforms, resolutionErr)
+	}
+}
+
+func TestPlatformResolverCachesNodes(t *testing.T) {
+	source := &fakePlatformSource{nodes: &core_v1.NodeList{Items: []core_v1.Node{testNode("amd", "linux", "amd64", nil)}}}
+	resource, err := NewGenericResource(&apps_v1.Deployment{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewPlatformResolver(source)
+	for range 2 {
+		if _, resolutionErr := resolver.Resolve(resource); resolutionErr != types.PlatformErrorNone {
+			t.Fatal(resolutionErr)
+		}
+	}
+	if source.calls != 1 {
+		t.Fatalf("expected one node-list call, got %d", source.calls)
+	}
+}
+
+func testNode(name, os, architecture string, extraLabels map[string]string) core_v1.Node {
+	labels := map[string]string{
+		core_v1.LabelOSStable:     os,
+		core_v1.LabelArchStable:   architecture,
+		"beta.kubernetes.io/os":   os,
+		"beta.kubernetes.io/arch": architecture,
+	}
+	for key, value := range extraLabels {
+		labels[key] = value
+	}
+	return core_v1.Node{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name, Labels: labels},
+		Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{
+			OperatingSystem: os,
+			Architecture:    architecture,
+		}},
+	}
+}

--- a/internal/k8s/resource.go
+++ b/internal/k8s/resource.go
@@ -266,6 +266,21 @@ func (r *GenericResource) GetImagePullSecrets() (secrets []string) {
 	return
 }
 
+// GetNodeSelector returns the pod template's node selector.
+func (r *GenericResource) GetNodeSelector() map[string]string {
+	switch obj := r.obj.(type) {
+	case *apps_v1.Deployment:
+		return obj.Spec.Template.Spec.NodeSelector
+	case *apps_v1.StatefulSet:
+		return obj.Spec.Template.Spec.NodeSelector
+	case *apps_v1.DaemonSet:
+		return obj.Spec.Template.Spec.NodeSelector
+	case *batch_v1.CronJob:
+		return obj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector
+	}
+	return nil
+}
+
 // GetImages - returns images used by this resource
 func (r *GenericResource) GetImages(filter ContainerFilter) (images []string) {
 	switch obj := r.obj.(type) {

--- a/internal/k8s/resource.go
+++ b/internal/k8s/resource.go
@@ -8,6 +8,8 @@ import (
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // GenericResource - generic resource,
@@ -279,6 +281,47 @@ func (r *GenericResource) GetNodeSelector() map[string]string {
 		return obj.Spec.JobTemplate.Spec.Template.Spec.NodeSelector
 	}
 	return nil
+}
+
+// GetPodSpec returns the workload pod template spec.
+func (r *GenericResource) GetPodSpec() *core_v1.PodSpec {
+	switch obj := r.obj.(type) {
+	case *apps_v1.Deployment:
+		return &obj.Spec.Template.Spec
+	case *apps_v1.StatefulSet:
+		return &obj.Spec.Template.Spec
+	case *apps_v1.DaemonSet:
+		return &obj.Spec.Template.Spec
+	case *batch_v1.CronJob:
+		return &obj.Spec.JobTemplate.Spec.Template.Spec
+	}
+	return nil
+}
+
+// GetPodSelector returns a selector for pods created from the workload template.
+func (r *GenericResource) GetPodSelector() (string, bool) {
+	var selector *meta_v1.LabelSelector
+	switch obj := r.obj.(type) {
+	case *apps_v1.Deployment:
+		selector = obj.Spec.Selector
+	case *apps_v1.StatefulSet:
+		selector = obj.Spec.Selector
+	case *apps_v1.DaemonSet:
+		selector = obj.Spec.Selector
+	case *batch_v1.CronJob:
+		if len(obj.Spec.JobTemplate.Spec.Template.Labels) == 0 {
+			return "", false
+		}
+		return labels.Set(obj.Spec.JobTemplate.Spec.Template.Labels).String(), true
+	}
+	if selector == nil {
+		return "", false
+	}
+	parsed, err := meta_v1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return "", false
+	}
+	return parsed.String(), true
 }
 
 // GetImages - returns images used by this resource

--- a/provider/helm3/helm3.go
+++ b/provider/helm3/helm3.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/keel-hq/keel/approvals"
+	"github.com/keel-hq/keel/internal/k8s"
 	"github.com/keel-hq/keel/internal/policy"
 	"github.com/keel-hq/keel/types"
 	"github.com/keel-hq/keel/util/image"
@@ -133,6 +134,8 @@ type ImageDetails struct {
 // Provider - helm3 provider, responsible for managing release updates
 type Provider struct {
 	implementer Implementer
+	platforms   *k8s.PlatformResolver
+	resources   ResourceCache
 
 	sender notification.Sender
 
@@ -142,15 +145,35 @@ type Provider struct {
 	stop   chan struct{}
 }
 
+// ResourceCache provides the Kubernetes workloads indexed by the shared cache.
+type ResourceCache interface {
+	Values() []*k8s.GenericResource
+}
+
+// ProviderOption configures optional Helm provider integrations.
+type ProviderOption func(*Provider)
+
+// WithWorkloadPlatforms enables Kubernetes-backed platform resolution for Helm images.
+func WithWorkloadPlatforms(platforms *k8s.PlatformResolver, resources ResourceCache) ProviderOption {
+	return func(provider *Provider) {
+		provider.platforms = platforms
+		provider.resources = resources
+	}
+}
+
 // NewProvider - create new Helm provider
-func NewProvider(implementer Implementer, sender notification.Sender, approvalManager approvals.Manager) *Provider {
-	return &Provider{
+func NewProvider(implementer Implementer, sender notification.Sender, approvalManager approvals.Manager, options ...ProviderOption) *Provider {
+	provider := &Provider{
 		implementer:     implementer,
 		approvalManager: approvalManager,
 		sender:          sender,
 		events:          make(chan *types.Event, 100),
 		stop:            make(chan struct{}),
 	}
+	for _, option := range options {
+		option(provider)
+	}
+	return provider
 }
 
 // GetName - get provider name
@@ -228,6 +251,7 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 			}
 			img.Namespace = release.Namespace
 			img.Provider = ProviderName
+			img.Platforms, img.PlatformErr = p.releaseImagePlatforms(release.Namespace, release.Name, img)
 			trackedImages = append(trackedImages, img)
 		}
 
@@ -287,6 +311,23 @@ func (p *Provider) createUpdatePlans(event *types.Event) ([]*UpdatePlan, error) 
 		}
 
 		if update {
+			if event.Repository.PlatformVerified {
+				ref, parseErr := image.Parse(event.Repository.String())
+				if parseErr != nil {
+					continue
+				}
+				platforms, resolutionErr := p.releaseImagePlatforms(release.Namespace, release.Name, &types.TrackedImage{Image: ref})
+				if resolutionErr != types.PlatformErrorNone || !types.PlatformsSupportAll(event.Repository.Platforms, platforms) {
+					log.WithFields(log.Fields{
+						"candidate_platforms": event.Repository.Platforms,
+						"eligible_platforms":  platforms,
+						"reason":              resolutionErr,
+						"name":                release.Name,
+						"namespace":           release.Namespace,
+					}).Warn("provider.helm3: skipping polling event that is not compatible with current workload platforms")
+					continue
+				}
+			}
 			helm3VersionedUpdatesCounter.With(prometheus.Labels{"chart": fmt.Sprintf("%s/%s", release.Namespace, release.Name)}).Inc()
 			plans = append(plans, plan)
 		}

--- a/provider/helm3/platform.go
+++ b/provider/helm3/platform.go
@@ -1,0 +1,67 @@
+package helm3
+
+import (
+	"sort"
+
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+const (
+	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
+)
+
+func (p *Provider) releaseImagePlatforms(namespace, releaseName string, trackedImage *types.TrackedImage) ([]types.Platform, types.PlatformError) {
+	if p.platforms == nil || p.resources == nil {
+		return nil, types.PlatformErrorHelmWorkloadMapping
+	}
+	platforms := make(map[types.Platform]struct{})
+	matched := false
+	for _, resource := range p.resources.Values() {
+		annotations := resource.GetAnnotations()
+		if resource.Namespace != namespace || annotations[helmReleaseNameAnnotation] != releaseName || annotations[helmReleaseNamespaceAnnotation] != namespace {
+			continue
+		}
+		if !resourceUsesRepository(resource.GetImages(nil), trackedImage.Image.Repository()) &&
+			!resourceUsesRepository(resource.GetInitImages(nil), trackedImage.Image.Repository()) &&
+			!resourceUsesRepository(resource.GetImageVolumeReferences(nil), trackedImage.Image.Repository()) {
+			continue
+		}
+		matched = true
+		resolved, resolutionErr := p.platforms.Resolve(resource)
+		if resolutionErr != types.PlatformErrorNone {
+			return nil, resolutionErr
+		}
+		for _, platform := range resolved {
+			platforms[platform] = struct{}{}
+		}
+	}
+	if !matched || len(platforms) == 0 {
+		return nil, types.PlatformErrorHelmWorkloadMapping
+	}
+	result := make([]types.Platform, 0, len(platforms))
+	for platform := range platforms {
+		result = append(result, platform)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].OS != result[j].OS {
+			return result[i].OS < result[j].OS
+		}
+		if result[i].Architecture != result[j].Architecture {
+			return result[i].Architecture < result[j].Architecture
+		}
+		return result[i].Variant < result[j].Variant
+	})
+	return result, types.PlatformErrorNone
+}
+
+func resourceUsesRepository(images []string, repository string) bool {
+	for _, candidate := range images {
+		ref, err := image.Parse(candidate)
+		if err == nil && ref.Repository() == repository {
+			return true
+		}
+	}
+	return false
+}

--- a/provider/helm3/platform_test.go
+++ b/provider/helm3/platform_test.go
@@ -1,0 +1,185 @@
+package helm3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+	"helm.sh/helm/v3/pkg/release"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type platformResourceCache struct {
+	resources []*k8s.GenericResource
+}
+
+func (c *platformResourceCache) Values() []*k8s.GenericResource {
+	return c.resources
+}
+
+type helmNodeSource struct {
+	nodes *core_v1.NodeList
+}
+
+func (s *helmNodeSource) Nodes() (*core_v1.NodeList, error) {
+	return s.nodes, nil
+}
+
+func TestReleaseImagePlatforms(t *testing.T) {
+	amd64 := helmTestNode("amd64", "amd64")
+	arm64 := helmTestNode("arm64", "arm64")
+	trackedRef, err := image.Parse("example/image:1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		nodes     []core_v1.Node
+		resources []*k8s.GenericResource
+		want      []types.Platform
+		wantErr   types.PlatformError
+		multiArch bool
+	}{
+		{
+			name:      "one owned workload",
+			nodes:     []core_v1.Node{amd64, arm64},
+			resources: []*k8s.GenericResource{helmWorkload(t, "release", "amd64", "example/image:1.0.0")},
+			want:      []types.Platform{{OS: "linux", Architecture: "amd64"}},
+			multiArch: true,
+		},
+		{
+			name:  "mixed owned workloads",
+			nodes: []core_v1.Node{amd64, arm64},
+			resources: []*k8s.GenericResource{
+				helmWorkload(t, "release", "amd64", "example/image:1.0.0"),
+				helmWorkload(t, "release", "arm64", "example/image:1.0.0"),
+			},
+			want:      []types.Platform{{OS: "linux", Architecture: "amd64"}, {OS: "linux", Architecture: "arm64"}},
+			multiArch: true,
+		},
+		{
+			name:      "missing ownership mapping",
+			nodes:     []core_v1.Node{amd64},
+			resources: []*k8s.GenericResource{helmWorkload(t, "another-release", "amd64", "example/image:1.0.0")},
+			wantErr:   types.PlatformErrorHelmWorkloadMapping,
+		},
+		{
+			name:      "unresolved child workload",
+			nodes:     []core_v1.Node{{ObjectMeta: meta_v1.ObjectMeta{Name: "unknown"}}},
+			resources: []*k8s.GenericResource{helmWorkload(t, "release", "", "example/image:1.0.0")},
+			wantErr:   types.PlatformErrorNodeMetadata,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &Provider{
+				platforms: k8s.NewPlatformResolver(&helmNodeSource{nodes: &core_v1.NodeList{Items: test.nodes}}),
+				resources: &platformResourceCache{resources: test.resources},
+			}
+			got, resolutionErr := provider.releaseImagePlatforms("default", "release", &types.TrackedImage{Image: trackedRef})
+			if resolutionErr != test.wantErr || fmt.Sprint(got) != fmt.Sprint(test.want) {
+				t.Fatalf("got %v (%s), want %v (%s)", got, resolutionErr, test.want, test.wantErr)
+			}
+			if test.multiArch && !types.PlatformsSupportAll([]types.Platform{
+				{OS: "linux", Architecture: "amd64"},
+				{OS: "linux", Architecture: "arm64"},
+			}, got) {
+				t.Fatal("multi-architecture candidate did not cover Helm workloads")
+			}
+		})
+	}
+}
+
+func TestVerifiedPollingEventIsRecheckedBeforeHelmUpdate(t *testing.T) {
+	chart, err := testingStringToChart(`
+image:
+  repository: example/image
+  tag: 1.0.0
+keel:
+  policy: all
+  trigger: poll
+  images:
+    - repository: image.repository
+      tag: image.tag
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	implementer := &fakeImplementer{listReleasesResponse: []*release.Release{{
+		Name:      "release",
+		Namespace: "default",
+		Chart:     chart,
+		Config:    map[string]interface{}{},
+	}}}
+	resolver := k8s.NewPlatformResolver(&helmNodeSource{nodes: &core_v1.NodeList{Items: []core_v1.Node{
+		helmTestNode("amd64", "amd64"),
+	}}})
+	resources := &platformResourceCache{resources: []*k8s.GenericResource{
+		helmWorkload(t, "release", "amd64", "example/image:1.0.0"),
+	}}
+	provider := NewProvider(implementer, nil, nil, WithWorkloadPlatforms(resolver, resources))
+	event := &types.Event{Repository: types.Repository{
+		Name:             "example/image",
+		Tag:              "2.0.0",
+		Platforms:        []types.Platform{{OS: "linux", Architecture: "arm64"}},
+		PlatformVerified: true,
+	}}
+
+	plans, err := provider.createUpdatePlans(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 0 {
+		t.Fatalf("incompatible verified polling event produced plans: %#v", plans)
+	}
+
+	event.Repository.Platforms = []types.Platform{{OS: "linux", Architecture: "amd64"}}
+	plans, err = provider.createUpdatePlans(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("compatible verified polling event produced %d plans", len(plans))
+	}
+}
+
+func helmWorkload(t *testing.T, releaseName, architecture, imageName string) *k8s.GenericResource {
+	t.Helper()
+	nodeSelector := map[string]string{}
+	if architecture != "" {
+		nodeSelector[core_v1.LabelArchStable] = architecture
+	}
+	deployment := &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      releaseName + "-workload-" + architecture,
+			Namespace: "default",
+			Annotations: map[string]string{
+				helmReleaseNameAnnotation:      releaseName,
+				helmReleaseNamespaceAnnotation: "default",
+			},
+		},
+		Spec: apps_v1.DeploymentSpec{Template: core_v1.PodTemplateSpec{Spec: core_v1.PodSpec{
+			NodeSelector: nodeSelector,
+			Containers:   []core_v1.Container{{Name: "app", Image: imageName}},
+		}}},
+	}
+	resource, err := k8s.NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resource
+}
+
+func helmTestNode(name, architecture string) core_v1.Node {
+	return core_v1.Node{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name, Labels: map[string]string{
+			core_v1.LabelOSStable:   "linux",
+			core_v1.LabelArchStable: architecture,
+		}},
+		Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{OperatingSystem: "linux", Architecture: architecture}},
+	}
+}

--- a/provider/kubernetes/implementer.go
+++ b/provider/kubernetes/implementer.go
@@ -21,6 +21,7 @@ import (
 // Implementer - thing wrapper around currently used k8s APIs
 type Implementer interface {
 	Namespaces() (*v1.NamespaceList, error)
+	Nodes() (*v1.NodeList, error)
 	Deployments(namespace string) (*apps_v1.DeploymentList, error)
 	Update(obj *k8s.GenericResource) error
 	Secret(namespace, name string) (*v1.Secret, error)
@@ -104,6 +105,11 @@ func (i *KubernetesImplementer) Config() *rest.Config {
 func (i *KubernetesImplementer) Namespaces() (*v1.NamespaceList, error) {
 	namespaces := i.client.CoreV1().Namespaces()
 	return namespaces.List(context.TODO(), meta_v1.ListOptions{})
+}
+
+// Nodes returns the cluster nodes used to resolve workload platform eligibility.
+func (i *KubernetesImplementer) Nodes() (*v1.NodeList, error) {
+	return i.client.CoreV1().Nodes().List(context.TODO(), meta_v1.ListOptions{})
 }
 
 // Deployment - get specific deployment for namespace/name

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -83,6 +82,7 @@ func (p *UpdatePlan) String() string {
 // Provider - kubernetes provider for auto update
 type Provider struct {
 	implementer Implementer
+	platforms   *k8s.PlatformResolver
 
 	sender notification.Sender
 
@@ -95,9 +95,14 @@ type Provider struct {
 }
 
 // NewProvider - create new kubernetes based provider
-func NewProvider(implementer Implementer, sender notification.Sender, approvalManager approvals.Manager, cache GenericResourceCache) (*Provider, error) {
+func NewProvider(implementer Implementer, sender notification.Sender, approvalManager approvals.Manager, cache GenericResourceCache, resolvers ...*k8s.PlatformResolver) (*Provider, error) {
+	platforms := k8s.NewPlatformResolver(implementer)
+	if len(resolvers) > 0 && resolvers[0] != nil {
+		platforms = resolvers[0]
+	}
 	return &Provider{
 		implementer:     implementer,
+		platforms:       platforms,
 		cache:           cache,
 		approvalManager: approvalManager,
 		events:          make(chan *types.Event, 100),
@@ -292,6 +297,7 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 			volumeFilter := GetMonitorVolumesFromMeta(annotations, labels)
 			images = append(images, gr.GetImageVolumeReferences(volumeFilter)...)
 		}
+		platforms, platformErr := p.platforms.Resolve(gr)
 
 		for _, img := range images {
 			ref, err := image.Parse(img)
@@ -322,34 +328,14 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 				Namespace:    gr.Namespace,
 				Secrets:      secrets,
 				Meta:         make(map[string]string),
-				Platform:     resourcePlatform(gr),
+				Platforms:    platforms,
+				PlatformErr:  platformErr,
 				Policy:       plc,
 			})
 		}
 	}
 
 	return trackedImages, nil
-}
-
-func resourcePlatform(resource *k8s.GenericResource) types.Platform {
-	platform := types.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
-	selector := resource.GetNodeSelector()
-	if os := firstNonEmpty(selector["kubernetes.io/os"], selector["beta.kubernetes.io/os"]); os != "" {
-		platform.OS = os
-	}
-	if architecture := firstNonEmpty(selector["kubernetes.io/arch"], selector["beta.kubernetes.io/arch"]); architecture != "" {
-		platform.Architecture = architecture
-	}
-	return platform
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 func (p *Provider) startInternal() error {
@@ -569,6 +555,20 @@ func (p *Provider) createUpdatePlans(repo *types.Repository) ([]*UpdatePlan, err
 		}
 
 		if shouldUpdateDeployment {
+			if repo.PlatformVerified {
+				platforms, resolutionErr := p.platforms.Resolve(resource)
+				if resolutionErr != types.PlatformErrorNone || !types.PlatformsSupportAll(repo.Platforms, platforms) {
+					log.WithFields(log.Fields{
+						"candidate_platforms": repo.Platforms,
+						"eligible_platforms":  platforms,
+						"reason":              resolutionErr,
+						"deployment":          resource.Name,
+						"kind":                resource.Kind(),
+						"namespace":           resource.Namespace,
+					}).Warn("provider.kubernetes: skipping polling event that is not compatible with current workload platforms")
+					continue
+				}
+			}
 			impacted = append(impacted, updated)
 		}
 	}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -321,12 +322,34 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 				Namespace:    gr.Namespace,
 				Secrets:      secrets,
 				Meta:         make(map[string]string),
+				Platform:     resourcePlatform(gr),
 				Policy:       plc,
 			})
 		}
 	}
 
 	return trackedImages, nil
+}
+
+func resourcePlatform(resource *k8s.GenericResource) types.Platform {
+	platform := types.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	selector := resource.GetNodeSelector()
+	if os := firstNonEmpty(selector["kubernetes.io/os"], selector["beta.kubernetes.io/os"]); os != "" {
+		platform.OS = os
+	}
+	if architecture := firstNonEmpty(selector["kubernetes.io/arch"], selector["beta.kubernetes.io/arch"]); architecture != "" {
+		platform.Architecture = architecture
+	}
+	return platform
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (p *Provider) startInternal() error {

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -43,6 +43,7 @@ func (p *fakeProvider) GetName() string {
 
 type fakeImplementer struct {
 	namespaces     *v1.NamespaceList
+	nodeList       *v1.NodeList
 	deployment     *apps_v1.Deployment
 	deploymentList *apps_v1.DeploymentList
 
@@ -57,6 +58,10 @@ type fakeImplementer struct {
 
 func (i *fakeImplementer) Namespaces() (*v1.NamespaceList, error) {
 	return i.namespaces, nil
+}
+
+func (i *fakeImplementer) Nodes() (*v1.NodeList, error) {
+	return i.nodeList, nil
 }
 
 func (i *fakeImplementer) Deployment(namespace, name string) (*apps_v1.Deployment, error) {
@@ -313,10 +318,10 @@ func TestGetImpactedInit(t *testing.T) {
 		{
 			meta_v1.TypeMeta{},
 			meta_v1.ObjectMeta{
-				Name:      "dep-1",
-				Namespace: "xxxx",
+				Name:        "dep-1",
+				Namespace:   "xxxx",
 				Annotations: map[string]string{types.KeelInitContainerAnnotation: "true"},
-				Labels:    map[string]string{types.KeelPolicyLabel: "all"},
+				Labels:      map[string]string{types.KeelPolicyLabel: "all"},
 			},
 			apps_v1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{
@@ -334,10 +339,10 @@ func TestGetImpactedInit(t *testing.T) {
 		{
 			meta_v1.TypeMeta{},
 			meta_v1.ObjectMeta{
-				Name:      "dep-2",
-				Namespace: "xxxx",
+				Name:        "dep-2",
+				Namespace:   "xxxx",
 				Annotations: map[string]string{types.KeelInitContainerAnnotation: "false"},
-				Labels:    map[string]string{"whatever": "all"},
+				Labels:      map[string]string{"whatever": "all"},
 			},
 			apps_v1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{

--- a/provider/kubernetes/platform_test.go
+++ b/provider/kubernetes/platform_test.go
@@ -1,12 +1,13 @@
 package kubernetes
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResourcePlatform(t *testing.T) {
@@ -22,14 +23,71 @@ func TestResourcePlatform(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := resourcePlatform(resource)
-	if got.OS != "linux" || got.Architecture != "arm64" {
+	resolver := k8s.NewPlatformResolver(&fakeImplementer{nodeList: &core_v1.NodeList{Items: []core_v1.Node{
+		{ObjectMeta: meta_v1.ObjectMeta{Name: "amd64", Labels: map[string]string{core_v1.LabelOSStable: "linux", core_v1.LabelArchStable: "amd64"}}, Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{OperatingSystem: "linux", Architecture: "amd64"}}},
+		{ObjectMeta: meta_v1.ObjectMeta{Name: "arm64", Labels: map[string]string{core_v1.LabelOSStable: "linux", core_v1.LabelArchStable: "arm64"}}, Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{OperatingSystem: "linux", Architecture: "arm64"}}},
+	}}})
+	got, platformErr := resolver.Resolve(resource)
+	if len(got) != 1 || got[0].OS != "linux" || got[0].Architecture != "arm64" {
 		t.Fatalf("got platform %#v", got)
+	}
+	if platformErr != types.PlatformErrorNone {
+		t.Fatalf("unexpected platform error %q", platformErr)
 	}
 
 	deployment.Spec.Template.Spec.NodeSelector = nil
-	got = resourcePlatform(resource)
-	if got.OS != runtime.GOOS || got.Architecture != runtime.GOARCH {
-		t.Fatalf("got fallback platform %#v", got)
+	got, platformErr = resolver.Resolve(resource)
+	if len(got) != 2 || platformErr != types.PlatformErrorNone {
+		t.Fatalf("expected both node platforms, got %#v (%s)", got, platformErr)
+	}
+}
+
+func TestVerifiedPollingEventIsRecheckedBeforeKubernetesUpdate(t *testing.T) {
+	deployment := &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "app",
+			Namespace: "default",
+			Labels:    map[string]string{types.KeelPolicyLabel: "all"},
+		},
+		Spec: apps_v1.DeploymentSpec{Template: core_v1.PodTemplateSpec{Spec: core_v1.PodSpec{
+			NodeSelector: map[string]string{core_v1.LabelArchStable: "amd64"},
+			Containers:   []core_v1.Container{{Image: "example/image:1.0.0"}},
+		}}},
+	}
+	resource, err := k8s.NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := &k8s.GenericResourceCache{}
+	cache.Add(resource)
+	implementer := &fakeImplementer{nodeList: &core_v1.NodeList{Items: []core_v1.Node{
+		{ObjectMeta: meta_v1.ObjectMeta{Name: "amd64", Labels: map[string]string{core_v1.LabelOSStable: "linux", core_v1.LabelArchStable: "amd64"}}, Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{OperatingSystem: "linux", Architecture: "amd64"}}},
+	}}}
+	provider, err := NewProvider(implementer, &fakeSender{}, nil, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repository := &types.Repository{
+		Name:             "example/image",
+		Tag:              "2.0.0",
+		Platforms:        []types.Platform{{OS: "linux", Architecture: "arm64"}},
+		PlatformVerified: true,
+	}
+	plans, err := provider.createUpdatePlans(repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 0 {
+		t.Fatalf("incompatible verified polling event produced plans: %#v", plans)
+	}
+
+	repository.Platforms = []types.Platform{{OS: "linux", Architecture: "amd64"}}
+	plans, err = provider.createUpdatePlans(repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("compatible verified polling event produced %d plans", len(plans))
 	}
 }

--- a/provider/kubernetes/platform_test.go
+++ b/provider/kubernetes/platform_test.go
@@ -1,0 +1,35 @@
+package kubernetes
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+func TestResourcePlatform(t *testing.T) {
+	deployment := &apps_v1.Deployment{
+		Spec: apps_v1.DeploymentSpec{Template: core_v1.PodTemplateSpec{
+			Spec: core_v1.PodSpec{NodeSelector: map[string]string{
+				"kubernetes.io/os":   "linux",
+				"kubernetes.io/arch": "arm64",
+			}},
+		}},
+	}
+	resource, err := k8s.NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := resourcePlatform(resource)
+	if got.OS != "linux" || got.Architecture != "arm64" {
+		t.Fatalf("got platform %#v", got)
+	}
+
+	deployment.Spec.Template.Spec.NodeSelector = nil
+	got = resourcePlatform(resource)
+	if got.OS != runtime.GOOS || got.Architecture != runtime.GOARCH {
+		t.Fatalf("got fallback platform %#v", got)
+	}
+}

--- a/registry/docker/manifest.go
+++ b/registry/docker/manifest.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	manifestlist "github.com/distribution/distribution/v3/manifest/manifestlist"
 	manifestv2 "github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/opencontainers/go-digest"
 	oci "github.com/opencontainers/image-spec/specs-go/v1"
@@ -49,7 +50,7 @@ func (r *Registry) request(method string, url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	req.Header.Set("Accept", strings.Join([]string{manifestv2.MediaTypeManifest, oci.MediaTypeImageIndex, oci.MediaTypeImageManifest}, ","))
+	req.Header.Set("Accept", strings.Join([]string{manifestlist.MediaTypeManifestList, manifestv2.MediaTypeManifest, oci.MediaTypeImageIndex, oci.MediaTypeImageManifest}, ","))
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/registry/docker/platform.go
+++ b/registry/docker/platform.go
@@ -1,0 +1,97 @@
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+
+	manifestlist "github.com/distribution/distribution/v3/manifest/manifestlist"
+	manifestv2 "github.com/distribution/distribution/v3/manifest/schema2"
+	"github.com/keel-hq/keel/types"
+	oci "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ManifestPlatforms resolves the platforms supported by a manifest or image
+// index. Single-platform manifests get their platform from the image config.
+func (r *Registry) ManifestPlatforms(repository, reference string) ([]types.Platform, error) {
+	manifestURL := r.url("/v2/%s/manifests/%s", repository, reference)
+	resp, err := r.request(http.MethodGet, manifestURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("manifest request returned %s", resp.Status)
+	}
+
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid manifest content type: %w", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch mediaType {
+	case manifestlist.MediaTypeManifestList, oci.MediaTypeImageIndex:
+		var index oci.Index
+		if err := json.Unmarshal(body, &index); err != nil {
+			return nil, fmt.Errorf("decode image index: %w", err)
+		}
+		platforms := make([]types.Platform, 0, len(index.Manifests))
+		for _, descriptor := range index.Manifests {
+			if descriptor.Platform == nil || descriptor.Platform.OS == "" || descriptor.Platform.Architecture == "" {
+				continue
+			}
+			platforms = append(platforms, types.Platform{
+				OS:           descriptor.Platform.OS,
+				Architecture: descriptor.Platform.Architecture,
+				Variant:      descriptor.Platform.Variant,
+			})
+		}
+		if len(platforms) == 0 {
+			return nil, fmt.Errorf("image index contains no platform metadata")
+		}
+		return platforms, nil
+
+	case manifestv2.MediaTypeManifest, oci.MediaTypeImageManifest:
+		var manifest oci.Manifest
+		if err := json.Unmarshal(body, &manifest); err != nil {
+			return nil, fmt.Errorf("decode image manifest: %w", err)
+		}
+		if manifest.Config.Digest == "" {
+			return nil, fmt.Errorf("image manifest has no config digest")
+		}
+		return r.configPlatforms(repository, manifest.Config.Digest.String())
+	default:
+		return nil, fmt.Errorf("unsupported manifest content type %q", mediaType)
+	}
+}
+
+func (r *Registry) configPlatforms(repository, configDigest string) ([]types.Platform, error) {
+	configURL := r.url("/v2/%s/blobs/%s", repository, configDigest)
+	resp, err := r.request(http.MethodGet, configURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("image config request returned %s", resp.Status)
+	}
+
+	var config oci.Image
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return nil, fmt.Errorf("decode image config: %w", err)
+	}
+	if config.OS == "" || config.Architecture == "" {
+		return nil, fmt.Errorf("image config contains no platform metadata")
+	}
+	return []types.Platform{{
+		OS:           config.OS,
+		Architecture: config.Architecture,
+		Variant:      config.Variant,
+	}}, nil
+}

--- a/registry/docker/platform_test.go
+++ b/registry/docker/platform_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestManifestPlatformsRegistryFixture(t *testing.T) {
 	const (
-		amd64Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		armDigest   = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		amd64Digest   = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		armDigest     = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		missingDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	)
 
 	manifest := func(configDigest string) []byte {
@@ -58,10 +59,27 @@ func TestManifestPlatformsRegistryFixture(t *testing.T) {
 		case "/v2/example/image/manifests/multi":
 			w.Header().Set("Content-Type", manifestlist.MediaTypeManifestList)
 			_, _ = w.Write(indexBody)
+		case "/v2/example/image/manifests/oci-multi":
+			w.Header().Set("Content-Type", oci.MediaTypeImageIndex)
+			_, _ = w.Write(indexBody)
+		case "/v2/example/image/manifests/malformed":
+			w.Header().Set("Content-Type", oci.MediaTypeImageIndex)
+			_, _ = w.Write([]byte("{"))
+		case "/v2/example/image/manifests/no-platforms":
+			w.Header().Set("Content-Type", oci.MediaTypeImageIndex)
+			_, _ = w.Write([]byte(`{"schemaVersion":2,"manifests":[{}]}`))
+		case "/v2/example/image/manifests/missing-config-platform":
+			w.Header().Set("Content-Type", manifestv2.MediaTypeManifest)
+			_, _ = w.Write(manifest(missingDigest))
+		case "/v2/example/image/manifests/schema1":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v1+json")
+			_, _ = w.Write([]byte(`{"schemaVersion":1}`))
 		case "/v2/example/image/blobs/" + amd64Digest:
 			_ = json.NewEncoder(w).Encode(oci.Image{Platform: oci.Platform{OS: "linux", Architecture: "amd64"}})
 		case "/v2/example/image/blobs/" + armDigest:
 			_ = json.NewEncoder(w).Encode(oci.Image{Platform: oci.Platform{OS: "linux", Architecture: "arm", Variant: "v7"}})
+		case "/v2/example/image/blobs/" + missingDigest:
+			_ = json.NewEncoder(w).Encode(oci.Image{})
 		default:
 			http.NotFound(w, r)
 		}
@@ -79,6 +97,10 @@ func TestManifestPlatformsRegistryFixture(t *testing.T) {
 			{OS: "linux", Architecture: "amd64"},
 			{OS: "linux", Architecture: "arm64", Variant: "v8"},
 		}},
+		{tag: "oci-multi", want: []types.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64", Variant: "v8"},
+		}},
 	}
 	for _, test := range tests {
 		t.Run(test.tag, func(t *testing.T) {
@@ -93,6 +115,14 @@ func TestManifestPlatformsRegistryFixture(t *testing.T) {
 				if got[i] != test.want[i] {
 					t.Fatalf("got %v, want %v", got, test.want)
 				}
+			}
+		})
+	}
+
+	for _, tag := range []string{"malformed", "no-platforms", "missing-config-platform", "schema1"} {
+		t.Run(tag, func(t *testing.T) {
+			if _, err := registry.ManifestPlatforms("example/image", tag); err == nil {
+				t.Fatalf("expected platform resolution error for %s", tag)
 			}
 		})
 	}

--- a/registry/docker/platform_test.go
+++ b/registry/docker/platform_test.go
@@ -1,0 +1,99 @@
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	manifestlist "github.com/distribution/distribution/v3/manifest/manifestlist"
+	manifestv2 "github.com/distribution/distribution/v3/manifest/schema2"
+	"github.com/keel-hq/keel/types"
+	"github.com/opencontainers/go-digest"
+	oci "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestManifestPlatformsRegistryFixture(t *testing.T) {
+	const (
+		amd64Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		armDigest   = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	manifest := func(configDigest string) []byte {
+		body, err := json.Marshal(oci.Manifest{
+			MediaType: manifestv2.MediaTypeManifest,
+			Config: oci.Descriptor{
+				MediaType: oci.MediaTypeImageConfig,
+				Digest:    digest.Digest(configDigest),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return body
+	}
+	indexBody, err := json.Marshal(oci.Index{
+		MediaType: oci.MediaTypeImageIndex,
+		Manifests: []oci.Descriptor{
+			{Platform: &oci.Platform{OS: "linux", Architecture: "amd64"}},
+			{Platform: &oci.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/example/image/manifests/multi" && !strings.Contains(r.Header.Get("Accept"), manifestlist.MediaTypeManifestList) {
+			t.Error("manifest request did not advertise Docker manifest-list support")
+		}
+		switch r.URL.Path {
+		case "/v2/example/image/manifests/amd64":
+			w.Header().Set("Content-Type", manifestv2.MediaTypeManifest)
+			_, _ = w.Write(manifest(amd64Digest))
+		case "/v2/example/image/manifests/armhf":
+			w.Header().Set("Content-Type", manifestv2.MediaTypeManifest)
+			_, _ = w.Write(manifest(armDigest))
+		case "/v2/example/image/manifests/multi":
+			w.Header().Set("Content-Type", manifestlist.MediaTypeManifestList)
+			_, _ = w.Write(indexBody)
+		case "/v2/example/image/blobs/" + amd64Digest:
+			_ = json.NewEncoder(w).Encode(oci.Image{Platform: oci.Platform{OS: "linux", Architecture: "amd64"}})
+		case "/v2/example/image/blobs/" + armDigest:
+			_ = json.NewEncoder(w).Encode(oci.Image{Platform: oci.Platform{OS: "linux", Architecture: "arm", Variant: "v7"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registry := New(server.URL, "", "")
+	tests := []struct {
+		tag  string
+		want []types.Platform
+	}{
+		{tag: "amd64", want: []types.Platform{{OS: "linux", Architecture: "amd64"}}},
+		{tag: "armhf", want: []types.Platform{{OS: "linux", Architecture: "arm", Variant: "v7"}}},
+		{tag: "multi", want: []types.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64", Variant: "v8"},
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			got, err := registry.ManifestPlatforms("example/image", test.tag)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("got %v, want %v", got, test.want)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Fatalf("got %v, want %v", got, test.want)
+				}
+			}
+		})
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/keel-hq/keel/registry/docker"
+	"github.com/keel-hq/keel/types"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -30,6 +31,7 @@ type Repository struct {
 type Client interface {
 	Get(opts Opts) (*Repository, error)
 	Digest(opts Opts) (string, error)
+	Platforms(opts Opts) ([]types.Platform, error)
 }
 
 // New - new registry client
@@ -145,4 +147,27 @@ INIT_CLIENT:
 	}
 
 	return manifestDigest.String(), nil
+}
+
+// Platforms returns the platforms supported by a tagged image manifest.
+func (c *DefaultClient) Platforms(opts Opts) ([]types.Platform, error) {
+	if opts.Tag == "" {
+		return nil, ErrTagNotSupplied
+	}
+
+INIT_CLIENT:
+	hub, err := c.getRegistryClient(opts.Registry, opts.Username, opts.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	platforms, err := hub.ManifestPlatforms(opts.Name, opts.Tag)
+	if err != nil {
+		if strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") && strings.HasPrefix(opts.Registry, "https://") && c.insecure {
+			opts.Registry = strings.Replace(opts.Registry, "https://", "http://", 1)
+			goto INIT_CLIENT
+		}
+		return nil, err
+	}
+	return platforms, nil
 }

--- a/tests/e2e_resources_test.go
+++ b/tests/e2e_resources_test.go
@@ -73,6 +73,7 @@ func createKeelResources(ctx context.Context, client kubernetes.Interface, cfg e
 				ObjectMeta: metav1.ObjectMeta{Name: "keel-e2e-" + cfg.runID, Labels: labels},
 				Rules: []rbacv1.PolicyRule{
 					{APIGroups: []string{""}, Resources: []string{"namespaces"}, Verbs: []string{"list", "watch"}},
+					{APIGroups: []string{""}, Resources: []string{"nodes"}, Verbs: []string{"get", "list", "watch"}},
 					{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list", "watch"}},
 					{APIGroups: []string{"", "apps", "batch"}, Resources: []string{"pods", "replicasets", "replicationcontrollers", "statefulsets", "deployments", "daemonsets", "jobs", "cronjobs"}, Verbs: []string{"get", "delete", "list", "update", "watch"}},
 				},

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -41,6 +41,8 @@ func (s *E2ESuite) SetupSuite() {
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", s.cfg.kubeconfig)
 	require.NoError(s.T(), err)
+	restConfig.QPS = 50
+	restConfig.Burst = 100
 	s.client, err = kubernetes.NewForConfig(restConfig)
 	require.NoError(s.T(), err)
 	require.NoError(s.T(), createKeelResources(context.Background(), s.client, s.cfg))

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -1,6 +1,8 @@
 package poll
 
 import (
+	"runtime"
+
 	"github.com/keel-hq/keel/extension/credentialshelper"
 	"github.com/keel-hq/keel/provider"
 	"github.com/keel-hq/keel/registry"
@@ -92,6 +94,8 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 
 	// This contains all tracked images that share the same imageIdentifier and thus, the same watcher
 	allRelatedTrackedImages := getRelatedTrackedImages(j.details.trackedImage, trackedImages)
+	platformCache := make(map[string][]types.Platform)
+	platformErrorCache := make(map[string]error)
 
 	for _, trackedImage := range allRelatedTrackedImages {
 
@@ -114,6 +118,33 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 			if trackedImage.Image.Tag() == tag {
 				break
 			}
+
+			platforms, resolved := platformCache[tag]
+			platformErr, failed := platformErrorCache[tag]
+			if !resolved && !failed {
+				platforms, platformErr = j.candidatePlatforms(trackedImage, tag)
+				if platformErr != nil {
+					platformErrorCache[tag] = platformErr
+				} else {
+					platformCache[tag] = platforms
+				}
+			}
+			if platformErr != nil {
+				log.WithFields(log.Fields{
+					"error": platformErr,
+					"image": trackedImage.Image.Repository(),
+					"tag":   tag,
+				}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because its platform could not be established")
+				continue
+			}
+			if !supportsRelatedWorkloads(platforms, tag, allRelatedTrackedImages) {
+				log.WithFields(log.Fields{
+					"candidate_platforms": platforms,
+					"image":               trackedImage.Image.Repository(),
+					"tag":                 tag,
+				}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because it is incompatible with a related workload platform")
+				continue
+			}
 			if !exists(tag, events) {
 				event := types.Event{
 					Repository: types.Repository{
@@ -134,6 +165,47 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 	}).Debug("trigger.poll.WatchRepositoryTagsJob: events: ", events)
 
 	return events, nil
+}
+
+func (j *WatchRepositoryTagsJob) candidatePlatforms(trackedImage *types.TrackedImage, tag string) ([]types.Platform, error) {
+	opts := registry.Opts{
+		Registry: trackedImage.Image.Scheme() + "://" + trackedImage.Image.Registry(),
+		Name:     trackedImage.Image.ShortName(),
+		Tag:      tag,
+	}
+	if creds, err := credentialshelper.GetCredentials(trackedImage); err == nil {
+		opts.Username = creds.Username
+		opts.Password = creds.Password
+	}
+	return j.registryClient.Platforms(opts)
+}
+
+func supportsRelatedWorkloads(candidatePlatforms []types.Platform, candidateTag string, trackedImages []*types.TrackedImage) bool {
+	for _, trackedImage := range trackedImages {
+		update, err := trackedImage.Policy.ShouldUpdate(trackedImage.Image.Tag(), candidateTag)
+		if err != nil || !update || trackedImage.Image.Tag() == candidateTag {
+			continue
+		}
+		target := trackedImage.Platform
+		if target.OS == "" {
+			target.OS = runtime.GOOS
+		}
+		if target.Architecture == "" {
+			target.Architecture = runtime.GOARCH
+		}
+
+		supported := false
+		for _, candidate := range candidatePlatforms {
+			if candidate.Supports(target) {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			return false
+		}
+	}
+	return true
 }
 
 func exists(tag string, events []types.Event) bool {

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -1,8 +1,6 @@
 package poll
 
 import (
-	"runtime"
-
 	"github.com/keel-hq/keel/extension/credentialshelper"
 	"github.com/keel-hq/keel/provider"
 	"github.com/keel-hq/keel/registry"
@@ -96,8 +94,20 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 	allRelatedTrackedImages := getRelatedTrackedImages(j.details.trackedImage, trackedImages)
 	platformCache := make(map[string][]types.Platform)
 	platformErrorCache := make(map[string]error)
+	diagnosedCandidates := make(map[string]bool)
 
 	for _, trackedImage := range allRelatedTrackedImages {
+		if trackedImage.PlatformErr != types.PlatformErrorNone || len(trackedImage.Platforms) == 0 {
+			reason := trackedImage.PlatformErr
+			if reason == types.PlatformErrorNone {
+				reason = types.PlatformErrorWorkloadMetadata
+			}
+			log.WithFields(log.Fields{
+				"image":  trackedImage.Image.Repository(),
+				"reason": reason,
+			}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping workload because its eligible platforms could not be established")
+			continue
+		}
 
 		filteredTags := tags
 
@@ -130,26 +140,35 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 				}
 			}
 			if platformErr != nil {
-				log.WithFields(log.Fields{
-					"error": platformErr,
-					"image": trackedImage.Image.Repository(),
-					"tag":   tag,
-				}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because its platform could not be established")
+				if !diagnosedCandidates[tag] {
+					log.WithFields(log.Fields{
+						"error": platformErr,
+						"image": trackedImage.Image.Repository(),
+						"tag":   tag,
+					}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because its platform could not be established")
+					diagnosedCandidates[tag] = true
+				}
 				continue
 			}
 			if !supportsRelatedWorkloads(platforms, tag, allRelatedTrackedImages) {
-				log.WithFields(log.Fields{
-					"candidate_platforms": platforms,
-					"image":               trackedImage.Image.Repository(),
-					"tag":                 tag,
-				}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because it is incompatible with a related workload platform")
+				if !diagnosedCandidates[tag] {
+					log.WithFields(log.Fields{
+						"candidate_platforms": platforms,
+						"eligible_platforms":  relatedPlatforms(allRelatedTrackedImages),
+						"image":               trackedImage.Image.Repository(),
+						"tag":                 tag,
+					}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping candidate because it is incompatible with a related workload platform")
+					diagnosedCandidates[tag] = true
+				}
 				continue
 			}
 			if !exists(tag, events) {
 				event := types.Event{
 					Repository: types.Repository{
-						Name: trackedImage.Image.Repository(),
-						Tag:  tag,
+						Name:             trackedImage.Image.Repository(),
+						Tag:              tag,
+						Platforms:        platforms,
+						PlatformVerified: true,
 					},
 					TriggerName: types.TriggerTypePoll.String(),
 				}
@@ -165,6 +184,21 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 	}).Debug("trigger.poll.WatchRepositoryTagsJob: events: ", events)
 
 	return events, nil
+}
+
+func relatedPlatforms(trackedImages []*types.TrackedImage) []types.Platform {
+	var result []types.Platform
+	seen := make(map[types.Platform]struct{})
+	for _, trackedImage := range trackedImages {
+		for _, platform := range trackedImage.Platforms {
+			if _, ok := seen[platform]; ok {
+				continue
+			}
+			seen[platform] = struct{}{}
+			result = append(result, platform)
+		}
+	}
+	return result
 }
 
 func (j *WatchRepositoryTagsJob) candidatePlatforms(trackedImage *types.TrackedImage, tag string) ([]types.Platform, error) {
@@ -186,22 +220,10 @@ func supportsRelatedWorkloads(candidatePlatforms []types.Platform, candidateTag 
 		if err != nil || !update || trackedImage.Image.Tag() == candidateTag {
 			continue
 		}
-		target := trackedImage.Platform
-		if target.OS == "" {
-			target.OS = runtime.GOOS
+		if trackedImage.PlatformErr != types.PlatformErrorNone || len(trackedImage.Platforms) == 0 {
+			return false
 		}
-		if target.Architecture == "" {
-			target.Architecture = runtime.GOARCH
-		}
-
-		supported := false
-		for _, candidate := range candidatePlatforms {
-			if candidate.Supports(target) {
-				supported = true
-				break
-			}
-		}
-		if !supported {
+		if !types.PlatformsSupportAll(candidatePlatforms, trackedImage.Platforms) {
 			return false
 		}
 	}

--- a/trigger/poll/platform_integration_test.go
+++ b/trigger/poll/platform_integration_test.go
@@ -1,0 +1,257 @@
+package poll
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keel-hq/keel/approvals"
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/provider/kubernetes"
+	"github.com/keel-hq/keel/registry"
+	"github.com/keel-hq/keel/types"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_typed_v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type integrationImplementer struct {
+	kubernetes.Implementer
+	nodes   *core_v1.NodeList
+	updated chan *k8s.GenericResource
+}
+
+func (i *integrationImplementer) Nodes() (*core_v1.NodeList, error) { return i.nodes, nil }
+func (i *integrationImplementer) Pods(string, string) (*core_v1.PodList, error) {
+	return &core_v1.PodList{}, nil
+}
+func (i *integrationImplementer) Update(resource *k8s.GenericResource) error {
+	i.updated <- resource.DeepCopy()
+	return nil
+}
+func (i *integrationImplementer) ConfigMaps(string) core_typed_v1.ConfigMapInterface {
+	return nil
+}
+
+type integrationSender struct{ notification.Sender }
+
+func (integrationSender) Send(types.EventNotification) error { return nil }
+
+type integrationApprovals struct{ approvals.Manager }
+
+func (integrationApprovals) Exists(string) bool { return false }
+
+type integrationProviders struct{ provider *kubernetes.Provider }
+
+func (p integrationProviders) Submit(event types.Event) error { return p.provider.Submit(event) }
+func (p integrationProviders) TrackedImages() ([]*types.TrackedImage, error) {
+	return p.provider.TrackedImages()
+}
+func (p integrationProviders) List() []string { return []string{p.provider.GetName()} }
+func (p integrationProviders) Stop()          { p.provider.Stop() }
+
+type registryPlatform struct {
+	OS           string
+	Architecture string
+	Variant      string
+}
+
+func TestRegistryPollingToKubernetesPlatformSelection(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentTag    string
+		tags          []string
+		selector      map[string]string
+		nodePlatforms []registryPlatform
+		manifests     map[string][]registryPlatform
+		wantTag       string
+	}{
+		{
+			name:       "issue 834 skips newer armhf tag on amd64 workload",
+			currentTag: "latest",
+			tags:       []string{"latest", "10.10.7", "20240303.2-unstable-armhf"},
+			selector:   map[string]string{core_v1.LabelArchStable: "amd64"},
+			nodePlatforms: []registryPlatform{
+				{OS: "linux", Architecture: "amd64"},
+			},
+			manifests: map[string][]registryPlatform{
+				"10.10.7":                   {{OS: "linux", Architecture: "amd64"}},
+				"20240303.2-unstable-armhf": {{OS: "linux", Architecture: "arm", Variant: "v7"}},
+			},
+			wantTag: "10.10.7",
+		},
+		{
+			name:       "mixed workload rejects single platform and accepts multi arch",
+			currentTag: "1.0.0",
+			tags:       []string{"1.0.0", "2.0.0", "3.0.0"},
+			nodePlatforms: []registryPlatform{
+				{OS: "linux", Architecture: "amd64"},
+				{OS: "linux", Architecture: "arm64"},
+			},
+			manifests: map[string][]registryPlatform{
+				"3.0.0": {{OS: "linux", Architecture: "amd64"}},
+				"2.0.0": {
+					{OS: "linux", Architecture: "amd64"},
+					{OS: "linux", Architecture: "arm64"},
+				},
+			},
+			wantTag: "2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newPlatformRegistry(t, tt.tags, tt.manifests)
+			defer server.Close()
+
+			imageName := strings.TrimPrefix(server.URL, "http://") + "/jellyfin/jellyfin:" + tt.currentTag
+			deployment := &apps_v1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "jellyfin",
+					Namespace: "media",
+					Labels: map[string]string{
+						types.KeelPolicyLabel:  "major",
+						types.KeelTriggerLabel: "poll",
+					},
+				},
+				Spec: apps_v1.DeploymentSpec{
+					Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": "jellyfin"}},
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{"app": "jellyfin"}},
+						Spec: core_v1.PodSpec{
+							NodeSelector: tt.selector,
+							Containers:   []core_v1.Container{{Name: "jellyfin", Image: "http://" + imageName}},
+						},
+					},
+				},
+			}
+			resource, err := k8s.NewGenericResource(deployment)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cache := &k8s.GenericResourceCache{}
+			cache.Add(resource)
+
+			implementer := &integrationImplementer{updated: make(chan *k8s.GenericResource, 1)}
+			for index, platform := range tt.nodePlatforms {
+				implementer.nodes = appendNode(implementer.nodes, index, platform)
+			}
+			kubeProvider, err := kubernetes.NewProvider(implementer, integrationSender{}, integrationApprovals{}, cache)
+			if err != nil {
+				t.Fatal(err)
+			}
+			providers := integrationProviders{provider: kubeProvider}
+			providerDone := make(chan error, 1)
+			go func() { providerDone <- kubeProvider.Start() }()
+			defer func() {
+				providers.Stop()
+				<-providerDone
+			}()
+
+			tracked, err := providers.TrackedImages()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tracked) != 1 {
+				t.Fatalf("expected one tracked image, got %d", len(tracked))
+			}
+			job := NewWatchRepositoryTagsJob(providers, registry.New(), &watchDetails{trackedImage: tracked[0]})
+			job.Run()
+
+			select {
+			case updated := <-implementer.updated:
+				got := updated.GetImages(nil)
+				if len(got) != 1 || !strings.HasSuffix(got[0], ":"+tt.wantTag) {
+					t.Fatalf("expected selected tag %s, got %v", tt.wantTag, got)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timed out waiting for Kubernetes update to %s", tt.wantTag)
+			}
+		})
+	}
+}
+
+func appendNode(nodes *core_v1.NodeList, index int, platform registryPlatform) *core_v1.NodeList {
+	if nodes == nil {
+		nodes = &core_v1.NodeList{}
+	}
+	nodes.Items = append(nodes.Items, core_v1.Node{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: fmt.Sprintf("node-%d", index),
+			Labels: map[string]string{
+				core_v1.LabelOSStable:   platform.OS,
+				core_v1.LabelArchStable: platform.Architecture,
+			},
+		},
+		Status: core_v1.NodeStatus{NodeInfo: core_v1.NodeSystemInfo{
+			OperatingSystem: platform.OS,
+			Architecture:    platform.Architecture,
+		}},
+	})
+	return nodes
+}
+
+func newPlatformRegistry(t *testing.T, tags []string, manifests map[string][]registryPlatform) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/jellyfin/jellyfin/tags/list":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "jellyfin/jellyfin", "tags": tags})
+		case strings.HasPrefix(r.URL.Path, "/v2/jellyfin/jellyfin/manifests/"):
+			tag := strings.TrimPrefix(r.URL.Path, "/v2/jellyfin/jellyfin/manifests/")
+			platforms, ok := manifests[tag]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			if len(platforms) == 1 {
+				w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"schemaVersion": 2,
+					"config": map[string]interface{}{
+						"mediaType": "application/vnd.oci.image.config.v1+json",
+						"digest":    configDigest(tag),
+						"size":      1,
+					},
+				})
+				return
+			}
+			w.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+			descriptors := make([]map[string]interface{}, 0, len(platforms))
+			for index, platform := range platforms {
+				descriptors = append(descriptors, map[string]interface{}{
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"digest":    fmt.Sprintf("sha256:%064x", index+1),
+					"size":      1,
+					"platform":  platform,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"schemaVersion": 2, "manifests": descriptors})
+		case strings.HasPrefix(r.URL.Path, "/v2/jellyfin/jellyfin/blobs/"):
+			digest := strings.TrimPrefix(r.URL.Path, "/v2/jellyfin/jellyfin/blobs/")
+			for tag, platforms := range manifests {
+				if len(platforms) == 1 && digest == configDigest(tag) {
+					_ = json.NewEncoder(w).Encode(platforms[0])
+					return
+				}
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func configDigest(tag string) string {
+	var total int
+	for _, char := range tag {
+		total += int(char)
+	}
+	return fmt.Sprintf("sha256:%064x", total)
+}

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/keel-hq/keel/approvals"
@@ -14,6 +15,7 @@ import (
 	"github.com/keel-hq/keel/registry"
 	"github.com/keel-hq/keel/types"
 	"github.com/keel-hq/keel/util/image"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func mustParse(img string, schedule string) *types.TrackedImage {
@@ -42,6 +44,7 @@ type fakeRegistryClient struct {
 	platformsToReturn map[string][]types.Platform
 	platformErrors    map[string]error
 	platformErr       error
+	platformCalls     []string
 }
 
 func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, error) {
@@ -59,6 +62,7 @@ func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err erro
 
 func (c *fakeRegistryClient) Platforms(opts registry.Opts) ([]types.Platform, error) {
 	c.opts = opts
+	c.platformCalls = append(c.platformCalls, opts.Tag)
 	if err, ok := c.platformErrors[opts.Tag]; ok {
 		return nil, err
 	}
@@ -77,6 +81,21 @@ type fakeProvider struct {
 	images    []*types.TrackedImage
 }
 
+type fakeProviders struct {
+	provider *fakeProvider
+}
+
+func (p *fakeProviders) Submit(event types.Event) error {
+	return p.provider.Submit(event)
+}
+
+func (p *fakeProviders) TrackedImages() ([]*types.TrackedImage, error) {
+	return p.provider.TrackedImages()
+}
+
+func (p *fakeProviders) List() []string { return []string{p.provider.GetName()} }
+func (p *fakeProviders) Stop()          {}
+
 func (p *fakeProvider) Submit(event types.Event) error {
 	p.submitted = append(p.submitted, event)
 	return nil
@@ -89,6 +108,11 @@ func (p *fakeProvider) Stop() {
 	return
 }
 func (p *fakeProvider) TrackedImages() ([]*types.TrackedImage, error) {
+	for _, trackedImage := range p.images {
+		if len(trackedImage.Platforms) == 0 && trackedImage.PlatformErr == types.PlatformErrorNone {
+			trackedImage.Platforms = []types.Platform{{OS: "linux", Architecture: "amd64"}}
+		}
+	}
 	return p.images, nil
 }
 
@@ -316,7 +340,7 @@ func TestWatchAllTagsJobCurrentLatest(t *testing.T) {
 	// checking whether new job was submitted
 
 	if len(fp.submitted) != 0 {
-		t.Errorf("expected 0 submitted events but got something: %s", fp.submitted[0].Repository)
+		t.Errorf("expected 0 submitted events but got something: %v", fp.submitted[0].Repository)
 	}
 
 }
@@ -415,19 +439,20 @@ func TestWatchMultipleTags(t *testing.T) {
 }
 
 func TestReportedLatestMajorTagSetSkipsArmCandidate(t *testing.T) {
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
 	img, _ := image.Parse("jellyfin/jellyfin:latest")
 	fp := &fakeProvider{images: []*types.TrackedImage{{
 		Image:   img,
 		Trigger: types.TriggerTypePoll,
 		Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
-		Platform: types.Platform{
+		Platforms: []types.Platform{{
 			OS:           "linux",
 			Architecture: "amd64",
-		},
+		}},
 	}}}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	providers := &fakeProviders{provider: fp}
 	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
 		"20240303.2-unstable-armhf": {{OS: "linux", Architecture: "arm", Variant: "v7"}},
 		"10.10.7":                   {{OS: "linux", Architecture: "amd64"}},
@@ -441,19 +466,21 @@ func TestReportedLatestMajorTagSetSkipsArmCandidate(t *testing.T) {
 	if len(events) != 1 || events[0].Repository.Tag != "10.10.7" {
 		t.Fatalf("expected compatible update after skipping ARM candidate, got %#v", events)
 	}
+	if !events[0].Repository.PlatformVerified || !types.PlatformsSupportAll(events[0].Repository.Platforms, fp.images[0].Platforms) {
+		t.Fatalf("event did not carry verified platform evidence: %#v", events[0].Repository)
+	}
+	assertLogMessage(t, hook, "skipping candidate because it is incompatible with a related workload platform")
 }
 
 func TestCandidateSelectionAcceptsMultiArchManifest(t *testing.T) {
 	img, _ := image.Parse("example/image:1.0.0")
 	fp := &fakeProvider{images: []*types.TrackedImage{{
-		Image:    img,
-		Trigger:  types.TriggerTypePoll,
-		Policy:   policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
-		Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+		Image:     img,
+		Trigger:   types.TriggerTypePoll,
+		Policy:    policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platforms: []types.Platform{{OS: "linux", Architecture: "amd64"}},
 	}}}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	providers := &fakeProviders{provider: fp}
 	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
 		"2.0.0": {
 			{OS: "linux", Architecture: "arm64"},
@@ -472,15 +499,16 @@ func TestCandidateSelectionAcceptsMultiArchManifest(t *testing.T) {
 }
 
 func TestCandidateSelectionFailsClosedWhenPlatformResolutionFails(t *testing.T) {
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
 	img, _ := image.Parse("example/image:1.0.0")
 	fp := &fakeProvider{images: []*types.TrackedImage{{
 		Image:   img,
 		Trigger: types.TriggerTypePoll,
 		Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
 	}}}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	providers := &fakeProviders{provider: fp}
 	job := NewWatchRepositoryTagsJob(providers, &fakeRegistryClient{platformErr: errors.New("no manifest metadata")}, &watchDetails{trackedImage: fp.images[0]})
 
 	events, err := job.computeEvents([]string{"2.0.0"})
@@ -490,6 +518,7 @@ func TestCandidateSelectionFailsClosedWhenPlatformResolutionFails(t *testing.T) 
 	if len(events) != 0 {
 		t.Fatalf("expected no unsafe update, got %#v", events)
 	}
+	assertLogMessage(t, hook, "skipping candidate because its platform could not be established")
 }
 
 func TestCandidateSelectionSupportsEveryRelatedWorkload(t *testing.T) {
@@ -498,21 +527,19 @@ func TestCandidateSelectionSupportsEveryRelatedWorkload(t *testing.T) {
 	majorPolicy := policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)
 	fp := &fakeProvider{images: []*types.TrackedImage{
 		{
-			Image:    amd64Image,
-			Trigger:  types.TriggerTypePoll,
-			Policy:   majorPolicy,
-			Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+			Image:     amd64Image,
+			Trigger:   types.TriggerTypePoll,
+			Policy:    majorPolicy,
+			Platforms: []types.Platform{{OS: "linux", Architecture: "amd64"}},
 		},
 		{
-			Image:    arm64Image,
-			Trigger:  types.TriggerTypePoll,
-			Policy:   majorPolicy,
-			Platform: types.Platform{OS: "linux", Architecture: "arm64"},
+			Image:     arm64Image,
+			Trigger:   types.TriggerTypePoll,
+			Policy:    majorPolicy,
+			Platforms: []types.Platform{{OS: "linux", Architecture: "arm64"}},
 		},
 	}}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	providers := &fakeProviders{provider: fp}
 	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
 		"3.0.0": {{OS: "linux", Architecture: "amd64"}},
 		"2.0.0": {
@@ -534,14 +561,12 @@ func TestCandidateSelectionSupportsEveryRelatedWorkload(t *testing.T) {
 func TestCandidateSelectionContinuesAfterPlatformResolutionFailure(t *testing.T) {
 	img, _ := image.Parse("example/image:1.0.0")
 	fp := &fakeProvider{images: []*types.TrackedImage{{
-		Image:    img,
-		Trigger:  types.TriggerTypePoll,
-		Policy:   policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
-		Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+		Image:     img,
+		Trigger:   types.TriggerTypePoll,
+		Policy:    policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platforms: []types.Platform{{OS: "linux", Architecture: "amd64"}},
 	}}}
-	store, teardown := newTestingUtils()
-	defer teardown()
-	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	providers := &fakeProviders{provider: fp}
 	registryClient := &fakeRegistryClient{
 		platformErrors: map[string]error{"3.0.0": errors.New("manifest metadata unavailable")},
 		platformsToReturn: map[string][]types.Platform{
@@ -557,6 +582,69 @@ func TestCandidateSelectionContinuesAfterPlatformResolutionFailure(t *testing.T)
 	if len(events) != 1 || events[0].Repository.Tag != "2.0.0" {
 		t.Fatalf("expected compatible fallback candidate, got %#v", events)
 	}
+}
+
+func TestSupportsRelatedWorkloadsRequiresEveryEligiblePlatform(t *testing.T) {
+	img, _ := image.Parse("example/image:1.0.0")
+	tracked := []*types.TrackedImage{{
+		Image:  img,
+		Policy: policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platforms: []types.Platform{
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+	}}
+	if supportsRelatedWorkloads([]types.Platform{{OS: "linux", Architecture: "amd64"}}, "2.0.0", tracked) {
+		t.Fatal("single-platform candidate unexpectedly supports a mixed workload")
+	}
+	if !supportsRelatedWorkloads([]types.Platform{
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64"},
+	}, "2.0.0", tracked) {
+		t.Fatal("complete multi-platform candidate was rejected")
+	}
+	tracked[0].Platforms = nil
+	tracked[0].PlatformErr = types.PlatformErrorNodeMetadata
+	if supportsRelatedWorkloads([]types.Platform{{OS: "linux", Architecture: "amd64"}}, "2.0.0", tracked) {
+		t.Fatal("unresolved workload unexpectedly accepted a candidate")
+	}
+}
+
+func TestCandidateSelectionFailsClosedForUnresolvedWorkload(t *testing.T) {
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
+	img, _ := image.Parse("example/image:1.0.0")
+	fp := &fakeProvider{images: []*types.TrackedImage{{
+		Image:       img,
+		Trigger:     types.TriggerTypePoll,
+		Policy:      policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		PlatformErr: types.PlatformErrorNodeMetadata,
+	}}}
+	providers := &fakeProviders{provider: fp}
+	registryClient := &fakeRegistryClient{}
+	job := NewWatchRepositoryTagsJob(providers, registryClient, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"2.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 || len(registryClient.platformCalls) != 0 {
+		t.Fatalf("unresolved workload evaluated a candidate: events=%#v calls=%v", events, registryClient.platformCalls)
+	}
+	assertLogMessage(t, hook, "skipping workload because its eligible platforms could not be established")
+}
+
+func assertLogMessage(t *testing.T, hook *logrustest.Hook, message string) {
+	t.Helper()
+	messages := make([]string, 0, len(hook.AllEntries()))
+	for _, entry := range hook.AllEntries() {
+		messages = append(messages, entry.Message)
+		if strings.Contains(entry.Message, message) {
+			return
+		}
+	}
+	t.Fatalf("expected log message %q, got %q", message, messages)
 }
 
 type fakeCredentialsHelper struct {

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -40,6 +40,7 @@ type fakeRegistryClient struct {
 	tagsToReturn []string
 
 	platformsToReturn map[string][]types.Platform
+	platformErrors    map[string]error
 	platformErr       error
 }
 
@@ -58,6 +59,9 @@ func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err erro
 
 func (c *fakeRegistryClient) Platforms(opts registry.Opts) ([]types.Platform, error) {
 	c.opts = opts
+	if err, ok := c.platformErrors[opts.Tag]; ok {
+		return nil, err
+	}
 	if c.platformErr != nil {
 		return nil, c.platformErr
 	}
@@ -485,6 +489,73 @@ func TestCandidateSelectionFailsClosedWhenPlatformResolutionFails(t *testing.T) 
 	}
 	if len(events) != 0 {
 		t.Fatalf("expected no unsafe update, got %#v", events)
+	}
+}
+
+func TestCandidateSelectionSupportsEveryRelatedWorkload(t *testing.T) {
+	amd64Image, _ := image.Parse("example/image:1.0.0")
+	arm64Image, _ := image.Parse("example/image:1.0.0")
+	majorPolicy := policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)
+	fp := &fakeProvider{images: []*types.TrackedImage{
+		{
+			Image:    amd64Image,
+			Trigger:  types.TriggerTypePoll,
+			Policy:   majorPolicy,
+			Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+		},
+		{
+			Image:    arm64Image,
+			Trigger:  types.TriggerTypePoll,
+			Policy:   majorPolicy,
+			Platform: types.Platform{OS: "linux", Architecture: "arm64"},
+		},
+	}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
+		"3.0.0": {{OS: "linux", Architecture: "amd64"}},
+		"2.0.0": {
+			{OS: "linux", Architecture: "amd64"},
+			{OS: "linux", Architecture: "arm64"},
+		},
+	}}
+	job := NewWatchRepositoryTagsJob(providers, registryClient, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"2.0.0", "3.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Repository.Tag != "2.0.0" {
+		t.Fatalf("expected multi-architecture candidate for related workloads, got %#v", events)
+	}
+}
+
+func TestCandidateSelectionContinuesAfterPlatformResolutionFailure(t *testing.T) {
+	img, _ := image.Parse("example/image:1.0.0")
+	fp := &fakeProvider{images: []*types.TrackedImage{{
+		Image:    img,
+		Trigger:  types.TriggerTypePoll,
+		Policy:   policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+	}}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{
+		platformErrors: map[string]error{"3.0.0": errors.New("manifest metadata unavailable")},
+		platformsToReturn: map[string][]types.Platform{
+			"2.0.0": {{OS: "linux", Architecture: "amd64"}},
+		},
+	}
+	job := NewWatchRepositoryTagsJob(providers, registryClient, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"2.0.0", "3.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Repository.Tag != "2.0.0" {
+		t.Fatalf("expected compatible fallback candidate, got %#v", events)
 	}
 }
 

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -38,6 +38,9 @@ type fakeRegistryClient struct {
 	digestErrToReturn error
 
 	tagsToReturn []string
+
+	platformsToReturn map[string][]types.Platform
+	platformErr       error
 }
 
 func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, error) {
@@ -51,6 +54,17 @@ func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, erro
 func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err error) {
 	c.opts = opts
 	return c.digestToReturn, c.digestErrToReturn
+}
+
+func (c *fakeRegistryClient) Platforms(opts registry.Opts) ([]types.Platform, error) {
+	c.opts = opts
+	if c.platformErr != nil {
+		return nil, c.platformErr
+	}
+	if platforms, ok := c.platformsToReturn[opts.Tag]; ok {
+		return platforms, nil
+	}
+	return []types.Platform{{OS: "linux", Architecture: "amd64"}}, nil
 }
 
 // ======== fake provider for testing =======
@@ -393,6 +407,84 @@ func TestWatchMultipleTags(t *testing.T) {
 		if det.latest != "5.0.0" {
 			t.Errorf("expected to find a tag set for multiple tags watch job")
 		}
+	}
+}
+
+func TestReportedLatestMajorTagSetSkipsArmCandidate(t *testing.T) {
+	img, _ := image.Parse("jellyfin/jellyfin:latest")
+	fp := &fakeProvider{images: []*types.TrackedImage{{
+		Image:   img,
+		Trigger: types.TriggerTypePoll,
+		Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platform: types.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		},
+	}}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
+		"20240303.2-unstable-armhf": {{OS: "linux", Architecture: "arm", Variant: "v7"}},
+		"10.10.7":                   {{OS: "linux", Architecture: "amd64"}},
+	}}
+	job := NewWatchRepositoryTagsJob(providers, registryClient, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"latest", "10.10.7", "20240303.2-unstable-armhf"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Repository.Tag != "10.10.7" {
+		t.Fatalf("expected compatible update after skipping ARM candidate, got %#v", events)
+	}
+}
+
+func TestCandidateSelectionAcceptsMultiArchManifest(t *testing.T) {
+	img, _ := image.Parse("example/image:1.0.0")
+	fp := &fakeProvider{images: []*types.TrackedImage{{
+		Image:    img,
+		Trigger:  types.TriggerTypePoll,
+		Policy:   policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+		Platform: types.Platform{OS: "linux", Architecture: "amd64"},
+	}}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	registryClient := &fakeRegistryClient{platformsToReturn: map[string][]types.Platform{
+		"2.0.0": {
+			{OS: "linux", Architecture: "arm64"},
+			{OS: "linux", Architecture: "amd64"},
+		},
+	}}
+	job := NewWatchRepositoryTagsJob(providers, registryClient, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"2.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Repository.Tag != "2.0.0" {
+		t.Fatalf("expected multi-architecture update, got %#v", events)
+	}
+}
+
+func TestCandidateSelectionFailsClosedWhenPlatformResolutionFails(t *testing.T) {
+	img, _ := image.Parse("example/image:1.0.0")
+	fp := &fakeProvider{images: []*types.TrackedImage{{
+		Image:   img,
+		Trigger: types.TriggerTypePoll,
+		Policy:  policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true),
+	}}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+	job := NewWatchRepositoryTagsJob(providers, &fakeRegistryClient{platformErr: errors.New("no manifest metadata")}, &watchDetails{trackedImage: fp.images[0]})
+
+	events, err := job.computeEvents([]string{"2.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no unsafe update, got %#v", events)
 	}
 }
 

--- a/types/tracked_images.go
+++ b/types/tracked_images.go
@@ -19,11 +19,28 @@ type TrackedImage struct {
 	Namespace    string            `json:"namespace"`
 	Secrets      []string          `json:"secrets"`
 	Meta         map[string]string `json:"meta"` // metadata supplied by providers
+	Platform     Platform          `json:"-"`
 	// a list of pre-release tags, ie: 1.0.0-dev, 1.5.0-prod get translated into
 	// dev, prod
 	// combined semver tags
 	Tags   []string `json:"tags"`
 	Policy Policy   `json:"policy"`
+}
+
+// Platform identifies the operating system and CPU architecture required by a
+// workload and advertised by an image manifest.
+type Platform struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+// Supports reports whether an image platform can run on the target platform.
+func (p Platform) Supports(target Platform) bool {
+	if p.OS != target.OS || p.Architecture != target.Architecture {
+		return false
+	}
+	return target.Variant == "" || p.Variant == target.Variant
 }
 
 type Policy interface {

--- a/types/tracked_images.go
+++ b/types/tracked_images.go
@@ -19,7 +19,8 @@ type TrackedImage struct {
 	Namespace    string            `json:"namespace"`
 	Secrets      []string          `json:"secrets"`
 	Meta         map[string]string `json:"meta"` // metadata supplied by providers
-	Platform     Platform          `json:"-"`
+	Platforms    []Platform        `json:"-"`
+	PlatformErr  PlatformError     `json:"-"`
 	// a list of pre-release tags, ie: 1.0.0-dev, 1.5.0-prod get translated into
 	// dev, prod
 	// combined semver tags
@@ -35,12 +36,43 @@ type Platform struct {
 	Variant      string `json:"variant,omitempty"`
 }
 
+// PlatformError identifies why a workload platform set could not be resolved.
+type PlatformError string
+
+const (
+	PlatformErrorNone                PlatformError = ""
+	PlatformErrorNodeMetadata        PlatformError = "node_metadata_unavailable"
+	PlatformErrorNoEligibleNodes     PlatformError = "no_eligible_nodes"
+	PlatformErrorWorkloadMetadata    PlatformError = "workload_platform_missing"
+	PlatformErrorHelmWorkloadMapping PlatformError = "helm_workload_unmapped"
+)
+
 // Supports reports whether an image platform can run on the target platform.
 func (p Platform) Supports(target Platform) bool {
 	if p.OS != target.OS || p.Architecture != target.Architecture {
 		return false
 	}
 	return target.Variant == "" || p.Variant == target.Variant
+}
+
+// PlatformsSupportAll reports whether candidate manifests cover every target platform.
+func PlatformsSupportAll(candidates, targets []Platform) bool {
+	if len(candidates) == 0 || len(targets) == 0 {
+		return false
+	}
+	for _, target := range targets {
+		supported := false
+		for _, candidate := range candidates {
+			if candidate.Supports(target) {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			return false
+		}
+	}
+	return true
 }
 
 type Policy interface {

--- a/types/types.go
+++ b/types/types.go
@@ -91,10 +91,12 @@ func init() {
 // Repository - represents main docker repository fields that
 // keel cares about
 type Repository struct {
-	Host   string `json:"host"`
-	Name   string `json:"name"`
-	Tag    string `json:"tag"`
-	Digest string `json:"digest"` // optional digest field
+	Host             string     `json:"host"`
+	Name             string     `json:"name"`
+	Tag              string     `json:"tag"`
+	Digest           string     `json:"digest"` // optional digest field
+	Platforms        []Platform `json:"platforms,omitempty"`
+	PlatformVerified bool       `json:"platformVerified,omitempty"`
 }
 
 // String gives you [host/]team/repo[:tag] identifier

--- a/types/types.go
+++ b/types/types.go
@@ -95,8 +95,8 @@ type Repository struct {
 	Name             string     `json:"name"`
 	Tag              string     `json:"tag"`
 	Digest           string     `json:"digest"` // optional digest field
-	Platforms        []Platform `json:"platforms,omitempty"`
-	PlatformVerified bool       `json:"platformVerified,omitempty"`
+	Platforms        []Platform `json:"platforms,omitempty" swaggerignore:"true"`
+	PlatformVerified bool       `json:"platformVerified,omitempty" swaggerignore:"true"`
 }
 
 // String gives you [host/]team/repo[:tag] identifier

--- a/util/testing/testing.go
+++ b/util/testing/testing.go
@@ -16,6 +16,7 @@ import (
 // FakeK8sImplementer - fake implementer used for testing
 type FakeK8sImplementer struct {
 	NamespacesList   *v1.NamespaceList
+	NodesList        *v1.NodeList
 	DeploymentSingle *apps_v1.Deployment
 	DeploymentList   *apps_v1.DeploymentList
 
@@ -34,6 +35,11 @@ type FakeK8sImplementer struct {
 // Namespaces - available namespaces
 func (i *FakeK8sImplementer) Namespaces() (*v1.NamespaceList, error) {
 	return i.NamespacesList, nil
+}
+
+// Nodes - available nodes
+func (i *FakeK8sImplementer) Nodes() (*v1.NodeList, error) {
+	return i.NodesList, nil
 }
 
 // Deployment - available deployment, doesn't filter anything


### PR DESCRIPTION
## Summary
Prevent polling updates from selecting registry tags that do not support every Kubernetes platform eligible for the tracked workload. Workload compatibility now comes from Kubernetes Node, Pod, and scheduling metadata, including Helm-owned workload mappings, instead of Keel's own runtime platform.

## Changes
- Resolve conservative workload platform sets from cached Node metadata, pod templates, required affinity, and observed Pods; fail closed with typed diagnostics when unresolved.
- Resolve Docker/OCI manifest and config platform metadata, preserve multi-architecture indexes, and carry verified evidence through Kubernetes and Helm update-plan selection.
- Add minimal read-only Node RBAC to the chart and native e2e harness.
- Add focused registry, resolver, polling, Kubernetes, and Helm tests plus a deterministic registry-to-poll-to-Kubernetes integration regression.

## Evidence
- Issue #834 fixture before the compatibility gate: policy ordering selected `20240303.2-unstable-armhf` from `latest`.
- After: linux/amd64 eligibility rejects the ARM/v7 candidate with a warning and applies `10.10.7`.
- Mixed linux/amd64 and linux/arm64 eligibility rejects amd64-only `3.0.0` and applies multi-arch `2.0.0`.

## Testing
- `gofmt` and `git diff --check`
- Focused resolver, registry, poll, Kubernetes, Helm, and integration tests
- `go test ./...` in a cgo-enabled Alpine container
- Compile-only `go test ./... -run '^$'` on the host
- `go build ./cmd/keel`
- OpenAPI contract test
- Docker static/cgo build and UI checks
- Native k3s e2e suite (polling positive/negative and webhook): pass

Host-wide SQLite-backed execution cannot run directly because the sandbox forces `CGO_ENABLED=0`; the full suite passed in the cgo-enabled container. `go vet ./...` continues to report pre-existing unkeyed Kubernetes literals and unexported-field JSON tags. Registries that omit/misreport manifest content types or config platform fields, and schema-v1 manifests, remain fail-closed with warnings.

LFG!