### PR TITLE
Support OAuth-proxied Admin UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ ui/node_modules
 ui/dist
 .test/.runs
 .test/artifacts
+tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   e2e:
     name: End-to-End Tests (k3s)
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.test/e2e-k3s.sh
+++ b/.test/e2e-k3s.sh
@@ -77,6 +77,7 @@ preflight() {
   port_is_listening 6443 && fail "Kubernetes API port 6443 is already in use"
   port_is_listening 5000 && fail "registry port 5000 is already in use"
   port_is_listening 19300 && fail "Keel port-forward port 19300 is already in use"
+  port_is_listening 19418 && fail "oauth2-proxy port-forward port 19418 is already in use"
   return 0
 }
 
@@ -376,6 +377,12 @@ collect_diagnostics() {
     >"${ARTIFACT_DIR}/keel.log" 2>&1 || true
   kubectl -n "keel-e2e-system-${RUN_ID}" logs deployment/keel --all-containers=true --previous \
     >"${ARTIFACT_DIR}/keel-previous.log" 2>&1 || true
+  kubectl -n "keel-e2e-system-${RUN_ID}" logs deployment/keel-oauth -c keel \
+    >"${ARTIFACT_DIR}/keel-oauth.log" 2>&1 || true
+  kubectl -n "keel-e2e-system-${RUN_ID}" logs deployment/keel-oauth -c oauth2-proxy \
+    >"${ARTIFACT_DIR}/oauth2-proxy.log" 2>&1 || true
+  kubectl -n "keel-e2e-system-${RUN_ID}" logs deployment/dex \
+    >"${ARTIFACT_DIR}/dex.log" 2>&1 || true
 }
 
 delete_suite_resources() {
@@ -397,12 +404,24 @@ stop_port_forward() {
   fi
 }
 
+stop_oauth_port_forward() {
+  local pid_file="${RUN_DIR}/oauth-port-forward.pid"
+  [[ -s "${pid_file}" ]] || return 0
+  local pid
+  pid="$(<"${pid_file}")"
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -TERM "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+  fi
+}
+
 cleanup() {
   ((CLEANUP_STARTED == 0)) || return 0
   CLEANUP_STARTED=1
   collect_diagnostics
   delete_suite_resources
   stop_port_forward
+  stop_oauth_port_forward
   stop_k3s
   stop_task_runtime
   unmount_task_runtime

--- a/.test/e2e-k3s.sh
+++ b/.test/e2e-k3s.sh
@@ -298,7 +298,27 @@ run_tests() {
   # shellcheck disable=SC1090
   source "${E2E_ENV_FILE}"
   set +a
+  if [[ "${KEEL_E2E_MANUAL:-false}" == "true" ]]; then
+    go test -count=1 -v ./tests \
+      -run '^TestE2ESuite/TestExternalOAuthProxyAdminFlow$' 2>&1 | \
+      tee "${ARTIFACT_DIR}/go-test.log"
+    return
+  fi
   go test -count=1 -v ./tests 2>&1 | tee "${ARTIFACT_DIR}/go-test.log"
+}
+
+hold_for_manual_inspection() {
+  [[ "${KEEL_E2E_KEEP_CLUSTER:-false}" == "true" ]] || return 0
+  printf '%s\n' "$$" >"${RUN_DIR}/harness.pid"
+  log "manual inspection stack is ready"
+  log "Admin UI: http://127.0.0.1:19418/"
+  log "Dex credentials: alice@example.test / password"
+  log "KUBECONFIG: ${KUBECONFIG}"
+  log "Artifacts: ${ARTIFACT_DIR}"
+  log "Cleanup: kill -INT \"\$(cat '${RUN_DIR}/harness.pid')\""
+  while true; do
+    sleep 30
+  done
 }
 
 stop_k3s() {
@@ -461,6 +481,7 @@ main() {
   seed_fixture_repositories
   build_keel_image
   run_tests
+  hold_for_manual_inspection
 }
 
 main "$@"

--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -140,6 +140,12 @@ The following table lists has the main configurable parameters (polling, trigger
 | `basicauth.enabled`                         | Enable/disable Basic Auth on approvals | `false`                                                   |
 | `basicauth.user`                            | Basic Auth username                    |                                                           |
 | `basicauth.password`                        | Basic Auth password                    |                                                           |
+| `auth.mode`                                 | Admin auth mode: `legacy`, `basic`, or `external-proxy` | `legacy`                                      |
+| `auth.proxyUserHeader`                      | Trusted attribution header in external-proxy mode | `X-Forwarded-User`                          |
+| `auth.proxyLogoutURL`                       | Same-origin oauth2-proxy logout path   | `/oauth2/sign_out?rd=/`                                  |
+| `oauth2Proxy.enabled`                       | Run the required oauth2-proxy sidecar  | `false`                                                   |
+| `oauth2Proxy.existingSecret`                | Secret containing oauth2-proxy environment variables |                                             |
+| `oauth2Proxy.extraArgs`                     | Provider-specific oauth2-proxy arguments | `[]`                                                    |
 | `dockerRegistry.enabled`                    | Docker registry secret enabled.        | `false`                                                   |
 | `dockerRegistry.name`                       | Docker registry secret name            |                                                           |
 | `dockerRegistry.key`                        | Docker registry secret key             |                                                           |

--- a/chart/keel/auth_mode_test.go
+++ b/chart/keel/auth_mode_test.go
@@ -1,0 +1,90 @@
+package keel_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+)
+
+func renderChart(t *testing.T, overrides map[string]interface{}) (map[string]string, error) {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	chart, err := loader.Load(filepath.Dir(filename))
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+	values, err := chartutil.CoalesceValues(chart, overrides)
+	if err != nil {
+		t.Fatalf("coalesce values: %v", err)
+	}
+	return engine.Render(chart, chartutil.Values{
+		"Values": values,
+		"Release": map[string]interface{}{
+			"Name": "test", "Namespace": "keel", "Service": "Helm", "IsInstall": true,
+		},
+		"Chart":        chart.Metadata,
+		"Capabilities": chartutil.DefaultCapabilities,
+	})
+}
+
+func TestLegacyAuthChartDefaultsRemainUnchanged(t *testing.T) {
+	rendered, err := renderChart(t, nil)
+	if err != nil {
+		t.Fatalf("render defaults: %v", err)
+	}
+	deployment := rendered["keel/templates/deployment.yaml"]
+	if !strings.Contains(deployment, `value: "legacy"`) {
+		t.Fatal("default deployment does not render AUTH_MODE=legacy")
+	}
+	if strings.Contains(deployment, "name: oauth2-proxy") {
+		t.Fatal("default deployment unexpectedly contains oauth2-proxy")
+	}
+}
+
+func TestExternalProxyChartUsesOnlyProxyServiceEntrypoint(t *testing.T) {
+	rendered, err := renderChart(t, map[string]interface{}{
+		"auth":        map[string]interface{}{"mode": "external-proxy"},
+		"oauth2Proxy": map[string]interface{}{"enabled": true, "existingSecret": "oauth2-proxy"},
+		"service":     map[string]interface{}{"enabled": true, "type": "ClusterIP"},
+	})
+	if err != nil {
+		t.Fatalf("render external proxy mode: %v", err)
+	}
+	deployment := rendered["keel/templates/deployment.yaml"]
+	service := rendered["keel/templates/service.yaml"]
+	for _, expected := range []string{"name: oauth2-proxy", "--upstream=http://127.0.0.1:9300", "name: AUTH_PROXY_USER_HEADER"} {
+		if !strings.Contains(deployment, expected) {
+			t.Fatalf("deployment missing %q", expected)
+		}
+	}
+	if !strings.Contains(service, "targetPort: 4180") || strings.Contains(service, "targetPort: 9300") {
+		t.Fatalf("external proxy Service must target only oauth2-proxy:\n%s", service)
+	}
+}
+
+func TestUnsafeOrConflictingAuthChartValuesFail(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]interface{}
+		message   string
+	}{
+		{name: "unknown mode", overrides: map[string]interface{}{"auth": map[string]interface{}{"mode": "oidc"}}, message: "auth.mode must be one of"},
+		{name: "external proxy without sidecar", overrides: map[string]interface{}{"auth": map[string]interface{}{"mode": "external-proxy"}}, message: "requires oauth2Proxy.enabled=true"},
+		{name: "external proxy plus basic", overrides: map[string]interface{}{"auth": map[string]interface{}{"mode": "external-proxy"}, "basicauth": map[string]interface{}{"enabled": true, "user": "admin", "password": "secret"}}, message: "conflicts with basicauth"},
+		{name: "sidecar outside proxy mode", overrides: map[string]interface{}{"oauth2Proxy": map[string]interface{}{"enabled": true}}, message: "requires auth.mode=external-proxy"},
+		{name: "basic missing credentials", overrides: map[string]interface{}{"auth": map[string]interface{}{"mode": "basic"}, "basicauth": map[string]interface{}{"enabled": true}}, message: "non-empty basicauth"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := renderChart(t, tt.overrides)
+			if err == nil || !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("error = %v, want message containing %q", err, tt.message)
+			}
+		})
+	}
+}

