### PR TITLE
fix(poll): seed the tag digest watcher from the running image digest

### DIFF
--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -325,6 +325,7 @@ type ProviderOpts struct {
 func setupProviders(opts *ProviderOpts) (providers provider.Providers) {
 	var enabledProviders []provider.Provider
 	platformResolver := k8s.NewPlatformResolver(opts.k8sImplementer)
+	runningDigestResolver := k8s.NewRunningDigestResolver(opts.k8sImplementer)
 
 	k8sProvider, err := kubernetes.NewProvider(opts.k8sImplementer, opts.sender, opts.approvalsManager, opts.grc, platformResolver)
 	if err != nil {
@@ -345,7 +346,7 @@ func setupProviders(opts *ProviderOpts) (providers provider.Providers) {
 
 	if opts.appConfig.Providers.Helm3 {
 		helm3Implementer := helm3.NewHelm3Implementer()
-		helm3Provider := helm3.NewProvider(helm3Implementer, opts.sender, opts.approvalsManager, helm3.WithWorkloadPlatforms(platformResolver, opts.grc))
+		helm3Provider := helm3.NewProvider(helm3Implementer, opts.sender, opts.approvalsManager, helm3.WithWorkloadPlatforms(platformResolver, opts.grc), helm3.WithRunningDigests(runningDigestResolver))
 
 		go func() {
 			err := helm3Provider.Start()

--- a/internal/k8s/running_digests.go
+++ b/internal/k8s/running_digests.go
@@ -1,0 +1,119 @@
+package k8s
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+// PodLister supplies the pods belonging to a workload.
+type PodLister interface {
+	Pods(namespace, labelSelector string) (*core_v1.PodList, error)
+}
+
+// RunningDigestResolver reports the image digests that a workload is actually
+// running, as opposed to the images requested by its pod template.
+type RunningDigestResolver struct {
+	pods PodLister
+}
+
+// NewRunningDigestResolver creates a resolver backed by the Kubernetes pod API.
+func NewRunningDigestResolver(pods PodLister) *RunningDigestResolver {
+	return &RunningDigestResolver{pods: pods}
+}
+
+// Resolve returns the running digests keyed by the container image reference
+// they were pulled for. Images without an observable digest are omitted, so
+// callers must treat a missing entry as "unknown" rather than "no drift".
+func (r *RunningDigestResolver) Resolve(resource *GenericResource) map[string][]string {
+	if r == nil || r.pods == nil || resource == nil {
+		return nil
+	}
+	selector, ok := resource.GetPodSelector()
+	if !ok {
+		return nil
+	}
+	podList, err := r.pods.Pods(resource.Namespace, selector)
+	if err != nil || podList == nil {
+		return nil
+	}
+
+	digests := make(map[string]map[string]struct{})
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		// pods on their way out tell us nothing about what should be running
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		images := podContainerImages(pod)
+		statuses := append(append([]core_v1.ContainerStatus(nil), pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...)
+		for _, status := range statuses {
+			image, known := images[status.Name]
+			if !known {
+				continue
+			}
+			// a waiting container has not pulled anything yet, its ImageID is
+			// either empty or left over from a previous run
+			if status.State.Waiting != nil {
+				continue
+			}
+			id := parseImageID(status.ImageID)
+			if id == "" {
+				continue
+			}
+			if digests[image] == nil {
+				digests[image] = make(map[string]struct{})
+			}
+			digests[image][id] = struct{}{}
+		}
+	}
+
+	if len(digests) == 0 {
+		return nil
+	}
+
+	result := make(map[string][]string, len(digests))
+	for image, set := range digests {
+		values := make([]string, 0, len(set))
+		for value := range set {
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		result[image] = values
+	}
+	return result
+}
+
+func podContainerImages(pod *core_v1.Pod) map[string]string {
+	images := make(map[string]string, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for _, container := range pod.Spec.InitContainers {
+		images[container.Name] = container.Image
+	}
+	for _, container := range pod.Spec.Containers {
+		images[container.Name] = container.Image
+	}
+	return images
+}
+
+// parseImageID normalizes the runtime specific forms of ContainerStatus.ImageID
+// (docker-pullable://repo@sha256:..., repo@sha256:..., sha256:...) into a bare
+// digest. It returns an empty string when no digest can be recovered, which is
+// the case for images identified only by a legacy docker image ID.
+func parseImageID(imageID string) string {
+	if imageID == "" {
+		return ""
+	}
+	if idx := strings.Index(imageID, "://"); idx != -1 {
+		imageID = imageID[idx+len("://"):]
+	}
+	if idx := strings.LastIndex(imageID, "@"); idx != -1 {
+		imageID = imageID[idx+1:]
+	}
+	parsed, err := digest.Parse(imageID)
+	if err != nil {
+		return ""
+	}
+	return parsed.String()
+}

--- a/internal/k8s/running_digests_test.go
+++ b/internal/k8s/running_digests_test.go
@@ -1,0 +1,206 @@
+package k8s
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakePodSource struct {
+	pods      *core_v1.PodList
+	err       error
+	namespace string
+	selector  string
+}
+
+func (f *fakePodSource) Pods(namespace, selector string) (*core_v1.PodList, error) {
+	f.namespace = namespace
+	f.selector = selector
+	return f.pods, f.err
+}
+
+func runningDigestDeployment() *GenericResource {
+	resource, err := NewGenericResource(&apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "app", Namespace: "prod"},
+		Spec: apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": "app"}},
+			Template: core_v1.PodTemplateSpec{
+				Spec: core_v1.PodSpec{Containers: []core_v1.Container{{Name: "app", Image: "foo/bar:latest"}}},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return resource
+}
+
+func runningPod(name string, containers []core_v1.Container, statuses []core_v1.ContainerStatus) core_v1.Pod {
+	return core_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name, Namespace: "prod"},
+		Spec:       core_v1.PodSpec{Containers: containers},
+		Status:     core_v1.PodStatus{ContainerStatuses: statuses},
+	}
+}
+
+func running(name, imageID string) core_v1.ContainerStatus {
+	return core_v1.ContainerStatus{
+		Name:    name,
+		ImageID: imageID,
+		State:   core_v1.ContainerState{Running: &core_v1.ContainerStateRunning{}},
+	}
+}
+
+func TestRunningDigestResolver(t *testing.T) {
+	container := []core_v1.Container{{Name: "app", Image: "foo/bar:latest"}}
+
+	tests := []struct {
+		name string
+		pods []core_v1.Pod
+		want map[string][]string
+	}{
+		{
+			name: "single pod",
+			pods: []core_v1.Pod{
+				runningPod("a", container, []core_v1.ContainerStatus{running("app", "docker-pullable://foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}),
+			},
+			want: map[string][]string{"foo/bar:latest": {"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+		},
+		{
+			name: "replicas mid rollout report both digests",
+			pods: []core_v1.Pod{
+				runningPod("a", container, []core_v1.ContainerStatus{running("app", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}),
+				runningPod("b", container, []core_v1.ContainerStatus{running("app", "foo/bar@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")}),
+				runningPod("c", container, []core_v1.ContainerStatus{running("app", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}),
+			},
+			want: map[string][]string{"foo/bar:latest": {"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}},
+		},
+		{
+			name: "digests are keyed per container image",
+			pods: []core_v1.Pod{
+				runningPod("a", []core_v1.Container{
+					{Name: "app", Image: "foo/bar:latest"},
+					{Name: "sidecar", Image: "foo/sidecar:latest"},
+				}, []core_v1.ContainerStatus{
+					running("app", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+					running("sidecar", "foo/sidecar@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+				}),
+			},
+			want: map[string][]string{
+				"foo/bar:latest":     {"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				"foo/sidecar:latest": {"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+			},
+		},
+		{
+			name: "init containers are included",
+			pods: []core_v1.Pod{{
+				ObjectMeta: meta_v1.ObjectMeta{Name: "a", Namespace: "prod"},
+				Spec: core_v1.PodSpec{
+					InitContainers: []core_v1.Container{{Name: "init", Image: "foo/init:latest"}},
+					Containers:     container,
+				},
+				Status: core_v1.PodStatus{
+					InitContainerStatuses: []core_v1.ContainerStatus{{
+						Name:    "init",
+						ImageID: "foo/init@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+						State:   core_v1.ContainerState{Terminated: &core_v1.ContainerStateTerminated{}},
+					}},
+					ContainerStatuses: []core_v1.ContainerStatus{running("app", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+				},
+			}},
+			want: map[string][]string{
+				"foo/bar:latest":  {"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				"foo/init:latest": {"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},
+			},
+		},
+		{
+			name: "terminating pods are ignored",
+			pods: []core_v1.Pod{
+				func() core_v1.Pod {
+					pod := runningPod("a", container, []core_v1.ContainerStatus{running("app", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")})
+					now := meta_v1.Now()
+					pod.DeletionTimestamp = &now
+					return pod
+				}(),
+				runningPod("b", container, []core_v1.ContainerStatus{running("app", "foo/bar@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")}),
+			},
+			want: map[string][]string{"foo/bar:latest": {"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}},
+		},
+		{
+			name: "waiting containers are ignored",
+			pods: []core_v1.Pod{
+				runningPod("a", container, []core_v1.ContainerStatus{{
+					Name:    "app",
+					ImageID: "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					State:   core_v1.ContainerState{Waiting: &core_v1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+				}}),
+			},
+			want: nil,
+		},
+		{
+			name: "statuses without a matching container are ignored",
+			pods: []core_v1.Pod{
+				runningPod("a", container, []core_v1.ContainerStatus{running("gone", "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}),
+			},
+			want: nil,
+		},
+		{
+			name: "images without a digest are ignored",
+			pods: []core_v1.Pod{
+				runningPod("a", container, []core_v1.ContainerStatus{running("app", "")}),
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := &fakePodSource{pods: &core_v1.PodList{Items: test.pods}}
+			got := NewRunningDigestResolver(source).Resolve(runningDigestDeployment())
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("unexpected digests: %v, want %v", got, test.want)
+			}
+			if source.namespace != "prod" || source.selector != "app=app" {
+				t.Fatalf("unexpected pod query: %s/%s", source.namespace, source.selector)
+			}
+		})
+	}
+}
+
+func TestRunningDigestResolverUnavailable(t *testing.T) {
+	if got := NewRunningDigestResolver(&fakePodSource{err: errors.New("forbidden")}).Resolve(runningDigestDeployment()); got != nil {
+		t.Fatalf("expected no digests when pods cannot be listed, got %v", got)
+	}
+	if got := NewRunningDigestResolver(&fakePodSource{}).Resolve(nil); got != nil {
+		t.Fatalf("expected no digests for a nil resource, got %v", got)
+	}
+	var resolver *RunningDigestResolver
+	if got := resolver.Resolve(runningDigestDeployment()); got != nil {
+		t.Fatalf("expected no digests from a nil resolver, got %v", got)
+	}
+}
+
+func TestParseImageID(t *testing.T) {
+	tests := []struct {
+		imageID string
+		want    string
+	}{
+		{imageID: "docker-pullable://foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{imageID: "foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{imageID: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{imageID: "docker://sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{imageID: "registry:5000/foo/bar@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{imageID: "", want: ""},
+		{imageID: "foo/bar:latest", want: ""},
+		{imageID: "foo/bar@md5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", want: ""},
+	}
+	for _, test := range tests {
+		if got := parseImageID(test.imageID); got != test.want {
+			t.Errorf("parseImageID(%q) = %q, want %q", test.imageID, got, test.want)
+		}
+	}
+}

--- a/provider/helm3/helm3.go
+++ b/provider/helm3/helm3.go
@@ -133,9 +133,10 @@ type ImageDetails struct {
 
 // Provider - helm3 provider, responsible for managing release updates
 type Provider struct {
-	implementer Implementer
-	platforms   *k8s.PlatformResolver
-	resources   ResourceCache
+	implementer    Implementer
+	platforms      *k8s.PlatformResolver
+	runningDigests *k8s.RunningDigestResolver
+	resources      ResourceCache
 
 	sender notification.Sender
 
@@ -158,6 +159,14 @@ func WithWorkloadPlatforms(platforms *k8s.PlatformResolver, resources ResourceCa
 	return func(provider *Provider) {
 		provider.platforms = platforms
 		provider.resources = resources
+	}
+}
+
+// WithRunningDigests enables reporting of the image digests that the release
+// workloads are actually running.
+func WithRunningDigests(runningDigests *k8s.RunningDigestResolver) ProviderOption {
+	return func(provider *Provider) {
+		provider.runningDigests = runningDigests
 	}
 }
 
@@ -252,6 +261,7 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 			img.Namespace = release.Namespace
 			img.Provider = ProviderName
 			img.Platforms, img.PlatformErr = p.releaseImagePlatforms(release.Namespace, release.Name, img)
+			img.RunningDigests = p.releaseImageRunningDigests(release.Namespace, release.Name, img)
 			trackedImages = append(trackedImages, img)
 		}
 

--- a/provider/helm3/running_digests.go
+++ b/provider/helm3/running_digests.go
@@ -1,0 +1,45 @@
+package helm3
+
+import (
+	"sort"
+
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+// releaseImageRunningDigests returns the digests that the Kubernetes workloads
+// belonging to a release are running for a tracked image. It returns nil when
+// the mapping or the runtime information is unavailable, which callers treat as
+// "unknown" rather than "no drift".
+func (p *Provider) releaseImageRunningDigests(namespace, releaseName string, trackedImage *types.TrackedImage) []string {
+	if p.runningDigests == nil || p.resources == nil || trackedImage == nil || trackedImage.Image == nil {
+		return nil
+	}
+
+	found := make(map[string]struct{})
+	for _, resource := range p.resources.Values() {
+		annotations := resource.GetAnnotations()
+		if resource.Namespace != namespace || annotations[helmReleaseNameAnnotation] != releaseName || annotations[helmReleaseNamespaceAnnotation] != namespace {
+			continue
+		}
+		for img, digests := range p.runningDigests.Resolve(resource) {
+			ref, err := image.Parse(img)
+			if err != nil || ref.Repository() != trackedImage.Image.Repository() || ref.Tag() != trackedImage.Image.Tag() {
+				continue
+			}
+			for _, digest := range digests {
+				found[digest] = struct{}{}
+			}
+		}
+	}
+
+	if len(found) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(found))
+	for digest := range found {
+		result = append(result, digest)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/provider/helm3/running_digests_test.go
+++ b/provider/helm3/running_digests_test.go
@@ -1,0 +1,101 @@
+package helm3
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type helmPodSource struct {
+	pods map[string]*core_v1.PodList
+}
+
+func (s *helmPodSource) Pods(_, selector string) (*core_v1.PodList, error) {
+	if list, ok := s.pods[selector]; ok {
+		return list, nil
+	}
+	return &core_v1.PodList{}, nil
+}
+
+func helmWorkloadWithSelector(t *testing.T, releaseName, name, imageName string) *k8s.GenericResource {
+	t.Helper()
+	deployment := &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				helmReleaseNameAnnotation:      releaseName,
+				helmReleaseNamespaceAnnotation: "default",
+			},
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: core_v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec:       core_v1.PodSpec{Containers: []core_v1.Container{{Name: "app", Image: imageName}}},
+			},
+		},
+	}
+	resource, err := k8s.NewGenericResource(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resource
+}
+
+func helmRunningPods(imageName, imageID string) *core_v1.PodList {
+	return &core_v1.PodList{Items: []core_v1.Pod{{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "pod", Namespace: "default"},
+		Spec:       core_v1.PodSpec{Containers: []core_v1.Container{{Name: "app", Image: imageName}}},
+		Status: core_v1.PodStatus{ContainerStatuses: []core_v1.ContainerStatus{{
+			Name:    "app",
+			ImageID: imageID,
+			State:   core_v1.ContainerState{Running: &core_v1.ContainerStateRunning{}},
+		}}},
+	}}}
+}
+
+func TestReleaseImageRunningDigests(t *testing.T) {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+
+	trackedRef, err := image.Parse("example/image:1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked := &types.TrackedImage{Image: trackedRef}
+
+	resources := &platformResourceCache{resources: []*k8s.GenericResource{
+		helmWorkloadWithSelector(t, "release", "owned", "example/image:1.0.0"),
+		helmWorkloadWithSelector(t, "release", "other-image", "example/other:1.0.0"),
+		helmWorkloadWithSelector(t, "another-release", "not-owned", "example/image:1.0.0"),
+	}}
+	pods := &helmPodSource{pods: map[string]*core_v1.PodList{
+		"app=owned":       helmRunningPods("example/image:1.0.0", "example/image@"+digestA),
+		"app=other-image": helmRunningPods("example/other:1.0.0", "example/other@"+digestB),
+		"app=not-owned":   helmRunningPods("example/image:1.0.0", "example/image@"+digestB),
+	}}
+
+	provider := &Provider{
+		resources:      resources,
+		runningDigests: k8s.NewRunningDigestResolver(pods),
+	}
+
+	got := provider.releaseImageRunningDigests("default", "release", tracked)
+	if !reflect.DeepEqual(got, []string{digestA}) {
+		t.Fatalf("unexpected running digests: %v", got)
+	}
+
+	// without the resolver wired in there is nothing to report
+	bare := &Provider{resources: resources}
+	if got := bare.releaseImageRunningDigests("default", "release", tracked); got != nil {
+		t.Fatalf("expected no digests without a resolver, got %v", got)
+	}
+}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -81,8 +81,9 @@ func (p *UpdatePlan) String() string {
 
 // Provider - kubernetes provider for auto update
 type Provider struct {
-	implementer Implementer
-	platforms   *k8s.PlatformResolver
+	implementer    Implementer
+	platforms      *k8s.PlatformResolver
+	runningDigests *k8s.RunningDigestResolver
 
 	sender notification.Sender
 
@@ -103,6 +104,7 @@ func NewProvider(implementer Implementer, sender notification.Sender, approvalMa
 	return &Provider{
 		implementer:     implementer,
 		platforms:       platforms,
+		runningDigests:  k8s.NewRunningDigestResolver(implementer),
 		cache:           cache,
 		approvalManager: approvalManager,
 		events:          make(chan *types.Event, 100),
@@ -298,6 +300,7 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 			images = append(images, gr.GetImageVolumeReferences(volumeFilter)...)
 		}
 		platforms, platformErr := p.platforms.Resolve(gr)
+		runningDigests := p.runningDigests.Resolve(gr)
 
 		for _, img := range images {
 			ref, err := image.Parse(img)
@@ -321,16 +324,17 @@ func (p *Provider) TrackedImages() ([]*types.TrackedImage, error) {
 			}
 
 			trackedImages = append(trackedImages, &types.TrackedImage{
-				Image:        ref,
-				PollSchedule: schedule,
-				Trigger:      trigger,
-				Provider:     ProviderName,
-				Namespace:    gr.Namespace,
-				Secrets:      secrets,
-				Meta:         make(map[string]string),
-				Platforms:    platforms,
-				PlatformErr:  platformErr,
-				Policy:       plc,
+				Image:          ref,
+				RunningDigests: runningDigests[img],
+				PollSchedule:   schedule,
+				Trigger:        trigger,
+				Provider:       ProviderName,
+				Namespace:      gr.Namespace,
+				Secrets:        secrets,
+				Meta:           make(map[string]string),
+				Platforms:      platforms,
+				PlatformErr:    platformErr,
+				Policy:         plc,
 			})
 		}
 	}

--- a/provider/kubernetes/running_digests_test.go
+++ b/provider/kubernetes/running_digests_test.go
@@ -1,0 +1,71 @@
+package kubernetes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+	apps_v1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTrackedImagesCarryRunningDigests(t *testing.T) {
+	runningDigest := "sha256:" + strings.Repeat("a", 64)
+
+	fp := &fakeImplementer{
+		namespaces: &v1.NamespaceList{Items: []v1.Namespace{{ObjectMeta: meta_v1.ObjectMeta{Name: "xxxx"}}}},
+		podList: &v1.PodList{Items: []v1.Pod{{
+			ObjectMeta: meta_v1.ObjectMeta{Name: "dep-1-abc", Namespace: "xxxx"},
+			Spec: v1.PodSpec{Containers: []v1.Container{
+				{Name: "app", Image: "gcr.io/v2-namespace/hello-world:1.1.1"},
+			}},
+			Status: v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{
+				Name:    "app",
+				ImageID: "docker-pullable://gcr.io/v2-namespace/hello-world@" + runningDigest,
+				State:   v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			}}},
+		}}},
+	}
+
+	dep := &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        "dep-1",
+			Namespace:   "xxxx",
+			Labels:      map[string]string{types.KeelPolicyLabel: "force"},
+			Annotations: map[string]string{types.KeelForceTagMatchLabel: "true"},
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": "dep-1"}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{"app": "dep-1"}},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "app", Image: "gcr.io/v2-namespace/hello-world:1.1.1"},
+				}},
+			},
+		},
+	}
+
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(MustParseGRS([]*apps_v1.Deployment{dep})...)
+
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, &fakeSender{}, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	tracked, err := provider.TrackedImages()
+	if err != nil {
+		t.Fatalf("failed to get tracked images: %s", err)
+	}
+	if len(tracked) != 1 {
+		t.Fatalf("expected a single tracked image, got %d", len(tracked))
+	}
+	if !reflect.DeepEqual(tracked[0].RunningDigests, []string{runningDigest}) {
+		t.Fatalf("unexpected running digests: %v", tracked[0].RunningDigests)
+	}
+}

--- a/registry/docker/manifest.go
+++ b/registry/docker/manifest.go
@@ -1,7 +1,10 @@
 package docker
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -41,6 +44,60 @@ func (r *Registry) ManifestDigest(repository, reference string) (digest.Digest, 
 		return "", err
 	}
 	return digest.FromBytes(body), nil
+}
+
+// ManifestDigests - get every digest that identifies a reference. For an image
+// index that is the digest of the index itself plus the digests of the
+// per-platform manifests it points at, since a node runs one of the children
+// while the registry reports the index. Single-platform manifests return one
+// digest.
+func (r *Registry) ManifestDigests(repository, reference string) ([]string, error) {
+	url := r.url("/v2/%s/manifests/%s", repository, reference)
+	r.Logf("registry.manifest.digests url=%s repository=%s reference=%s", url, repository, reference)
+
+	resp, err := r.request("GET", url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("manifest request returned %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	top := resp.Header.Get("Docker-Content-Digest")
+	if top == "" {
+		top = digest.FromBytes(body).String()
+	} else if parsed, err := digest.Parse(top); err == nil {
+		top = parsed.String()
+	} else {
+		return nil, err
+	}
+	digests := []string{top}
+
+	mediaType := resp.Header.Get("Content-Type")
+	if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+		mediaType = parsed
+	}
+	switch mediaType {
+	case manifestlist.MediaTypeManifestList, oci.MediaTypeImageIndex:
+		var index oci.Index
+		if err := json.Unmarshal(body, &index); err != nil {
+			return nil, fmt.Errorf("decode image index: %w", err)
+		}
+		for _, descriptor := range index.Manifests {
+			if descriptor.Digest == "" {
+				continue
+			}
+			digests = append(digests, descriptor.Digest.String())
+		}
+	}
+
+	return digests, nil
 }
 
 // request performs a request against a url

--- a/registry/docker/manifest_digests_test.go
+++ b/registry/docker/manifest_digests_test.go
@@ -1,0 +1,85 @@
+package docker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	manifestlist "github.com/distribution/distribution/v3/manifest/manifestlist"
+	manifestv2 "github.com/distribution/distribution/v3/manifest/schema2"
+	"github.com/opencontainers/go-digest"
+	oci "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestManifestDigests(t *testing.T) {
+	const (
+		indexDigest    = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		amd64Digest    = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		arm64Digest    = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+		manifestDigest = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	)
+
+	indexBody, err := json.Marshal(oci.Index{
+		MediaType: oci.MediaTypeImageIndex,
+		Manifests: []oci.Descriptor{
+			{Digest: digest.Digest(amd64Digest), Platform: &oci.Platform{OS: "linux", Architecture: "amd64"}},
+			{Digest: digest.Digest(arm64Digest), Platform: &oci.Platform{OS: "linux", Architecture: "arm64"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestBody, err := json.Marshal(oci.Manifest{MediaType: manifestv2.MediaTypeManifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/example/image/manifests/multi":
+			w.Header().Set("Content-Type", manifestlist.MediaTypeManifestList+"; charset=utf-8")
+			w.Header().Set("Docker-Content-Digest", indexDigest)
+			_, _ = w.Write(indexBody)
+		case "/v2/example/image/manifests/single":
+			w.Header().Set("Content-Type", manifestv2.MediaTypeManifest)
+			w.Header().Set("Docker-Content-Digest", manifestDigest)
+			_, _ = w.Write(manifestBody)
+		case "/v2/example/image/manifests/unsigned":
+			// registries are allowed to omit the digest header
+			w.Header().Set("Content-Type", manifestv2.MediaTypeManifest)
+			_, _ = w.Write(manifestBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	registry := New(server.URL, "", "")
+	registry.Logf = func(string, ...interface{}) {}
+
+	tests := []struct {
+		reference string
+		want      []string
+	}{
+		{reference: "multi", want: []string{indexDigest, amd64Digest, arm64Digest}},
+		{reference: "single", want: []string{manifestDigest}},
+		{reference: "unsigned", want: []string{digest.FromBytes(manifestBody).String()}},
+	}
+	for _, test := range tests {
+		t.Run(test.reference, func(t *testing.T) {
+			got, err := registry.ManifestDigests("example/image", test.reference)
+			if err != nil {
+				t.Fatalf("failed to get manifest digests: %s", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("unexpected digests: %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	if _, err := registry.ManifestDigests("example/image", "missing"); err == nil {
+		t.Error("expected an error for a missing manifest")
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -31,6 +31,7 @@ type Repository struct {
 type Client interface {
 	Get(opts Opts) (*Repository, error)
 	Digest(opts Opts) (string, error)
+	Digests(opts Opts) ([]string, error)
 	Platforms(opts Opts) ([]types.Platform, error)
 }
 
@@ -147,6 +148,33 @@ INIT_CLIENT:
 	}
 
 	return manifestDigest.String(), nil
+}
+
+// Digests returns every digest that identifies a tag: the digest reported for
+// the tag plus, for a multi-platform image, the digests of the per-platform
+// manifests a node can actually be running.
+func (c *DefaultClient) Digests(opts Opts) ([]string, error) {
+	if opts.Tag == "" {
+		return nil, ErrTagNotSupplied
+	}
+
+	// fallback to HTTP if the registry doesn't speak HTTPS https://github.com/keel-hq/keel/issues/331
+INIT_CLIENT:
+	hub, err := c.getRegistryClient(opts.Registry, opts.Username, opts.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	digests, err := hub.ManifestDigests(opts.Name, opts.Tag)
+	if err != nil {
+		if strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") && strings.HasPrefix(opts.Registry, "https://") && c.insecure {
+			opts.Registry = strings.Replace(opts.Registry, "https://", "http://", 1)
+			goto INIT_CLIENT
+		}
+		return nil, err
+	}
+
+	return digests, nil
 }
 
 // Platforms returns the platforms supported by a tagged image manifest.

--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -116,11 +116,23 @@ func (w *RepositoryWatcher) Watch(images ...*types.TrackedImage) error {
 	var errs []string
 	tracked := map[string]bool{}
 
+	// a watcher can be shared by several workloads, any one of them running a
+	// stale digest is drift the watcher has to report, so the digests are kept
+	// grouped per workload rather than merged into one set
+	running := map[string][][]string{}
+	for _, image := range images {
+		if image.Trigger != types.TriggerTypePoll || len(image.RunningDigests) == 0 {
+			continue
+		}
+		key := getImageIdentifier(image.Image, image.Policy.KeepTag())
+		running[key] = append(running[key], image.RunningDigests)
+	}
+
 	for _, image := range images {
 		if image.Trigger != types.TriggerTypePoll {
 			continue
 		}
-		identifier, err := w.watch(image)
+		identifier, err := w.watch(image, running[getImageIdentifier(image.Image, image.Policy.KeepTag())])
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -156,7 +168,7 @@ func (w *RepositoryWatcher) unwatch(tracked map[string]bool) {
 	}
 }
 
-func (w *RepositoryWatcher) watch(image *types.TrackedImage) (string, error) {
+func (w *RepositoryWatcher) watch(image *types.TrackedImage, runningDigests [][]string) (string, error) {
 
 	if image.PollSchedule == "" {
 		return "", fmt.Errorf("cron schedule cannot be empty")
@@ -177,7 +189,7 @@ func (w *RepositoryWatcher) watch(image *types.TrackedImage) (string, error) {
 	// checking whether it's already being watched
 	details, ok := w.watched[key]
 	if !ok {
-		err = w.addJob(image, image.PollSchedule)
+		err = w.addJob(image, image.PollSchedule, runningDigests)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -211,7 +223,56 @@ func (w *RepositoryWatcher) watch(image *types.TrackedImage) (string, error) {
 	return key, nil
 }
 
-func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) error {
+// runtimeBaseline reports a digest that a workload is running when no workload
+// sharing this watcher runs the digest the tag resolves to. It is deliberately
+// conservative: a workload that runs the current digest on at least one replica
+// is mid-rollout, not stale, and the per-platform manifests of a multi-arch
+// image index never equal the index digest a registry reports.
+func (w *RepositoryWatcher) runtimeBaseline(ti *types.TrackedImage, workloads [][]string, registryOpts registry.Opts, digest string) (string, bool) {
+	known := map[string]bool{digest: true}
+	var candidates [][]string
+	for _, workload := range workloads {
+		if len(workload) > 0 && !matchesAny(workload, known) {
+			candidates = append(candidates, workload)
+		}
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+
+	// the tag may resolve to an image index whose children are what nodes run
+	tagDigests, err := w.registryClient.Digests(registryOpts)
+	if err != nil {
+		// without the full digest set a mismatch cannot be told apart from a
+		// multi-arch image, so keep the registry digest as the baseline
+		log.WithFields(log.Fields{
+			"error": err,
+			"image": ti.Image.String(),
+		}).Warn("trigger.poll.RepositoryWatcher.addJob: failed to resolve tag manifest digests, cannot check for runtime drift")
+		return "", false
+	}
+	for _, tagDigest := range tagDigests {
+		known[tagDigest] = true
+	}
+
+	for _, workload := range candidates {
+		if !matchesAny(workload, known) {
+			return workload[0], true
+		}
+	}
+	return "", false
+}
+
+func matchesAny(digests []string, known map[string]bool) bool {
+	for _, d := range digests {
+		if known[d] {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string, runningDigests [][]string) error {
 	// getting initial digest
 	reg := ti.Image.Scheme() + "://" + ti.Image.Registry()
 
@@ -240,9 +301,25 @@ func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) erro
 
 	key := getImageIdentifier(ti.Image, ti.Policy.KeepTag())
 
+	// The baseline is what the workload is running, not what the registry
+	// serves. Seeding it with the registry digest hides drift that happened
+	// while Keel was not watching (the watcher state is in-memory only, so
+	// every restart starts from scratch) - https://github.com/keel-hq/keel/issues/845
+	baseline := digest
+	if ti.Policy.KeepTag() {
+		if running, ok := w.runtimeBaseline(ti, runningDigests, registryOpts, digest); ok {
+			log.WithFields(log.Fields{
+				"image":           ti.Image.String(),
+				"registry_digest": digest,
+				"running_digests": runningDigests,
+			}).Info("trigger.poll.RepositoryWatcher.addJob: workload is not running the current tag digest, seeding watcher with the running digest")
+			baseline = running
+		}
+	}
+
 	details := &watchDetails{
 		trackedImage: ti,
-		digest:       digest, // current image digest
+		digest:       baseline, // digest the workload is known to be running
 		latest:       ti.Image.Tag(),
 		schedule:     schedule,
 	}
@@ -258,7 +335,7 @@ func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string) erro
 		log.WithFields(log.Fields{
 			"job_name": key,
 			"image":    ti.Image.String(),
-			"digest":   digest,
+			"digest":   baseline,
 			"schedule": schedule,
 		}).Info("trigger.poll.RepositoryWatcher: new watch tag digest job added")
 

--- a/trigger/poll/watcher_drift_test.go
+++ b/trigger/poll/watcher_drift_test.go
@@ -1,0 +1,202 @@
+package poll
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/approvals"
+	"github.com/keel-hq/keel/internal/policy"
+	"github.com/keel-hq/keel/provider"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+func digestOf(char string) string {
+	return "sha256:" + strings.Repeat(char, 64)
+}
+
+// https://github.com/keel-hq/keel/issues/845 - the watcher baseline is
+// in-memory only, so on every start it has to be seeded from what the workload
+// is running instead of from what the registry currently serves.
+func TestWatcherSeedsBaselineFromRunningDigest(t *testing.T) {
+	registryDigest := digestOf("a")
+	runningDigest := digestOf("b")
+
+	tests := []struct {
+		name           string
+		runningDigests []string
+		tagDigests     []string
+		tagDigestsErr  error
+		keepTag        bool
+		expectEvent    bool
+	}{
+		{
+			name:           "running digest is stale",
+			runningDigests: []string{runningDigest},
+			expectEvent:    true,
+		},
+		{
+			name:           "running digest is current",
+			runningDigests: []string{registryDigest},
+			expectEvent:    false,
+		},
+		{
+			name:           "rollout in progress, some replicas already updated",
+			runningDigests: []string{registryDigest, runningDigest},
+			expectEvent:    false,
+		},
+		{
+			name:           "multi arch child manifest is not drift",
+			runningDigests: []string{runningDigest},
+			tagDigests:     []string{registryDigest, runningDigest},
+			expectEvent:    false,
+		},
+		{
+			name:           "unresolvable tag manifest keeps the registry baseline",
+			runningDigests: []string{runningDigest},
+			tagDigestsErr:  errors.New("manifest request returned 401 Unauthorized"),
+			expectEvent:    false,
+		},
+		{
+			name:           "no runtime information available",
+			runningDigests: nil,
+			expectEvent:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			img, _ := image.Parse("gcr.io/v2-namespace/hello-world:1.1.1")
+			tracked := &types.TrackedImage{
+				Image:          img,
+				Trigger:        types.TriggerTypePoll,
+				Provider:       "fp",
+				PollSchedule:   types.KeelPollDefaultSchedule,
+				Policy:         policy.NewForcePolicy(true),
+				RunningDigests: test.runningDigests,
+			}
+
+			fp := &fakeProvider{images: []*types.TrackedImage{tracked}}
+			store, teardown := newTestingUtils()
+			defer teardown()
+			am := approvals.New(&approvals.Opts{Store: store})
+			providers := provider.New([]provider.Provider{fp}, am)
+
+			frc := &fakeRegistryClient{
+				digestToReturn:        registryDigest,
+				tagDigestsToReturn:    test.tagDigests,
+				tagDigestsErrToReturn: test.tagDigestsErr,
+			}
+
+			watcher := NewRepositoryWatcher(providers, frc)
+			if err := watcher.Watch(tracked); err != nil {
+				t.Fatalf("failed to watch image: %s", err)
+			}
+
+			if !test.expectEvent {
+				if len(fp.submitted) != 0 {
+					t.Fatalf("expected no event, got %v", fp.submitted)
+				}
+				return
+			}
+
+			if len(fp.submitted) != 1 {
+				t.Fatalf("expected a single event, got %v", fp.submitted)
+			}
+			submitted := fp.submitted[0]
+			if submitted.Repository.Digest != registryDigest {
+				t.Errorf("unexpected event digest: %s", submitted.Repository.Digest)
+			}
+			if submitted.Repository.Tag != "1.1.1" {
+				t.Errorf("unexpected event tag: %s", submitted.Repository.Tag)
+			}
+
+			// once the event is out, the baseline has caught up and a second
+			// poll must stay quiet
+			watcher.watched["gcr.io/v2-namespace/hello-world:1.1.1"].trackedImage = tracked
+			NewWatchTagJob(providers, frc, watcher.watched["gcr.io/v2-namespace/hello-world:1.1.1"]).Run()
+			if len(fp.submitted) != 1 {
+				t.Fatalf("expected no repeated event, got %v", fp.submitted)
+			}
+		})
+	}
+}
+
+// two workloads using the same image share a single watcher, so the baseline
+// has to account for the stale one even when it is not the first seen
+func TestWatcherSeedsSharedBaselineFromAnyStaleWorkload(t *testing.T) {
+	registryDigest := digestOf("a")
+	runningDigest := digestOf("b")
+
+	img, _ := image.Parse("gcr.io/v2-namespace/hello-world:1.1.1")
+	current := &types.TrackedImage{
+		Image:          img,
+		Trigger:        types.TriggerTypePoll,
+		Provider:       "fp",
+		Namespace:      "current",
+		PollSchedule:   types.KeelPollDefaultSchedule,
+		Policy:         policy.NewForcePolicy(true),
+		RunningDigests: []string{registryDigest},
+	}
+	stale := &types.TrackedImage{
+		Image:          img,
+		Trigger:        types.TriggerTypePoll,
+		Provider:       "fp",
+		Namespace:      "stale",
+		PollSchedule:   types.KeelPollDefaultSchedule,
+		Policy:         policy.NewForcePolicy(true),
+		RunningDigests: []string{runningDigest},
+	}
+
+	fp := &fakeProvider{images: []*types.TrackedImage{current, stale}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	am := approvals.New(&approvals.Opts{Store: store})
+	providers := provider.New([]provider.Provider{fp}, am)
+
+	frc := &fakeRegistryClient{digestToReturn: registryDigest}
+
+	watcher := NewRepositoryWatcher(providers, frc)
+	if err := watcher.Watch(current, stale); err != nil {
+		t.Fatalf("failed to watch images: %s", err)
+	}
+
+	if len(fp.submitted) != 1 {
+		t.Fatalf("expected a single event, got %v", fp.submitted)
+	}
+	if fp.submitted[0].Repository.Digest != registryDigest {
+		t.Errorf("unexpected event digest: %s", fp.submitted[0].Repository.Digest)
+	}
+}
+
+// semver style watchers do not compare digests, so they must not pay for the
+// extra manifest lookup
+func TestWatcherSkipsDriftCheckWithoutMatchTag(t *testing.T) {
+	img, _ := image.Parse("gcr.io/v2-namespace/hello-world:1.1.1")
+	tracked := &types.TrackedImage{
+		Image:          img,
+		Trigger:        types.TriggerTypePoll,
+		Provider:       "fp",
+		PollSchedule:   types.KeelPollDefaultSchedule,
+		Policy:         policy.NewForcePolicy(false),
+		RunningDigests: []string{digestOf("b")},
+	}
+
+	fp := &fakeProvider{images: []*types.TrackedImage{tracked}}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	am := approvals.New(&approvals.Opts{Store: store})
+	providers := provider.New([]provider.Provider{fp}, am)
+
+	frc := &fakeRegistryClient{digestToReturn: digestOf("a")}
+
+	watcher := NewRepositoryWatcher(providers, frc)
+	if err := watcher.Watch(tracked); err != nil {
+		t.Fatalf("failed to watch image: %s", err)
+	}
+
+	if frc.tagDigestsCalls != 0 {
+		t.Errorf("expected no manifest digest lookups, got %d", frc.tagDigestsCalls)
+	}
+}

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -41,6 +41,11 @@ type fakeRegistryClient struct {
 
 	digestErrToReturn error
 
+	// digests returned by Digests(), defaults to digestToReturn
+	tagDigestsToReturn    []string
+	tagDigestsErrToReturn error
+	tagDigestsCalls       int
+
 	tagsToReturn []string
 
 	platformsToReturn map[string][]types.Platform
@@ -62,6 +67,18 @@ func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err erro
 	c.digestCalls++
 	c.opts = opts
 	return c.digestToReturn, c.digestErrToReturn
+}
+
+func (c *fakeRegistryClient) Digests(opts registry.Opts) ([]string, error) {
+	c.tagDigestsCalls++
+	c.opts = opts
+	if c.tagDigestsErrToReturn != nil {
+		return nil, c.tagDigestsErrToReturn
+	}
+	if c.tagDigestsToReturn != nil {
+		return c.tagDigestsToReturn, nil
+	}
+	return []string{c.digestToReturn}, nil
 }
 
 func (c *fakeRegistryClient) Platforms(opts registry.Opts) ([]types.Platform, error) {

--- a/types/tracked_images.go
+++ b/types/tracked_images.go
@@ -21,6 +21,9 @@ type TrackedImage struct {
 	Meta         map[string]string `json:"meta"` // metadata supplied by providers
 	Platforms    []Platform        `json:"-"`
 	PlatformErr  PlatformError     `json:"-"`
+	// RunningDigests are the image digests reported by the workload runtime for
+	// this image reference. Empty when the provider cannot observe them.
+	RunningDigests []string `json:"-"`
 	// a list of pre-release tags, ie: 1.0.0-dev, 1.5.0-prod get translated into
 	// dev, prod
 	// combined semver tags


### PR DESCRIPTION
## Summary
Keel's same-tag digest watcher (`force` policy with `keel.sh/match-tag=true`) fetched the tag's registry digest at registration and stored it as its baseline, then immediately compared the registry against itself. A workload already running an older digest of a mutable tag therefore produced no event. Because the baseline lives only in the in-memory `watched` map and is never persisted, this happened on every Keel start or restart, and drift went unnoticed until the tag moved again. Fixes keel-hq/keel#845.

The baseline is now taken from what the workload is actually running:

- `internal/k8s/running_digests.go` adds `RunningDigestResolver`. It lists a workload's pods by its selector and maps each pod-spec container image to the digests reported by the corresponding container statuses. Statuses are matched to containers by name, so init containers are covered and multi-container pods do not cross-contaminate. Terminating pods and waiting containers are skipped, and the runtime forms of `imageID` (`docker-pullable://repo@sha256:…`, `repo@sha256:…`, bare `sha256:…`) are normalized to a bare digest.
- `types.TrackedImage.RunningDigests` carries that per-image set. The Kubernetes provider populates it in `TrackedImages`; the Helm 3 provider does the same through `releaseImageRunningDigests`, reusing the release-to-workload annotation mapping already used for platform resolution, wired up in `cmd/keel/main.go` via the new `helm3.WithRunningDigests` option.
- `registry.Client.Digests` / `docker.ManifestDigests` return the digest a tag resolves to plus, for an image index, the digests of its child manifests.
- `trigger/poll/watcher.go` seeds `watchDetails.digest` from the running digest when it no longer matches the tag, so the poll that runs immediately after registration emits an event and the workload is corrected.

The drift check is deliberately narrow. It runs only for `KeepTag()` policies, the sole path that compares digests, so semver and tag-discovery watchers make no extra registry call. Drift is reported only when a workload runs *none* of the digests the tag maps to: a workload mid-rollout with at least one updated replica is not stale, a pod running a per-platform child of a multi-arch image index is not stale (that digest never equals the index digest a registry reports), and if the manifest cannot be fetched the previous behaviour is kept rather than guessing. Running digests are grouped per workload rather than merged, so a watcher shared by several workloads still fires when one of them is stale even if the first workload seen is current. The check runs at watcher registration only; re-checking on every provider rescan would re-emit events for workloads blocked on approvals.

No chart change was needed: the existing ClusterRole already grants `list` on `pods`.

## Testing
`CGO_ENABLED=1 go test ./...` — all 32 packages pass (CGO is required for the `go-sqlite3` based store used by the polling tests).

New tests cover:
- `internal/k8s` — the resolver across replicas reporting different digests, per-container-image keying, init containers, terminating pods, waiting containers, statuses with no matching container, pods without a digest, pod-list errors and nil inputs, plus a table for every `imageID` form.
- `provider/kubernetes` — `TrackedImages` carries the running digest observed on the pod.
- `provider/helm3` — release-owned workloads contribute digests while other releases and other images do not, and the absence of a resolver yields nothing.
- `registry/docker` — `ManifestDigests` against a fixture registry for an image index, a single manifest, and a response with no `Docker-Content-Digest` header, plus the error path.
- `trigger/poll` — the six baseline-seeding cases (stale, current, mid-rollout, multi-arch child, unresolvable manifest, no runtime information), a shared watcher where only the second workload is stale, and the absence of manifest lookups without `match-tag`.

LFG!