### PR TITLE
Verify and implement native ARM64 Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,21 +88,28 @@ jobs:
           retention-days: 7
 
   docker:
-    name: Build Docker Image
+    name: Build Docker Image (${{ matrix.arch }})
     needs: [test, lint-ui, e2e]
     if: always() && needs.test.result == 'success' && needs.lint-ui.result == 'success' && (needs.e2e.result == 'success' || needs.e2e.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -127,22 +134,134 @@ jobs:
 
       - name: Build and push
         if: github.event_name != 'pull_request'
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=keel-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=keel-${{ matrix.arch }}
+
+      - name: Export image digest
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unexpected image digest: $IMAGE_DIGEST" >&2
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload image digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Build for PR validation
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=keel-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=keel-${{ matrix.arch }}
+
+  docker-manifest:
+    name: Publish Docker Manifest
+    needs: docker
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+
+      - name: Create multi-architecture manifest
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          mapfile -t digest_files < <(find /tmp/digests -mindepth 2 -maxdepth 2 -type f | sort)
+          digests=()
+          for digest_file in "${digest_files[@]}"; do
+            digests+=("$(basename "$digest_file")")
+          done
+          if [[ "${#digests[@]}" -ne 2 ]]; then
+            echo "Expected exactly two architecture digests, found ${#digests[@]}" >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in "${digests[@]}"; do
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Unexpected digest artifact name: $digest" >&2
+              exit 1
+            fi
+            sources+=("$IMAGE_NAME@sha256:$digest")
+          done
+
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=(--tag "$tag")
+          done < <(jq -r '.tags[]' <<< "$METADATA_JSON")
+          if [[ "${#tag_args[@]}" -eq 0 ]]; then
+            echo "Docker metadata produced no tags" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+
+      - name: Verify published manifest
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA_JSON")
+          expected_hash=""
+          for tag in "${tags[@]}"; do
+            manifest=$(docker buildx imagetools inspect "$tag" --raw)
+            jq -e '
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64") and
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")
+            ' <<< "$manifest" >/dev/null
+
+            manifest_hash=$(sha256sum <<< "$manifest" | cut -d " " -f 1)
+            if [[ -n "$expected_hash" && "$manifest_hash" != "$expected_hash" ]]; then
+              echo "Published tags do not point to identical manifests" >&2
+              exit 1
+            fi
+            expected_hash="$manifest_hash"
+          done


### PR DESCRIPTION
GitHub issue: https://github.com/keel-hq/keel/issues/853

Outcome:
Verify the proposal and, if supported by the current repository and GitHub-hosted runner environment, replace QEMU-emulated ARM64 Docker builds with native ARM64 jobs while preserving correct multi-architecture image publication.

Required investigation:
- Inspect all current Docker build/publish workflows, especially CI and nightly, and identify where QEMU or cross-platform Buildx is used.
- Verify that ubuntu-24.04-arm is available and appropriate for this public repository and that required actions/tools work on both amd64 and arm64.
- Review the issue author's branch only as reference; do not blindly copy it and do not import unrelated changes.
- Determine whether both CI and nightly workflows should use the pattern based on their actual publication behavior.

Implementation requirements:
- Use a matrix or equivalent native jobs for amd64 and arm64.
- Build and push immutable per-architecture digests, with architecture-scoped cache keys/scopes to prevent collisions.
- Add a dependent manifest job that downloads/collects digests and creates the expected multi-architecture tags using docker buildx imagetools create or the repository's compatible equivalent.
- Preserve existing image registries, tags, authentication, metadata, event conditions, permissions, concurrency, provenance/SBOM behavior, and release/nightly semantics unless a change is strictly required and documented.
- Ensure manifest publication cannot run with missing/failed architecture builds.
- Avoid QEMU setup where native runners make it unnecessary; retain a documented safe fallback only if verification proves one is required.
- Keep changes limited to relevant workflows and focused tests/checks/documentation.

Acceptance criteria and verification:
- Workflow YAML parses and action expressions/matrix outputs are valid.
- Each architecture builds natively and produces the intended digest artifact/output.
- Digest artifact names and cache scopes cannot collide across architectures.
- The manifest contains linux/amd64 and linux/arm64 and applies exactly the existing expected tags.
- Fork PRs and untrusted events do not gain registry write access or expose secrets.
- Existing CI-only, nightly, release, and manual-trigger behavior remains correct.
- Run available workflow linting (for example actionlint), repository tests relevant to workflow changes, and local Buildx validation where feasible.
- If publishing cannot safely be exercised, provide a precise dry-run/static verification report and identify the remaining GitHub-run validation.
- Report before/after expected build-time impact, changed files, exact verification commands/results, and residual risks.
- Do not merge, release, or deploy. Let Spec Task automation handle any branch and PR creation.

LFG!