### PR TITLE
Accept valid HTTP 202 notification responses

### DIFF
--- a/extension/notification/mattermost/mattermost.go
+++ b/extension/notification/mattermost/mattermost.go
@@ -69,8 +69,9 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 
 	// Setup HTTP client.
 	s.client = &http.Client{
-		Transport: http.DefaultTransport,
-		Timeout:   timeout,
+		Transport:     http.DefaultTransport,
+		Timeout:       timeout,
+		CheckRedirect: rejectRedirect,
 	}
 
 	log.WithFields(log.Fields{
@@ -100,13 +101,21 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
-		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201", resp.StatusCode)
-		}
-		return err
+	if err != nil {
+		return fmt.Errorf("could not send Mattermost notification: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("could not send Mattermost notification: empty HTTP response")
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("got HTTP status %s, expected 2xx", resp.Status)
+	}
+
 	return nil
+}
+
+func rejectRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }

--- a/extension/notification/mattermost/mattermost_test.go
+++ b/extension/notification/mattermost/mattermost_test.go
@@ -1,68 +1,16 @@
-package webhook
+package mattermost
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/keel-hq/keel/types"
 )
 
-func TestWebhookRequest(t *testing.T) {
-	currentTime := time.Now()
-	handler := func(resp http.ResponseWriter, req *http.Request) {
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			t.Errorf("failed to parse body: %s", err)
-		}
-
-		bodyStr := string(body)
-
-		if !strings.Contains(bodyStr, types.NotificationPreDeploymentUpdate.String()) {
-			t.Errorf("missing deployment type")
-		}
-
-		if !strings.Contains(bodyStr, "debug") {
-			t.Errorf("missing level")
-		}
-
-		if !strings.Contains(bodyStr, "update deployment") {
-			t.Errorf("missing name")
-		}
-		if !strings.Contains(bodyStr, "message here") {
-			t.Errorf("missing message")
-		}
-
-		t.Log(bodyStr)
-
-	}
-
-	// create test server with handler
-	ts := httptest.NewServer(http.HandlerFunc(handler))
-	defer ts.Close()
-
-	s := &sender{
-		endpoint: ts.URL,
-		client:   &http.Client{},
-	}
-
-	err := s.Send(types.EventNotification{
-		Name:      "update deployment",
-		Message:   "message here",
-		CreatedAt: currentTime,
-		Type:      types.NotificationPreDeploymentUpdate,
-		Level:     types.LevelDebug,
-	})
-	if err != nil {
-		t.Fatalf("Send() error = %v", err)
-	}
-}
-
-func TestWebhookResponseStatuses(t *testing.T) {
+func TestMattermostResponseStatuses(t *testing.T) {
 	tests := []struct {
 		name       string
 		statusCode int
@@ -94,6 +42,7 @@ func TestWebhookResponseStatuses(t *testing.T) {
 
 			s := &sender{
 				endpoint: server.URL,
+				name:     "keel",
 				client:   &http.Client{CheckRedirect: rejectRedirect},
 			}
 

--- a/extension/notification/webhook/webhook.go
+++ b/extension/notification/webhook/webhook.go
@@ -53,8 +53,9 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 
 	// Setup HTTP client.
 	s.client = &http.Client{
-		Transport: http.DefaultTransport,
-		Timeout:   timeout,
+		Transport:     http.DefaultTransport,
+		Timeout:       timeout,
+		CheckRedirect: rejectRedirect,
 	}
 
 	log.WithFields(log.Fields{
@@ -78,13 +79,21 @@ func (s *sender) Send(event types.EventNotification) error {
 
 	// Send notification via HTTP POST.
 	resp, err := s.client.Post(s.endpoint, "application/json", bytes.NewBuffer(jsonNotification))
-	if err != nil || resp == nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
-		if resp != nil {
-			return fmt.Errorf("got status %d, expected 200/201", resp.StatusCode)
-		}
-		return err
+	if err != nil {
+		return fmt.Errorf("could not send webhook: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("could not send webhook: empty HTTP response")
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("got HTTP status %s, expected 2xx", resp.Status)
+	}
+
 	return nil
+}
+
+func rejectRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }


### PR DESCRIPTION
GitHub issue: https://github.com/keel-hq/keel/issues/827

Outcome:
Treat HTTP 202 Accepted as a successful notification delivery for the generic webhook and Mattermost paths, preventing unnecessary retries and spam.

Constraints and acceptance criteria:
- Audit notifier status handling and use consistent HTTP success semantics where appropriate; do not silently accept redirects or non-2xx failures.
- Preserve response-body cleanup and useful diagnostics.
- Add table-driven tests for 200, 201, 202, other valid 2xx statuses if intended, redirects, 4xx, and 5xx across affected notifiers.
- Confirm a 202 response is sent once and produces no error/retry.
- Run focused notifier tests, go test ./..., gofmt, and build/lint checks.
- No unrelated notification redesign, release, deployment, or merge.

LFG!