--- a/chart/keel/templates/_helpers.tpl
+++ b/chart/keel/templates/_helpers.tpl
@@ -38,3 +38,33 @@ Create chart name and version as used by the chart label.
 {{- define "keel.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* Validate the explicit administrator authentication topology. */}}
+{{- define "keel.validateAuth" -}}
+{{- $mode := default "legacy" .Values.auth.mode -}}
+{{- if not (has $mode (list "legacy" "basic" "external-proxy")) -}}
+{{- fail (printf "auth.mode must be one of legacy, basic, or external-proxy, got %q" $mode) -}}
+{{- end -}}
+{{- if and (eq $mode "basic") (not .Values.basicauth.enabled) -}}
+{{- fail "auth.mode=basic requires basicauth.enabled=true and non-empty credentials" -}}
+{{- end -}}
+{{- if and .Values.basicauth.enabled (or (empty .Values.basicauth.user) (empty .Values.basicauth.password)) -}}
+{{- fail "basicauth.enabled=true requires non-empty basicauth.user and basicauth.password" -}}
+{{- end -}}
+{{- if eq $mode "external-proxy" -}}
+{{- if .Values.basicauth.enabled -}}
+{{- fail "auth.mode=external-proxy conflicts with basicauth.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.oauth2Proxy.enabled -}}
+{{- fail "auth.mode=external-proxy requires oauth2Proxy.enabled=true so the loopback-only Keel listener has an authenticated entrypoint" -}}
+{{- end -}}
+{{- if empty .Values.oauth2Proxy.existingSecret -}}
+{{- fail "auth.mode=external-proxy requires oauth2Proxy.existingSecret" -}}
+{{- end -}}
+{{- if not .Values.service.enabled -}}
+{{- fail "auth.mode=external-proxy requires service.enabled=true; the Service targets oauth2-proxy, never Keel directly" -}}
+{{- end -}}
+{{- else if .Values.oauth2Proxy.enabled -}}
+{{- fail "oauth2Proxy.enabled=true requires auth.mode=external-proxy" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "keel.validateAuth" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,6 +71,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: AUTH_MODE
+              value: {{ .Values.auth.mode | quote }}
+{{- if eq .Values.auth.mode "external-proxy" }}
+            - name: AUTH_PROXY_USER_HEADER
+              value: {{ .Values.auth.proxyUserHeader | quote }}
+            - name: AUTH_PROXY_LOGOUT_URL
+              value: {{ .Values.auth.proxyLogoutURL | quote }}
+{{- end }}
 {{- if .Values.googleApplicationCredentials }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secret/google-application-credentials.json
@@ -209,18 +218,50 @@ spec:
             - containerPort: 9300
           livenessProbe:
             httpGet:
+{{- if eq .Values.auth.mode "external-proxy" }}
+              path: /ping
+              port: 4180
+{{- else }}
               path: /healthz
               port: 9300
+{{- end }}
             initialDelaySeconds: 5
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
+{{- if eq .Values.auth.mode "external-proxy" }}
+              path: /ready
+              port: 4180
+{{- else }}
               path: /healthz
               port: 9300
+{{- end }}
             initialDelaySeconds: 5
             timeoutSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.oauth2Proxy.enabled }}
+        - name: oauth2-proxy
+          image: "{{ .Values.oauth2Proxy.image.repository }}@{{ .Values.oauth2Proxy.image.digest }}"
+          imagePullPolicy: {{ .Values.oauth2Proxy.image.pullPolicy }}
+          args:
+            - --http-address=0.0.0.0:4180
+            - --upstream=http://127.0.0.1:9300
+            - --reverse-proxy=true
+            - --set-xauthrequest=true
+            - --pass-user-headers=true
+{{- range .Values.oauth2Proxy.extraArgs }}
+            - {{ . | quote }}
+{{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.oauth2Proxy.existingSecret | quote }}
+          ports:
+            - name: oauth2-proxy
+              containerPort: 4180
+          resources:
+{{ toYaml .Values.oauth2Proxy.resources | indent 12 }}
+{{- end }}
 {{- if .Values.webhookRelay.enabled }}
         - name: webhookrelayd
           image: "{{ .Values.webhookRelay.image.repository }}:{{ .Values.webhookRelay.image.tag }}"

--- a/chart/keel/templates/service.yaml
+++ b/chart/keel/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
   ports:
     - port: {{ .Values.service.externalPort }}
   {{- if or (ne .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "None") }}
-      targetPort: 9300
+      targetPort: {{ ternary 4180 9300 (eq .Values.auth.mode "external-proxy") }}
   {{- end }}
       protocol: TCP
       name: keel

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -149,6 +149,33 @@ basicauth:
   user: ""
   password: ""
 
+# Administrator authentication mode. "legacy" preserves the historical behavior:
+# the Admin UI/API exist only when basicauth is enabled. "external-proxy" is an
+# explicit trust boundary and must be used with the oauth2-proxy sidecar below.
+auth:
+  mode: legacy
+  proxyUserHeader: X-Forwarded-User
+  proxyLogoutURL: /oauth2/sign_out?rd=/
+
+oauth2Proxy:
+  enabled: false
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    # Pinned multi-architecture image index for v7.8.1.
+    digest: sha256:d62e2d81c6f5048f652f67c302083be1272c181b971fad80e5a30ebe2b8b75d8
+    pullPolicy: IfNotPresent
+  # Secret keys must use oauth2-proxy environment names, including
+  # OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, and OAUTH2_PROXY_COOKIE_SECRET.
+  existingSecret: ""
+  extraArgs: []
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
 # Keel service
 # Enable to receive webhooks from Docker registries
 service:

--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -127,6 +127,11 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	authConfig, err := auth.ConfigFromEnv(os.Getenv)
+	if err != nil {
+		log.WithError(err).Fatal("invalid administrator authentication configuration")
+	}
+
 	dataDir := "/data"
 	if os.Getenv(EnvDataDir) != "" {
 		dataDir = os.Getenv(EnvDataDir)
@@ -276,6 +281,7 @@ func main() {
 		k8sClient:        implementer,
 		store:            sqlStore,
 		uiDir:            *uiDir,
+		authConfig:       authConfig,
 	})
 
 	bot.Run(implementer, approvalsManager)
@@ -372,6 +378,7 @@ type TriggerOpts struct {
 	k8sClient        kubernetes.Implementer
 	store            store.Store
 	uiDir            string
+	authConfig       auth.Config
 }
 
 // setupTriggers - setting up triggers. New triggers should be added to this function. Each trigger
@@ -380,8 +387,8 @@ type TriggerOpts struct {
 func setupTriggers(ctx context.Context, opts *TriggerOpts) (teardown func()) {
 
 	authenticator := auth.New(&auth.Opts{
-		Username: os.Getenv(constants.EnvBasicAuthUser),
-		Password: os.Getenv(constants.EnvBasicAuthPassword),
+		Username: opts.authConfig.Username,
+		Password: opts.authConfig.Password,
 		Secret:   []byte(os.Getenv(constants.EnvTokenSecret)),
 	})
 
@@ -396,7 +403,18 @@ func setupTriggers(ctx context.Context, opts *TriggerOpts) (teardown func()) {
 		Authenticator:         authenticator,
 		UIDir:                 opts.uiDir,
 		AuthenticatedWebhooks: os.Getenv(constants.EnvAuthenticatedWebhooks) == "true",
+		AuthMode:              opts.authConfig.Mode,
+		AuthProxyUserHeader:   opts.authConfig.ProxyUserHeader,
+		AuthProxyLogoutURL:    opts.authConfig.ProxyLogoutURL,
 	})
+
+	if opts.authConfig.Mode == auth.ModeExternalProxy {
+		log.WithFields(log.Fields{
+			"auth_mode":         opts.authConfig.Mode,
+			"listen_address":    "127.0.0.1",
+			"proxy_user_header": opts.authConfig.ProxyUserHeader,
+		}).Warn("external authentication proxy mode enabled; Keel trusts the configured identity header only because the HTTP listener is loopback-only")
+	}
 
 	go func() {
 		err := whs.Start()

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -55,6 +55,9 @@ const EnvBasicAuthUser = "BASIC_AUTH_USER"
 const EnvBasicAuthPassword = "BASIC_AUTH_PASSWORD"
 const EnvAuthenticatedWebhooks = "AUTHENTICATED_WEBHOOKS"
 const EnvTokenSecret = "TOKEN_SECRET"
+const EnvAuthMode = "AUTH_MODE"
+const EnvAuthProxyUserHeader = "AUTH_PROXY_USER_HEADER"
+const EnvAuthProxyLogoutURL = "AUTH_PROXY_LOGOUT_URL"
 
 // KeelLogoURL - is a logo URL for bot icon
 const KeelLogoURL = "https://keel.sh/img/logo.png"

--- a/docs/external-auth-proxy.md
+++ b/docs/external-auth-proxy.md
@@ -1,0 +1,136 @@
+# Admin UI behind an external authentication proxy
+
+Keel can delegate the authentication boundary for its Admin UI and Admin API to
+an external reverse proxy such as oauth2-proxy. This is explicitly opt-in:
+`AUTH_MODE=external-proxy` (or `auth.mode: external-proxy` in the Helm chart).
+The default `legacy` mode retains the existing Basic Auth/JWT behavior.
+
+## Security boundary
+
+In external-proxy mode Keel does not validate an OAuth token or create a local
+session. It trusts that the proxy authenticated every request before forwarding
+it. To make that trust boundary enforceable, Keel listens only on
+`127.0.0.1:9300`. The supported Helm topology runs oauth2-proxy in the same Pod
+and targets only its port from the Service and Ingress:
+
+```
+browser -> Ingress -> Service:4180 -> oauth2-proxy -> 127.0.0.1:9300 -> Keel
+```
+
+Do not expose port 9300 with a second Service, `hostPort`, `hostNetwork`, or
+another sidecar. An identity header is attribution data, not authentication;
+any client that can reach the Keel listener could forge it. Keel rejects Admin
+API requests without the configured header, but loopback-only reachability is
+the control that prevents spoofing.
+
+The proxy user header defaults to `X-Forwarded-User`. Keel uses it for the user
+shown in the UI and, in this mode only, overrides client-supplied approval voter
+names with the authenticated identity. Keep oauth2-proxy configured to replace
+forwarded headers (`--pass-user-headers=true`), and do not configure it to
+preserve a client-supplied identity header.
+
+## Helm example with oauth2-proxy
+
+Create a Secret using oauth2-proxy's environment variable names. The cookie
+secret value delivered to the container must be 16, 24, or 32 bytes (a random
+32-character value is suitable when using `stringData`).
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keel-oauth2-proxy
+  namespace: keel
+type: Opaque
+stringData:
+  OAUTH2_PROXY_CLIENT_ID: keel
+  OAUTH2_PROXY_CLIENT_SECRET: replace-with-provider-client-secret
+  OAUTH2_PROXY_COOKIE_SECRET: replace-with-a-random-32-character-value
+```
+
+Then install with values like these (replace the issuer and public URL):
+
+```yaml
+auth:
+  mode: external-proxy
+  proxyUserHeader: X-Forwarded-User
+  proxyLogoutURL: /oauth2/sign_out?rd=/
+
+basicauth:
+  enabled: false
+
+oauth2Proxy:
+  enabled: true
+  existingSecret: keel-oauth2-proxy
+  extraArgs:
+    - --provider=oidc
+    - --oidc-issuer-url=https://identity.example.com
+    - --redirect-url=https://keel.example.com/oauth2/callback
+    - --email-domain=example.com
+    - --scope=openid profile email
+    - --prefer-email-to-user=true
+    - --cookie-secure=true
+    - --code-challenge-method=S256
+
+service:
+  enabled: true
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  hosts:
+    - host: keel.example.com
+      paths:
+        - /
+  tls:
+    - secretName: keel-tls
+      hosts: [keel.example.com]
+```
+
+The chart pins oauth2-proxy v7.8.1 by its multi-architecture image digest. It
+fails template rendering if external-proxy mode is combined with Basic Auth,
+has no oauth2-proxy sidecar/Secret, or has no Service. The Service target changes
+from Keel's port 9300 to oauth2-proxy's port 4180.
+
+The Ingress must route `/oauth2/*`, the SPA, static assets, and `/v1/*` to the
+same Service. Keel has no websocket routes. oauth2-proxy protects all paths by
+default, including webhook endpoints; if provider webhooks must remain public,
+review each `--skip-auth-route` exception separately because it changes the
+external boundary.
+
+## Runtime configuration and validation
+
+| Variable | Meaning |
+| --- | --- |
+| `AUTH_MODE` | `legacy` (default), `basic`, or `external-proxy` |
+| `AUTH_PROXY_USER_HEADER` | Stable user header; external-proxy only; default `X-Forwarded-User` |
+| `AUTH_PROXY_LOGOUT_URL` | Same-origin proxy sign-out path; external-proxy only; default `/oauth2/sign_out?rd=/` |
+
+`AUTH_MODE=basic` requires both Basic Auth variables. External-proxy mode rejects
+either Basic Auth variable, invalid header names, and absolute/cross-origin
+logout URLs. Proxy-specific variables in other modes also fail startup. Startup
+logs record the selected mode, loopback address, and trusted identity header.
+
+The UI probes the current-user API on startup without manufacturing Keel
+credentials. Thus an authenticated proxy session enters the application without
+the Keel login screen, while legacy mode still falls back to the existing local
+login after a 401. Logout clears the oauth2-proxy cookie through the configured
+path. Whether that also terminates the identity provider's SSO session depends
+on provider configuration; returning to Keel may immediately authenticate again.
+
+## Deterministic local verification
+
+`make e2e` extends the existing isolated k3s harness with oauth2-proxy v7.8.1
+and Dex v2.41.1, both pinned by digest. It exercises redirect, password login
+against an in-cluster test identity, Admin UI and `/v1/resources`, the forwarded
+audit identity, direct-listener isolation, spoofed unauthenticated requests, and
+logout. The harness uses no external OAuth account or repository secret and
+collects all three components' logs and cluster events under `.test/artifacts/`.
+
+```bash
+make e2e
+```
+
+This command creates its own k3s process and namespaces, uses bounded readiness
+polling, and removes the cluster/resources on exit. Its preflight intentionally
+refuses to run over an existing local k3s installation.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -458,6 +458,8 @@ definitions:
     type: object
   pkg_http.UserInfo:
     properties:
+      auth_mode:
+        type: string
       avatar:
         type: string
       id:
@@ -466,6 +468,8 @@ definitions:
         type: string
       last_login_time:
         type: integer
+      logout_url:
+        type: string
       name:
         type: string
       role_id:

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/keel-hq/keel/constants"
+)
+
+type Mode string
+
+const (
+	ModeLegacy        Mode = "legacy"
+	ModeBasic         Mode = "basic"
+	ModeExternalProxy Mode = "external-proxy"
+)
+
+const (
+	DefaultProxyUserHeader = "X-Forwarded-User"
+	DefaultProxyLogoutURL  = "/oauth2/sign_out?rd=/"
+)
+
+// Config is the validated administrator authentication configuration.
+type Config struct {
+	Mode            Mode
+	Username        string
+	Password        string
+	ProxyUserHeader string
+	ProxyLogoutURL  string
+}
+
+func ConfigFromEnv(getenv func(string) string) (Config, error) {
+	modeValue := strings.TrimSpace(getenv(constants.EnvAuthMode))
+	if modeValue == "" {
+		modeValue = string(ModeLegacy)
+	}
+
+	cfg := Config{
+		Mode:            Mode(strings.ToLower(modeValue)),
+		Username:        getenv(constants.EnvBasicAuthUser),
+		Password:        getenv(constants.EnvBasicAuthPassword),
+		ProxyUserHeader: strings.TrimSpace(getenv(constants.EnvAuthProxyUserHeader)),
+		ProxyLogoutURL:  strings.TrimSpace(getenv(constants.EnvAuthProxyLogoutURL)),
+	}
+
+	if (cfg.Username == "") != (cfg.Password == "") {
+		return Config{}, fmt.Errorf("BASIC_AUTH_USER and BASIC_AUTH_PASSWORD must either both be set or both be unset")
+	}
+
+	switch cfg.Mode {
+	case ModeLegacy:
+		if cfg.ProxyUserHeader != "" || cfg.ProxyLogoutURL != "" {
+			return Config{}, fmt.Errorf("AUTH_PROXY_USER_HEADER and AUTH_PROXY_LOGOUT_URL require AUTH_MODE=external-proxy")
+		}
+	case ModeBasic:
+		if cfg.Username == "" {
+			return Config{}, fmt.Errorf("AUTH_MODE=basic requires BASIC_AUTH_USER and BASIC_AUTH_PASSWORD")
+		}
+		if cfg.ProxyUserHeader != "" || cfg.ProxyLogoutURL != "" {
+			return Config{}, fmt.Errorf("AUTH_PROXY_USER_HEADER and AUTH_PROXY_LOGOUT_URL require AUTH_MODE=external-proxy")
+		}
+	case ModeExternalProxy:
+		if cfg.Username != "" {
+			return Config{}, fmt.Errorf("AUTH_MODE=external-proxy conflicts with BASIC_AUTH_USER and BASIC_AUTH_PASSWORD; remove the Basic Auth credentials")
+		}
+		if cfg.ProxyUserHeader == "" {
+			cfg.ProxyUserHeader = DefaultProxyUserHeader
+		}
+		if !validHeaderName(cfg.ProxyUserHeader) {
+			return Config{}, fmt.Errorf("AUTH_PROXY_USER_HEADER %q is not a valid HTTP header name", cfg.ProxyUserHeader)
+		}
+		cfg.ProxyUserHeader = http.CanonicalHeaderKey(cfg.ProxyUserHeader)
+		if cfg.ProxyLogoutURL == "" {
+			cfg.ProxyLogoutURL = DefaultProxyLogoutURL
+		}
+		parsed, err := url.Parse(cfg.ProxyLogoutURL)
+		if err != nil || parsed.IsAbs() || !strings.HasPrefix(cfg.ProxyLogoutURL, "/") || strings.HasPrefix(cfg.ProxyLogoutURL, "//") {
+			return Config{}, fmt.Errorf("AUTH_PROXY_LOGOUT_URL must be a same-origin absolute path beginning with /, got %q", cfg.ProxyLogoutURL)
+		}
+	default:
+		return Config{}, fmt.Errorf("AUTH_MODE must be one of legacy, basic, or external-proxy, got %q", modeValue)
+	}
+
+	return cfg, nil
+}
+
+func (c Config) AdminEnabled() bool {
+	return c.Mode == ModeExternalProxy || c.Username != ""
+}
+
+func validHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') && !strings.ContainsRune("!#$%&'*+-.^_`|~", r) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/keel-hq/keel/constants"
+)
+
+func TestConfigFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		wantMode    Mode
+		wantEnabled bool
+		wantHeader  string
+		wantErr     bool
+	}{
+		{name: "empty environment preserves disabled legacy behavior", wantMode: ModeLegacy},
+		{name: "legacy credentials preserve basic auth", env: map[string]string{constants.EnvBasicAuthUser: "admin", constants.EnvBasicAuthPassword: "secret"}, wantMode: ModeLegacy, wantEnabled: true},
+		{name: "explicit basic", env: map[string]string{constants.EnvAuthMode: "basic", constants.EnvBasicAuthUser: "admin", constants.EnvBasicAuthPassword: "secret"}, wantMode: ModeBasic, wantEnabled: true},
+		{name: "external proxy has safe defaults", env: map[string]string{constants.EnvAuthMode: "external-proxy"}, wantMode: ModeExternalProxy, wantEnabled: true, wantHeader: DefaultProxyUserHeader},
+		{name: "external proxy custom canonical header", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvAuthProxyUserHeader: "x-auth-request-user"}, wantMode: ModeExternalProxy, wantEnabled: true, wantHeader: "X-Auth-Request-User"},
+		{name: "unknown mode", env: map[string]string{constants.EnvAuthMode: "oidc"}, wantErr: true},
+		{name: "partial basic credentials", env: map[string]string{constants.EnvBasicAuthUser: "admin"}, wantErr: true},
+		{name: "basic without credentials", env: map[string]string{constants.EnvAuthMode: "basic"}, wantErr: true},
+		{name: "proxy conflicts with basic", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvBasicAuthUser: "admin", constants.EnvBasicAuthPassword: "secret"}, wantErr: true},
+		{name: "proxy options in legacy", env: map[string]string{constants.EnvAuthProxyUserHeader: "X-User"}, wantErr: true},
+		{name: "invalid proxy header", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvAuthProxyUserHeader: "Bad Header"}, wantErr: true},
+		{name: "external logout URL", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvAuthProxyLogoutURL: "/oauth2/sign_out?rd=/goodbye"}, wantMode: ModeExternalProxy, wantEnabled: true, wantHeader: DefaultProxyUserHeader},
+		{name: "external absolute logout URL rejected", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvAuthProxyLogoutURL: "https://example.com/logout"}, wantErr: true},
+		{name: "protocol relative logout URL rejected", env: map[string]string{constants.EnvAuthMode: "external-proxy", constants.EnvAuthProxyLogoutURL: "//example.com/logout"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ConfigFromEnv(func(key string) string { return tt.env[key] })
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected configuration error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected configuration error: %v", err)
+			}
+			if cfg.Mode != tt.wantMode || cfg.AdminEnabled() != tt.wantEnabled || cfg.ProxyUserHeader != tt.wantHeader {
+				t.Fatalf("config = %#v, want mode=%q enabled=%t header=%q", cfg, tt.wantMode, tt.wantEnabled, tt.wantHeader)
+			}
+		})
+	}
+}

--- a/pkg/http/approvals_endpoint.go
+++ b/pkg/http/approvals_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/keel-hq/keel/pkg/auth"
 	"github.com/keel-hq/keel/pkg/store"
 	"github.com/keel-hq/keel/types"
 )
@@ -181,6 +182,9 @@ func (s *TriggerServer) approvalApproveHandler(resp http.ResponseWriter, req *ht
 		http.Error(resp, "identifier cannot be empty", http.StatusNotFound)
 		return
 	}
+	if s.authMode == auth.ModeExternalProxy {
+		ar.Voter = s.approvalVoter(req, ar.Voter)
+	}
 
 	var approval *types.Approval
 
@@ -257,4 +261,13 @@ func (s *TriggerServer) approvalApproveHandler(resp http.ResponseWriter, req *ht
 	}
 
 	resp.Write(bts)
+}
+
+func (s *TriggerServer) approvalVoter(req *http.Request, requested string) string {
+	if s.authMode == auth.ModeExternalProxy {
+		if user := auth.GetAccountFromCtx(req.Context()); user != nil && user.Username != "" {
+			return user.Username
+		}
+	}
+	return requested
 }

--- a/pkg/http/auth.go
+++ b/pkg/http/auth.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
+	"unicode"
 
 	request "github.com/golang-jwt/jwt/v4/request"
 	"github.com/keel-hq/keel/pkg/auth"
@@ -29,6 +31,18 @@ func (s *TriggerServer) requireAdminAuthorization(next http.HandlerFunc) http.Ha
 		//
 		if r.Method == "OPTIONS" {
 			rw.WriteHeader(200)
+			return
+		}
+
+		if s.authMode == auth.ModeExternalProxy {
+			username := strings.TrimSpace(r.Header.Get(s.authProxyUserHeader))
+			if !validProxyIdentity(username) {
+				log.WithField("header", s.authProxyUserHeader).Warn("external authentication proxy request is missing a valid identity header")
+				http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+				return
+			}
+			r = auth.SetAuthenticationDetails(r, &auth.User{Username: username})
+			next(rw, r)
 			return
 		}
 
@@ -75,6 +89,18 @@ func (s *TriggerServer) requireAdminAuthorization(next http.HandlerFunc) http.Ha
 
 		next(rw, r)
 	}
+}
+
+func validProxyIdentity(username string) bool {
+	if username == "" || len(username) > 256 {
+		return false
+	}
+	for _, r := range username {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func extractToken(req *http.Request) string {

--- a/pkg/http/external_auth_proxy_test.go
+++ b/pkg/http/external_auth_proxy_test.go
@@ -1,0 +1,85 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/pkg/auth"
+)
+
+func newExternalProxyServer() *TriggerServer {
+	return NewTriggerServer(&Opts{
+		Authenticator:       auth.New(&auth.Opts{}),
+		AuthMode:            auth.ModeExternalProxy,
+		AuthProxyUserHeader: auth.DefaultProxyUserHeader,
+		AuthProxyLogoutURL:  auth.DefaultProxyLogoutURL,
+	})
+}
+
+func TestExternalProxyAdminAuthorization(t *testing.T) {
+	server := newExternalProxyServer()
+	server.registerRoutes(server.router)
+
+	tests := []struct {
+		name       string
+		path       string
+		identity   string
+		basic      bool
+		wantStatus int
+	}{
+		{name: "missing forwarded identity", path: "/v1/auth/user", wantStatus: http.StatusUnauthorized},
+		{name: "basic credentials do not substitute for proxy identity", path: "/v1/auth/user", basic: true, wantStatus: http.StatusUnauthorized},
+		{name: "forwarded identity authorizes API", path: "/v1/auth/user", identity: "alice@example.test", wantStatus: http.StatusOK},
+		{name: "second admin path uses same middleware", path: "/v1/auth/info", identity: "alice@example.test", wantStatus: http.StatusOK},
+		{name: "control characters rejected", path: "/v1/auth/user", identity: "alice\x7f", wantStatus: http.StatusUnauthorized},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.identity != "" {
+				req.Header.Set(auth.DefaultProxyUserHeader, tt.identity)
+			}
+			if tt.basic {
+				req.SetBasicAuth("admin", "secret")
+			}
+			resp := httptest.NewRecorder()
+			server.router.ServeHTTP(resp, req)
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body: %s", resp.Code, tt.wantStatus, resp.Body.String())
+			}
+			if tt.path == "/v1/auth/user" && tt.wantStatus == http.StatusOK && !strings.Contains(resp.Body.String(), `"name":"alice@example.test"`) {
+				t.Fatalf("forwarded user missing from response: %s", resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestExternalProxyDoesNotRegisterLocalLoginOrRefresh(t *testing.T) {
+	server := newExternalProxyServer()
+	server.registerRoutes(server.router)
+	for _, endpoint := range []struct{ method, path string }{{http.MethodPost, "/v1/auth/login"}, {http.MethodGet, "/v1/auth/refresh"}} {
+		req := httptest.NewRequest(endpoint.method, endpoint.path, strings.NewReader(`{}`))
+		req.Header.Set(auth.DefaultProxyUserHeader, "alice")
+		resp := httptest.NewRecorder()
+		server.router.ServeHTTP(resp, req)
+		if resp.Code != http.StatusNotFound {
+			t.Fatalf("%s %s status = %d, want 404", endpoint.method, endpoint.path, resp.Code)
+		}
+	}
+}
+
+func TestExternalProxyApprovalAttributionUsesAuthenticatedIdentity(t *testing.T) {
+	server := newExternalProxyServer()
+	req := httptest.NewRequest(http.MethodPost, "/v1/approvals", nil)
+	req = auth.SetAuthenticationDetails(req, &auth.User{Username: "alice"})
+	if got := server.approvalVoter(req, "spoofed-client-voter"); got != "alice" {
+		t.Fatalf("approval voter = %q, want authenticated proxy identity", got)
+	}
+
+	legacy := NewTriggerServer(&Opts{Authenticator: auth.New(&auth.Opts{Username: "admin", Password: "secret"})})
+	if got := legacy.approvalVoter(req, "legacy-client-voter"); got != "legacy-client-voter" {
+		t.Fatalf("legacy approval voter = %q, want existing client-supplied behavior", got)
+	}
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -47,6 +47,10 @@ type Opts struct {
 	UIDir string
 
 	AuthenticatedWebhooks bool
+
+	AuthMode            auth.Mode
+	AuthProxyUserHeader string
+	AuthProxyLogoutURL  string
 }
 
 // TriggerServer - webhook trigger & healthcheck server
@@ -66,6 +70,9 @@ type TriggerServer struct {
 	uiDir string
 
 	authenticatedWebhooks bool
+	authMode              auth.Mode
+	authProxyUserHeader   string
+	authProxyLogoutURL    string
 }
 
 // NewTriggerServer - create new HTTP trigger based server
@@ -81,6 +88,9 @@ func NewTriggerServer(opts *Opts) *TriggerServer {
 		store:                 opts.Store,
 		uiDir:                 opts.UIDir,
 		authenticatedWebhooks: opts.AuthenticatedWebhooks,
+		authMode:              opts.AuthMode,
+		authProxyUserHeader:   opts.AuthProxyUserHeader,
+		authProxyLogoutURL:    opts.AuthProxyLogoutURL,
 	}
 }
 
@@ -93,13 +103,17 @@ func (s *TriggerServer) Start() error {
 	n.Use(negroni.HandlerFunc(corsHeadersMiddleware))
 	n.UseHandler(s.router)
 
+	address := fmt.Sprintf(":%d", s.port)
+	if s.authMode == auth.ModeExternalProxy {
+		address = fmt.Sprintf("127.0.0.1:%d", s.port)
+	}
 	s.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", s.port),
+		Addr:    address,
 		Handler: n,
 	}
 
 	log.WithFields(log.Fields{
-		"port": s.port,
+		"address": address,
 	}).Info("webhook trigger server starting...")
 
 	return s.server.ListenAndServe()
@@ -131,15 +145,20 @@ func (s *TriggerServer) registerRoutes(mux *mux.Router) {
 
 	mux.Handle("/metrics", promhttp.Handler())
 
-	if s.authenticator.Enabled() {
+	if s.adminEnabled() {
 		log.Info("authentication enabled, setting up admin HTTP handlers")
 		// auth
-		mux.HandleFunc("/v1/auth/login", s.loginHandler).Methods("POST", "OPTIONS")
+		if s.authMode != auth.ModeExternalProxy {
+			mux.HandleFunc("/v1/auth/login", s.loginHandler).Methods("POST", "OPTIONS")
+			mux.HandleFunc("/v1/auth/refresh", s.requireAdminAuthorization(s.refreshHandler)).Methods("GET", "OPTIONS")
+		} else {
+			mux.HandleFunc("/v1/auth/login", localAuthDisabledHandler).Methods("POST", "OPTIONS")
+			mux.HandleFunc("/v1/auth/refresh", localAuthDisabledHandler).Methods("GET", "OPTIONS")
+		}
 		mux.HandleFunc("/v1/auth/info", s.requireAdminAuthorization(s.authInfoHandler)).Methods("GET", "OPTIONS")
 		mux.HandleFunc("/v1/auth/user", s.requireAdminAuthorization(s.authUserHandler)).Methods("GET", "OPTIONS")
 		mux.HandleFunc("/v1/auth/logout", s.requireAdminAuthorization(s.logoutGetHandler)).Methods("GET", "OPTIONS")
 		mux.HandleFunc("/v1/auth/logout", s.requireAdminAuthorization(s.logoutPostHandler)).Methods("POST", "OPTIONS")
-		mux.HandleFunc("/v1/auth/refresh", s.requireAdminAuthorization(s.refreshHandler)).Methods("GET", "OPTIONS")
 
 		// approvals
 		mux.HandleFunc("/v1/approvals", s.requireAdminAuthorization(s.approvalsHandler)).Methods("GET", "OPTIONS")
@@ -176,6 +195,14 @@ func (s *TriggerServer) registerRoutes(mux *mux.Router) {
 		log.Info("authentication is not enabled, admin HTTP handlers are not initialized")
 	}
 
+}
+
+func (s *TriggerServer) adminEnabled() bool {
+	return s.authMode == auth.ModeExternalProxy || (s.authenticator != nil && s.authenticator.Enabled())
+}
+
+func localAuthDisabledHandler(resp http.ResponseWriter, _ *http.Request) {
+	http.Error(resp, "Keel local authentication is disabled in external-proxy mode", http.StatusNotFound)
 }
 
 func (s *TriggerServer) registerWebhookRoutes(mux *mux.Router) {
@@ -314,6 +341,8 @@ type UserInfo struct {
 	LastLoginIP   string `json:"last_login_ip"`
 	LastLoginTime int64  `json:"last_login_time"`
 	RoleID        string `json:"role_id"`
+	AuthMode      string `json:"auth_mode,omitempty"`
+	LogoutURL     string `json:"logout_url,omitempty"`
 }
 
 func (s *TriggerServer) userInfoHandler(resp http.ResponseWriter, req *http.Request) {
@@ -328,6 +357,8 @@ func (s *TriggerServer) userInfoHandler(resp http.ResponseWriter, req *http.Requ
 		LastLoginIP:   "",
 		LastLoginTime: time.Now().Unix(),
 		RoleID:        "admin",
+		AuthMode:      string(s.authMode),
+		LogoutURL:     s.authProxyLogoutURL,
 	}
 
 	response(&ui, 200, nil, resp, req)

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,9 @@ Support Keel's development by:
 
 ### Helm quick start
 
+To put the Admin UI and API behind oauth2-proxy without Keel Basic Auth, use
+the explicit [`external-proxy` authentication mode](docs/external-auth-proxy.md).
+
 Prerequisites:
 
 * [Helm](https://docs.helm.sh/using_helm/#installing-helm)

--- a/tests/e2e_helpers_test.go
+++ b/tests/e2e_helpers_test.go
@@ -97,6 +97,10 @@ func waitForDeploymentAvailable(ctx context.Context, client kubernetes.Interface
 }
 
 func waitForHTTPReady(ctx context.Context, client *http.Client, url string) error {
+	return waitForHTTPStatus(ctx, client, url, http.StatusOK)
+}
+
+func waitForHTTPStatus(ctx context.Context, client *http.Client, url string, expected int) error {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	last := "<not observed>"
@@ -107,7 +111,7 @@ func waitForHTTPReady(ctx context.Context, client *http.Client, url string) erro
 		} else {
 			_ = response.Body.Close()
 			last = fmt.Sprintf("HTTP %d", response.StatusCode)
-			if response.StatusCode == http.StatusOK {
+			if response.StatusCode == expected {
 				return nil
 			}
 		}

--- a/tests/e2e_oauth_proxy_test.go
+++ b/tests/e2e_oauth_proxy_test.go
@@ -109,7 +109,7 @@ func oauthKeelDeployment(cfg e2eConfig, labels map[string]string) *appsv1.Deploy
 				{Name: "oauth2-proxy", Image: oauthProxyImage, Args: []string{
 					"--http-address=0.0.0.0:4180", "--upstream=http://127.0.0.1:9300", "--provider=oidc", "--oidc-issuer-url=http://" + dexServiceIP + ":5556/dex",
 					"--client-id=keel-e2e", "--client-secret=keel-e2e-secret", "--redirect-url=" + oauthProxyURL + "/oauth2/callback", "--cookie-secret=0123456789abcdef0123456789abcdef",
-					"--cookie-secure=false", "--email-domain=*", "--scope=openid profile email", "--skip-provider-button=true", "--code-challenge-method=S256", "--reverse-proxy=true", "--set-xauthrequest=true", "--pass-user-headers=true",
+					"--cookie-secure=false", "--cookie-csrf-expire=8h", "--email-domain=*", "--scope=openid profile email", "--skip-provider-button=true", "--code-challenge-method=S256", "--reverse-proxy=true", "--set-xauthrequest=true", "--pass-user-headers=true",
 					"--prefer-email-to-user=true",
 				}, Ports: []corev1.ContainerPort{{Name: "oauth", ContainerPort: 4180}}, ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("oauth")}}, PeriodSeconds: 1, FailureThreshold: 60}, Resources: resources},
 			}}},

--- a/tests/e2e_oauth_proxy_test.go
+++ b/tests/e2e_oauth_proxy_test.go
@@ -1,0 +1,259 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	oauthProxyURL   = "http://127.0.0.1:19418"
+	dexServiceIP    = "10.53.0.60"
+	dexImage        = "ghcr.io/dexidp/dex@sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d"
+	oauthProxyImage = "quay.io/oauth2-proxy/oauth2-proxy@sha256:d62e2d81c6f5048f652f67c302083be1272c181b971fad80e5a30ebe2b8b75d8"
+)
+
+func createOAuthProxyResources(ctx context.Context, client kubernetes.Interface, cfg e2eConfig) error {
+	namespace := cfg.systemNamespace()
+	labels := map[string]string{"app": "keel-oauth-e2e", e2eRunLabel: cfg.runID}
+	dexConfig := fmt.Sprintf(`issuer: http://%s:5556/dex
+storage:
+  type: memory
+web:
+  http: 0.0.0.0:5556
+oauth2:
+  skipApprovalScreen: true
+staticClients:
+- id: keel-e2e
+  name: Keel e2e
+  secret: keel-e2e-secret
+  redirectURIs:
+  - http://127.0.0.1:19418/oauth2/callback
+enablePasswordDB: true
+staticPasswords:
+- email: alice@example.test
+  hash: '$2a$10$NMYoKasT1XS0eJjSEWD5e.k4lArOO7boaygjnFqk07WdM4koH5DLq'
+  username: alice
+  userID: 00000000-0000-0000-0000-000000000001
+`, dexServiceIP)
+
+	if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "dex", Namespace: namespace, Labels: labels},
+		Data:       map[string]string{"config.yaml": dexConfig},
+	}, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	if _, err := client.AppsV1().Deployments(namespace).Create(ctx, dexDeployment(cfg, labels), metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	if _, err := client.CoreV1().Services(namespace).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "dex", Namespace: namespace, Labels: labels},
+		Spec:       corev1.ServiceSpec{ClusterIP: dexServiceIP, Selector: map[string]string{"app": "dex-e2e", e2eRunLabel: cfg.runID}, Ports: []corev1.ServicePort{{Name: "http", Port: 5556}}},
+	}, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	if _, err := client.AppsV1().Deployments(namespace).Create(ctx, oauthKeelDeployment(cfg, labels), metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	_, err := client.CoreV1().Services(namespace).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "keel-oauth", Namespace: namespace, Labels: labels},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "keel-oauth-e2e", e2eRunLabel: cfg.runID}, Ports: []corev1.ServicePort{{Name: "http", Port: 4180, TargetPort: intstr.FromString("oauth")}}},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+func dexDeployment(cfg e2eConfig, labels map[string]string) *appsv1.Deployment {
+	podLabels := map[string]string{"app": "dex-e2e", e2eRunLabel: cfg.runID}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dex", Namespace: cfg.systemNamespace(), Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrTo(int32(1)),
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: podLabels}, Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "dex", Image: dexImage, Args: []string{"dex", "serve", "/etc/dex/config.yaml"},
+					Ports:          []corev1.ContainerPort{{Name: "http", ContainerPort: 5556}},
+					VolumeMounts:   []corev1.VolumeMount{{Name: "config", MountPath: "/etc/dex", ReadOnly: true}},
+					ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/dex/.well-known/openid-configuration", Port: intstr.FromString("http")}}, PeriodSeconds: 1, FailureThreshold: 60},
+				}},
+				Volumes: []corev1.Volume{{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "dex"}}}}},
+			}},
+		},
+	}
+}
+
+func oauthKeelDeployment(cfg e2eConfig, labels map[string]string) *appsv1.Deployment {
+	podLabels := map[string]string{"app": "keel-oauth-e2e", e2eRunLabel: cfg.runID}
+	resources := corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("32Mi")}}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "keel-oauth", Namespace: cfg.systemNamespace(), Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrTo(int32(1)), Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: podLabels}, Spec: corev1.PodSpec{ServiceAccountName: "keel", Containers: []corev1.Container{
+				{Name: "keel", Image: cfg.keelImage, ImagePullPolicy: corev1.PullIfNotPresent, Env: []corev1.EnvVar{{Name: "AUTH_MODE", Value: "external-proxy"}, {Name: "AUTH_PROXY_USER_HEADER", Value: "X-Forwarded-User"}, {Name: "POLL", Value: "false"}}, Ports: []corev1.ContainerPort{{Name: "keel", ContainerPort: 9300}}, Resources: resources},
+				{Name: "oauth2-proxy", Image: oauthProxyImage, Args: []string{
+					"--http-address=0.0.0.0:4180", "--upstream=http://127.0.0.1:9300", "--provider=oidc", "--oidc-issuer-url=http://" + dexServiceIP + ":5556/dex",
+					"--client-id=keel-e2e", "--client-secret=keel-e2e-secret", "--redirect-url=" + oauthProxyURL + "/oauth2/callback", "--cookie-secret=0123456789abcdef0123456789abcdef",
+					"--cookie-secure=false", "--email-domain=*", "--scope=openid profile email", "--skip-provider-button=true", "--code-challenge-method=S256", "--reverse-proxy=true", "--set-xauthrequest=true", "--pass-user-headers=true",
+					"--prefer-email-to-user=true",
+				}, Ports: []corev1.ContainerPort{{Name: "oauth", ContainerPort: 4180}}, ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("oauth")}}, PeriodSeconds: 1, FailureThreshold: 60}, Resources: resources},
+			}}},
+		},
+	}
+}
+
+func (s *E2ESuite) TestExternalOAuthProxyAdminFlow() {
+	noRedirect := &http.Client{Timeout: 5 * time.Second, CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }}
+	req, err := http.NewRequest(http.MethodGet, oauthProxyURL+"/v1/resources", nil)
+	s.Require().NoError(err)
+	req.Header.Set("X-Forwarded-User", "spoofed@example.test")
+	response, err := noRedirect.Do(req)
+	s.Require().NoError(err)
+	_ = response.Body.Close()
+	s.Require().Equal(http.StatusFound, response.StatusCode, "unauthenticated spoofed identity must be redirected")
+	s.Require().NotEmpty(response.Header.Get("Location"), "unauthenticated request must be redirected into the OIDC flow")
+
+	pods, err := s.client.CoreV1().Pods(s.cfg.systemNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: "app=keel-oauth-e2e"})
+	s.Require().NoError(err)
+	s.Require().Len(pods.Items, 1)
+	connection, err := net.DialTimeout("tcp", net.JoinHostPort(pods.Items[0].Status.PodIP, "9300"), time.Second)
+	if err == nil {
+		_ = connection.Close()
+	}
+	s.Require().Error(err, "Keel port 9300 must not accept direct Pod-IP connections")
+
+	jar, err := cookiejar.New(nil)
+	s.Require().NoError(err)
+	client := &http.Client{Timeout: 15 * time.Second, Jar: jar}
+	response, err = client.Get(oauthProxyURL + "/")
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, response.StatusCode)
+	loginPage, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	s.Require().NoError(err)
+	action, fields, err := dexLoginForm(loginPage, response.Request.URL)
+	s.Require().NoError(err)
+	fields.Set("login", "alice@example.test")
+	fields.Set("password", "password")
+	response, err = client.PostForm(action, fields)
+	s.Require().NoError(err)
+	index, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	s.Require().NoError(err)
+	if !strings.Contains(string(index), `<div id="root"></div>`) {
+		approvalAction, approvalFields, formErr := dexLoginForm(index, response.Request.URL)
+		s.Require().NoError(formErr, "expected Dex approval form after password login")
+		response, err = client.PostForm(approvalAction, approvalFields)
+		s.Require().NoError(err)
+		index, err = io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(http.StatusOK, response.StatusCode)
+	s.Require().Contains(string(index), `<div id="root"></div>`, "authenticated Admin UI index must load")
+
+	response, err = client.Get(oauthProxyURL + "/v1/auth/user")
+	s.Require().NoError(err)
+	var user struct {
+		Name     string `json:"name"`
+		AuthMode string `json:"auth_mode"`
+	}
+	s.Require().NoError(json.NewDecoder(response.Body).Decode(&user))
+	_ = response.Body.Close()
+	s.Require().Equal("alice@example.test", user.Name)
+	s.Require().Equal("external-proxy", user.AuthMode)
+
+	response, err = client.Get(oauthProxyURL + "/v1/resources")
+	s.Require().NoError(err)
+	resourcesBody, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, response.StatusCode)
+	s.Require().NotEmpty(resourcesBody, "meaningful authenticated Admin API read must return JSON")
+
+	response, err = client.Post(oauthProxyURL+"/v1/auth/login", "application/json", strings.NewReader(`{"username":"admin","password":"secret"}`))
+	s.Require().NoError(err)
+	_ = response.Body.Close()
+	s.Require().Equal(http.StatusNotFound, response.StatusCode, "local Keel login must remain disabled")
+
+	response, err = client.Get(oauthProxyURL + "/oauth2/sign_out?rd=/")
+	s.Require().NoError(err)
+	_ = response.Body.Close()
+	response, err = noRedirect.Get(oauthProxyURL + "/v1/resources")
+	s.Require().NoError(err)
+	_ = response.Body.Close()
+	s.Require().Equal(http.StatusFound, response.StatusCode, "logged-out session must be protected")
+}
+
+func dexLoginForm(document []byte, base *url.URL) (string, url.Values, error) {
+	root, err := html.Parse(strings.NewReader(string(document)))
+	if err != nil {
+		return "", nil, err
+	}
+	var form *html.Node
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if form != nil {
+			return
+		}
+		if node.Type == html.ElementNode && node.Data == "form" {
+			form = node
+			return
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	if form == nil {
+		return "", nil, fmt.Errorf("Dex login form not found in %s", base)
+	}
+	action := base.String()
+	fields := url.Values{}
+	for _, attr := range form.Attr {
+		if attr.Key == "action" {
+			parsed, err := base.Parse(attr.Val)
+			if err != nil {
+				return "", nil, err
+			}
+			action = parsed.String()
+		}
+	}
+	var inputs func(*html.Node)
+	inputs = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "input" {
+			name, value := "", ""
+			for _, attr := range node.Attr {
+				if attr.Key == "name" {
+					name = attr.Val
+				}
+				if attr.Key == "value" {
+					value = attr.Val
+				}
+			}
+			if name != "" {
+				fields.Set(name, value)
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			inputs(child)
+		}
+	}
+	inputs(form)
+	return action, fields, nil
+}

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -87,6 +87,10 @@ func (s *E2ESuite) SetupSuite() {
 }
 
 func (s *E2ESuite) TearDownSuite() {
+	if os.Getenv("KEEL_E2E_KEEP_CLUSTER") == "true" {
+		s.T().Log("KEEL_E2E_KEEP_CLUSTER=true: preserving suite resources and port-forwards for manual inspection")
+		return
+	}
 	if s.portForward != nil && s.portForward.Process != nil {
 		_ = s.portForward.Process.Signal(os.Interrupt)
 		_, _ = s.portForward.Process.Wait()

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -21,10 +21,11 @@ const keelForwardURL = "http://127.0.0.1:19300"
 
 type E2ESuite struct {
 	suite.Suite
-	cfg           e2eConfig
-	client        *kubernetes.Clientset
-	portForward   *exec.Cmd
-	testNamespace string
+	cfg              e2eConfig
+	client           *kubernetes.Clientset
+	portForward      *exec.Cmd
+	oauthPortForward *exec.Cmd
+	testNamespace    string
 }
 
 func TestE2ESuite(t *testing.T) {
@@ -50,6 +51,9 @@ func (s *E2ESuite) SetupSuite() {
 	deploymentCtx, deploymentCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer deploymentCancel()
 	require.NoError(s.T(), waitForDeploymentAvailable(deploymentCtx, s.client, s.cfg.systemNamespace(), "keel"))
+	require.NoError(s.T(), createOAuthProxyResources(context.Background(), s.client, s.cfg))
+	require.NoError(s.T(), waitForDeploymentAvailable(deploymentCtx, s.client, s.cfg.systemNamespace(), "dex"))
+	require.NoError(s.T(), waitForDeploymentAvailable(deploymentCtx, s.client, s.cfg.systemNamespace(), "keel-oauth"))
 
 	logPath := filepath.Join(s.cfg.artifactDir, "port-forward.log")
 	logFile, err := os.Create(logPath)
@@ -67,12 +71,29 @@ func (s *E2ESuite) SetupSuite() {
 	healthCtx, healthCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer healthCancel()
 	require.NoError(s.T(), waitForHTTPReady(healthCtx, httpClient, keelForwardURL+"/healthz"))
+
+	oauthLogPath := filepath.Join(s.cfg.artifactDir, "oauth-port-forward.log")
+	oauthLogFile, err := os.Create(oauthLogPath)
+	require.NoError(s.T(), err)
+	s.oauthPortForward = exec.Command(s.cfg.kubectl, "kubectl", "--kubeconfig", s.cfg.kubeconfig,
+		"--namespace", s.cfg.systemNamespace(), "port-forward", "service/keel-oauth", "19418:4180")
+	s.oauthPortForward.Env = append(os.Environ(), "K3S_DATA_DIR="+s.cfg.k3sDataDir)
+	s.oauthPortForward.Stdout = oauthLogFile
+	s.oauthPortForward.Stderr = oauthLogFile
+	require.NoError(s.T(), s.oauthPortForward.Start())
+	require.NoError(s.T(), os.WriteFile(filepath.Join(filepath.Dir(s.cfg.kubeconfig), "oauth-port-forward.pid"),
+		[]byte(fmt.Sprintf("%d\n", s.oauthPortForward.Process.Pid)), 0o600))
+	require.NoError(s.T(), waitForHTTPStatus(healthCtx, &http.Client{Timeout: 2 * time.Second}, "http://127.0.0.1:19418/ping", http.StatusOK))
 }
 
 func (s *E2ESuite) TearDownSuite() {
 	if s.portForward != nil && s.portForward.Process != nil {
 		_ = s.portForward.Process.Signal(os.Interrupt)
 		_, _ = s.portForward.Process.Wait()
+	}
+	if s.oauthPortForward != nil && s.oauthPortForward.Process != nil {
+		_ = s.oauthPortForward.Process.Signal(os.Interrupt)
+		_, _ = s.oauthPortForward.Process.Wait()
 	}
 	if s.client == nil || s.cfg.runID == "" {
 		return

--- a/ui/src/api/generated/model/PkgHttpUserInfo.js
+++ b/ui/src/api/generated/model/PkgHttpUserInfo.js
@@ -47,6 +47,9 @@ class PkgHttpUserInfo {
         if (data) {
             obj = obj || new PkgHttpUserInfo();
 
+            if (data.hasOwnProperty('auth_mode')) {
+                obj['auth_mode'] = ApiClient.convertToType(data['auth_mode'], 'String');
+            }
             if (data.hasOwnProperty('avatar')) {
                 obj['avatar'] = ApiClient.convertToType(data['avatar'], 'String');
             }
@@ -58,6 +61,9 @@ class PkgHttpUserInfo {
             }
             if (data.hasOwnProperty('last_login_time')) {
                 obj['last_login_time'] = ApiClient.convertToType(data['last_login_time'], 'Number');
+            }
+            if (data.hasOwnProperty('logout_url')) {
+                obj['logout_url'] = ApiClient.convertToType(data['logout_url'], 'String');
             }
             if (data.hasOwnProperty('name')) {
                 obj['name'] = ApiClient.convertToType(data['name'], 'String');
@@ -82,6 +88,10 @@ class PkgHttpUserInfo {
      */
     static validateJSON(data) {
         // ensure the json data is a string
+        if (data['auth_mode'] && !(typeof data['auth_mode'] === 'string' || data['auth_mode'] instanceof String)) {
+            throw new Error("Expected the field `auth_mode` to be a primitive type in the JSON string but got " + data['auth_mode']);
+        }
+        // ensure the json data is a string
         if (data['avatar'] && !(typeof data['avatar'] === 'string' || data['avatar'] instanceof String)) {
             throw new Error("Expected the field `avatar` to be a primitive type in the JSON string but got " + data['avatar']);
         }
@@ -92,6 +102,10 @@ class PkgHttpUserInfo {
         // ensure the json data is a string
         if (data['last_login_ip'] && !(typeof data['last_login_ip'] === 'string' || data['last_login_ip'] instanceof String)) {
             throw new Error("Expected the field `last_login_ip` to be a primitive type in the JSON string but got " + data['last_login_ip']);
+        }
+        // ensure the json data is a string
+        if (data['logout_url'] && !(typeof data['logout_url'] === 'string' || data['logout_url'] instanceof String)) {
+            throw new Error("Expected the field `logout_url` to be a primitive type in the JSON string but got " + data['logout_url']);
         }
         // ensure the json data is a string
         if (data['name'] && !(typeof data['name'] === 'string' || data['name'] instanceof String)) {
@@ -115,6 +129,11 @@ class PkgHttpUserInfo {
 
 
 /**
+ * @member {String} auth_mode
+ */
+PkgHttpUserInfo.prototype['auth_mode'] = undefined;
+
+/**
  * @member {String} avatar
  */
 PkgHttpUserInfo.prototype['avatar'] = undefined;
@@ -133,6 +152,11 @@ PkgHttpUserInfo.prototype['last_login_ip'] = undefined;
  * @member {Number} last_login_time
  */
 PkgHttpUserInfo.prototype['last_login_time'] = undefined;
+
+/**
+ * @member {String} logout_url
+ */
+PkgHttpUserInfo.prototype['logout_url'] = undefined;
 
 /**
  * @member {String} name

--- a/ui/src/auth.test.tsx
+++ b/ui/src/auth.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AuthProvider, useAuth } from "@/auth"
+import { tokenStore } from "@/lib/api"
+
+function AuthState() {
+  const { user, loading } = useAuth()
+  return <div>{loading ? "loading" : user?.name || "local-login-required"}</div>
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => tokenStore.clear())
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("discovers an external-proxy session without a Keel token or login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: "1",
+            name: "alice",
+            username: "",
+            role_id: "admin",
+            auth_mode: "external-proxy",
+            logout_url: "/oauth2/sign_out?rd=/",
+          }),
+          { status: 200 }
+        )
+      )
+    )
+
+    render(
+      <AuthProvider>
+        <AuthState />
+      </AuthProvider>
+    )
+    expect(screen.getByText("loading")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument())
+    expect(fetch).toHaveBeenCalledWith(
+      "/v1/auth/user",
+      expect.objectContaining({ headers: expect.any(Headers) })
+    )
+    const headers = new Headers(vi.mocked(fetch).mock.calls[0][1]?.headers)
+    expect(headers.has("Authorization")).toBe(false)
+  })
+})

--- a/ui/src/auth.tsx
+++ b/ui/src/auth.tsx
@@ -18,7 +18,7 @@ interface AuthValue {
 const AuthContext = createContext<AuthValue | undefined>(undefined)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<UserInfo | null>(null)
-  const [loading, setLoading] = useState(Boolean(tokenStore.get()))
+  const [loading, setLoading] = useState(true)
   const clear = useCallback(() => {
     tokenStore.clear()
     setUser(null)
@@ -27,12 +27,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const unauthorized = () => clear()
     window.addEventListener("keel:unauthorized", unauthorized)
-    if (tokenStore.get())
-      api
-        .user()
-        .then(setUser)
-        .catch(clear)
-        .finally(() => setLoading(false))
+    api
+      .user()
+      .then(setUser)
+      .catch(clear)
+      .finally(() => setLoading(false))
     return () => window.removeEventListener("keel:unauthorized", unauthorized)
   }, [clear])
   async function login(username: string, password: string) {
@@ -40,10 +39,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(await api.user())
   }
   async function logout() {
+    const logoutURL =
+      user?.auth_mode === "external-proxy" ? user.logout_url : undefined
     try {
       await api.logout()
     } finally {
       clear()
+      if (logoutURL) window.location.assign(logoutURL)
     }
   }
   return (

--- a/ui/src/pages/approvals.test.tsx
+++ b/ui/src/pages/approvals.test.tsx
@@ -3,6 +3,10 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ApprovalsPage } from "@/pages/approvals"
 
+vi.mock("@/auth", () => ({
+  useAuth: () => ({ user: { name: "admin-web-ui" } }),
+}))
+
 const apiMock = vi.hoisted(() => ({
   approvals: vi.fn(),
   updateApproval: vi.fn(),

--- a/ui/src/pages/approvals.tsx
+++ b/ui/src/pages/approvals.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
 } from "lucide-react"
 import { toast } from "sonner"
+import { useAuth } from "@/auth"
 import { api } from "@/lib/api"
 import { deadline, formatDate } from "@/lib/format"
 import type { Approval } from "@/types"
@@ -48,6 +49,7 @@ type PendingAction = {
   action: "approve" | "reject" | "archive" | "delete"
 } | null
 export function ApprovalsPage() {
+  const { user } = useAuth()
   const [approvals, setApprovals] = useState<Approval[]>([])
   const [selected, setSelected] = useState<string[]>([])
   const [filter, setFilter] = useState("")
@@ -87,7 +89,7 @@ export function ApprovalsPage() {
             id: item.id,
             identifier: item.identifier,
             action: pendingAction.action,
-            voter: "admin-web-ui",
+            voter: user?.name || "admin-web-ui",
           })
         )
       )

--- a/ui/src/pages/login.test.tsx
+++ b/ui/src/pages/login.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest"
 import { LoginPage } from "@/pages/login"
 import { ThemeProvider } from "@/components/theme-provider"
 
-vi.mock("@/auth", () => ({ useAuth: () => ({ user: null, login: vi.fn() }) }))
+vi.mock("@/auth", () => ({
+  useAuth: () => ({ user: null, loading: false, login: vi.fn() }),
+}))
 
 describe("LoginPage", () => {
   it("renders the existing username and password authentication flow", () => {

--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -11,11 +11,17 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 export function LoginPage() {
-  const { user, login } = useAuth()
+  const { user, loading, login } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState("")
+  if (loading)
+    return (
+      <div className="grid min-h-svh place-items-center text-sm text-muted-foreground">
+        Loading Keel…
+      </div>
+    )
   if (user) return <Navigate to="/dashboard" replace />
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -3,6 +3,8 @@ export interface UserInfo {
   name: string
   username: string
   role_id: string
+  auth_mode?: "legacy" | "basic" | "external-proxy"
+  logout_url?: string
 }
 export interface Resource {
   provider: string


### PR DESCRIPTION
GitHub issue: https://github.com/keel-hq/keel/issues/433

Outcome:
Add a supported, explicitly opt-in way to run Keel's Admin UI and its API behind an external OAuth authentication proxy without requiring Keel Basic Auth or showing Keel's local login flow. Validate the complete deployment locally on k3s with oauth2-proxy and exercise the same scenario in GitHub Actions CI.

Product scope:
- Focus on the concrete external-proxy use case requested in #433. Do not build a general OAuth/OIDC provider inside Keel unless repository investigation proves that is the smallest safe solution; oauth2-proxy remains the authentication boundary.
- Preserve Keel's existing authentication behavior and defaults for all current users.
- Do not treat arbitrary identity headers as trustworthy unless the deployment topology prevents direct/spoofed access and the trust boundary is explicit.
- Keep approval/audit identity behavior compatible. If a stable authenticated-user header can safely populate existing audit attribution, support and test it narrowly; otherwise document the limitation rather than expanding the auth model.
- No release, deployment to shared infrastructure, merge, or unrelated UI/auth redesign.

Required investigation:
- Reproduce the current issue against master: Admin UI enabled behind oauth2-proxy still requires Keel Basic Auth and/or lands on the Keel login flow.
- Trace backend auth middleware, Admin UI enablement, frontend session/login routing, API client authentication, Helm values/templates, ingress/service exposure, and existing k3s e2e infrastructure.
- Define one clear configuration surface (prefer an auth-mode enum or equivalently explicit option over ambiguous combinations of booleans) with secure validation and backward-compatible defaults.
- Threat-model direct access to Keel, spoofed forwarded identity headers, accidentally enabling an unauthenticated public Admin UI, websocket/API paths if applicable, and logout/session behavior.

Implementation requirements:
- Add an explicit external-auth-proxy mode that enables Admin UI/API operation without Keel Basic Auth credentials and bypasses/removes the Keel login prompt for that mode.
- Default remains existing Keel authentication; external-proxy mode must never activate merely because credentials are absent.
- Make the proxy trust boundary observable with startup logs and clear documentation. Invalid or conflicting auth configuration must fail safely with actionable diagnostics.
- Ensure all Admin UI API routes needed by the application work consistently through the proxy; do not accidentally leave sensitive routes with different auth semantics.
- Add Helm chart configuration and deployment documentation for oauth2-proxy, including safe service/ingress topology that does not expose the unauthenticated Keel upstream directly.
- Avoid provider-specific code and live third-party OAuth dependencies.

Local k3s end-to-end verification:
- Extend the repository's established k3s e2e harness rather than creating a parallel cluster workflow.
- Bring up Keel plus oauth2-proxy and a deterministic in-cluster OIDC identity provider/fixture (for example Dex if suitable), with pinned versions/images.
- Test the real HTTP/browser-facing flow through the proxy: unauthenticated access is rejected or redirected to login; a test user completes authentication; the Admin UI loads without Keel Basic Auth/login; authenticated API calls succeed; direct/spoofed access cannot bypass the documented topology; logout/session expiry or an equivalent negative session case is covered.
- Exercise at least one meaningful authenticated Admin UI action/read path, not only a health endpoint.
- Use bounded readiness polling, isolated namespaces/resources, automatic cleanup, and collect Keel/oauth2-proxy/identity-provider/ingress events and logs on failure.
- Record exact local commands, versions, runtime, and before/after evidence.

CI requirements:
- Add the OAuth-proxy k3s scenario to GitHub Actions as a repeatable PR check using the existing e2e job or a narrowly justified dedicated job.
- Pin third-party components and avoid external OAuth accounts, mutable test identities, or repository secrets.
- Ensure CI runs for relevant backend, frontend, Helm, and e2e changes; validate workflow YAML and keep permissions least-privilege.
- The CI test must fail if Keel reintroduces Basic Auth/login in external-proxy mode or if unauthenticated proxy access reaches protected Admin UI/API content.
- Upload actionable cluster/test diagnostics on failure and keep runtime/cost reasonable.

Acceptance criteria:
1. Existing installations retain current authentication behavior with no configuration changes.
2. Explicit external-proxy mode lets an oauth2-proxy-authenticated user load and use the Admin UI/API without Keel Basic Auth or Keel's login screen.
3. Unauthenticated requests through the supported proxy entrypoint cannot access protected Admin UI/API content.
4. Documentation and chart defaults prevent or prominently warn against exposing the unauthenticated Keel upstream directly.
5. Invalid/conflicting configuration fails safely and produces clear diagnostics.
6. Focused backend/frontend/chart tests cover mode selection, middleware/routes, login bypass, and configuration rendering.
7. A deterministic local k3s test with Keel + oauth2-proxy + in-cluster OAuth/OIDC fixture passes.
8. The same end-to-end scenario runs and passes in GitHub Actions CI with failure diagnostics.
9. Existing unit, UI, build, Helm, and k3s e2e checks do not regress.

Expected verification:
- gofmt and focused Go auth/router/config tests.
- Frontend lint/type/unit/build tests covering external-proxy mode and login routing.
- Helm lint/template tests for defaults, external-proxy configuration, and unsafe/conflicting values.
- go test ./..., repository build/lint/static checks, and existing e2e suite.
- A clean local k3s execution of the full OAuth-proxy scenario.
- GitHub Actions workflow validation and successful CI execution.
- Report root cause, changed trust boundaries, exact commands/results, CI evidence, runtime, and residual security/operational limitations.

LFG!