### PR TITLE
Make application releases reliable and prepare 0.22.1

### DIFF
--- a/.agents/skills/release-keel/SKILL.md
+++ b/.agents/skills/release-keel/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: release-keel
+description: Prepare, validate, publish, verify, and recover Keel application and Helm chart releases. Use when an agent is asked to release Keel, bump application or chart versions, create or inspect release tags, check release readiness, publish GHCR images or Helm charts, or recover a failed release.
+---
+
+# Release Keel
+
+Release application images before publishing the GitHub Release, then release any chart that references the verified application. Read `docs/release-validation.md` for the full validation contract and diagnostics.
+
+## Guardrails
+
+- Require explicit user authorization before pushing tags, creating releases, or changing public registry state.
+- Never use the GitHub Release form or `gh release create` to create a new application tag. Push the tag first; CI creates the GitHub Release only after the image passes verification.
+- Never move, overwrite, or reuse a public release tag. Correct the source and choose a new version after a failed publication.
+- Use a clean release commit on `master`. Do not tag an unmerged feature branch or a commit whose required CI failed.
+- Treat the application Git tag as the application build version. Treat `Chart.yaml.appVersion` as the version installed by that chart release.
+- Run `make release-validate` for any chart metadata or template change and confirm the Deployment, probes, and k3s suite pass.
+
+## Inspect readiness
+
+1. Run `git status -sb`, `gh auth status`, and inspect the latest application and chart releases.
+2. Confirm the proposed application tag, GHCR tag, GitHub Release, chart tag, chart GitHub Release, and Helm index version do not already exist.
+3. Inspect `chart/keel/Chart.yaml`. To publish a chart for the new application, set `appVersion` to the application version and choose an unused chart `version`.
+4. Run a tag rehearsal before creating remote state:
+
+   ```bash
+   GITHUB_REF=refs/tags/<app-version> make release-package
+   make release-validate
+   ```
+
+## Publish an application
+
+1. Commit the release metadata and workflow changes through a PR.
+2. Wait for required CI on the merged `master` commit.
+3. Create and push only an annotated application tag:
+
+   ```bash
+   git tag -a <app-version> -m "Keel <app-version>" <release-commit>
+   git push origin <app-version>
+   ```
+
+4. Monitor the tag's `CI` workflow. Require unit, UI, package, k3s release, behavioral, amd64, arm64, manifest, and GitHub Release jobs to succeed.
+5. Verify `ghcr.io/keel-hq/keel:<app-version>` is an amd64/arm64 index and the GitHub Release exists only after it.
+
+Do not manually create the GitHub Release before the image. The `github-release` CI job owns that step.
+
+## Publish a chart
+
+Publish a chart only after its `appVersion` has both a non-draft GitHub application release and verified amd64/arm64 GHCR image.
+
+```bash
+git tag -a chart-v<chart-version> -m "Keel chart v<chart-version>" <release-commit>
+git push origin chart-v<chart-version>
+```
+
+Monitor `Release Charts`, then verify the chart release and public index:
+
+```bash
+KEEL_PUBLISHED_APP_VERSION=<app-version> \
+KEEL_PUBLISHED_CHART_VERSION=v<chart-version> \
+make published-release-check
+```
+
+## Recover a failure
+
+1. Inspect the exact failed job and public GitHub, GHCR, and Helm state.
+2. Rerun only when the failed workflow has not created an immutable versioned tag or artifact that the workflow refuses to overwrite.
+3. If a public version is incomplete, mark its release notes as withdrawn, fix the source through a PR, and use the next version.
+4. Leave orphaned content-addressed image blobs alone; they are not addressable by a release tag.

--- a/.agents/skills/release-keel/agents/openai.yaml
+++ b/.agents/skills/release-keel/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release Keel"
+  short_description: "Safely validate and publish Keel releases"
+  default_prompt: "Use $release-keel to prepare, validate, publish, and verify a Keel application or Helm chart release."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/chart-') && 'release-application' || format('ci-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -188,7 +188,10 @@ jobs:
       - name: Extract validated application version
         id: version
         shell: bash
-        run: echo "app_version=$(awk '$1 == \"appVersion:\" {print $2; exit}' chart/keel/Chart.yaml)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "app_version=$(./scripts/resolve-application-version.sh)" >> "$GITHUB_OUTPUT"
+          epoch=$(git show -s --format=%ct "$GITHUB_SHA")
+          echo "build_date=$(date -u -d "@$epoch" +%Y-%m-%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
       - name: Build without publishing
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -197,6 +200,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.app_version }}
             REVISION=${{ github.sha }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
           push: false
           cache-from: type=gha,scope=keel-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=keel-${{ matrix.arch }}
@@ -248,7 +252,10 @@ jobs:
       - name: Extract validated application version
         id: version
         shell: bash
-        run: echo "app_version=$(awk '$1 == \"appVersion:\" {print $2; exit}' chart/keel/Chart.yaml)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "app_version=$(./scripts/resolve-application-version.sh)" >> "$GITHUB_OUTPUT"
+          epoch=$(git show -s --format=%ct "$GITHUB_SHA")
+          echo "build_date=$(date -u -d "@$epoch" +%Y-%m-%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Refuse to overwrite an application release tag
         if: startsWith(github.ref, 'refs/tags/')
@@ -276,6 +283,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.app_version }}
             REVISION=${{ github.sha }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=keel-${{ matrix.arch }}
@@ -390,3 +398,29 @@ jobs:
             fi
             expected_hash="$manifest_hash"
           done
+
+  github-release:
+    name: Publish GitHub Release
+    needs: docker-manifest
+    if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/chart-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release after verified image publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release $RELEASE_TAG already exists; leaving it unchanged"
+          else
+            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+              --verify-tag --generate-notes --title "$RELEASE_TAG"
+          fi
+          release_state=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft --jq '[.tagName, .isDraft] | @tsv')
+          if [[ "$release_state" != "$RELEASE_TAG"$'\tfalse' ]]; then
+            echo "Unexpected GitHub Release state: $release_state" >&2
+            exit 1
+          fi

--- a/.github/workflows/releasecharts.yaml
+++ b/.github/workflows/releasecharts.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-chart-${{ github.ref }}
+  group: release-chart
   cancel-in-progress: false
 
 jobs:

--- a/.test/install-helm.sh
+++ b/.test/install-helm.sh
@@ -7,26 +7,41 @@ readonly HELM_VERSION
 
 install_helm() {
   local destination="$1"
-  local architecture archive checksum expected temporary
+  local architecture archive checksum expected operating_system temporary
+  operating_system="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "${operating_system}" in
+    linux|darwin) ;;
+    *) printf 'unsupported Helm operating system: %s\n' "${operating_system}" >&2; return 1 ;;
+  esac
   architecture="$(uname -m)"
   case "${architecture}" in
-    x86_64) architecture="amd64"; expected="f8180838c23d7c7d797b208861fecb591d9ce1690d8704ed1e4cb8e2add966c1" ;;
-    aarch64|arm64) architecture="arm64"; expected="c0a45e67eef0c7416a8a8c9e9d5d2d30d70e4f4d3f7bea5de28241fffa8f3b89" ;;
+    x86_64) architecture="amd64" ;;
+    aarch64|arm64) architecture="arm64" ;;
     *) printf 'unsupported Helm architecture: %s\n' "${architecture}" >&2; return 1 ;;
+  esac
+  case "${operating_system}-${architecture}" in
+    linux-amd64) expected="f8180838c23d7c7d797b208861fecb591d9ce1690d8704ed1e4cb8e2add966c1" ;;
+    linux-arm64) expected="c0a45e67eef0c7416a8a8c9e9d5d2d30d70e4f4d3f7bea5de28241fffa8f3b89" ;;
+    darwin-amd64) expected="860a7238285b44b5dc7b3c4dad6194316885d7015d77c34e23177e0e9554af8f" ;;
+    darwin-arm64) expected="041849741550b20710d7ad0956e805ebd960b483fe978864f8e7fdd03ca84ec8" ;;
   esac
 
   mkdir -p "$(dirname "${destination}")"
   temporary="$(mktemp -d)"
   archive="${temporary}/helm.tar.gz"
   curl --fail --location --show-error --silent \
-    --output "${archive}" "https://get.helm.sh/helm-${HELM_VERSION}-linux-${architecture}.tar.gz"
-  checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+    --output "${archive}" "https://get.helm.sh/helm-${HELM_VERSION}-${operating_system}-${architecture}.tar.gz"
+  if command -v sha256sum >/dev/null; then
+    checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+  else
+    checksum="$(shasum -a 256 "${archive}" | awk '{print $1}')"
+  fi
   [[ "${checksum}" == "${expected}" ]] || {
     printf 'Helm archive checksum mismatch: expected %s, got %s\n' "${expected}" "${checksum}" >&2
     return 1
   }
-  tar -xzf "${archive}" -C "${temporary}" "linux-${architecture}/helm"
-  install -m 0755 "${temporary}/linux-${architecture}/helm" "${destination}"
+  tar -xzf "${archive}" -C "${temporary}" "${operating_system}-${architecture}/helm"
+  install -m 0755 "${temporary}/${operating_system}-${architecture}/helm" "${destination}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/.test/release-version.sh
+++ b/.test/release-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT
+RESOLVER="${REPO_ROOT}/scripts/resolve-application-version.sh"
+chart_version="$(awk '$1 == "appVersion:" {print $2; exit}' "${REPO_ROOT}/chart/keel/Chart.yaml")"
+
+[[ "$("${RESOLVER}")" == "${chart_version}" ]]
+[[ "$(GITHUB_REF=refs/tags/9.8.7 "${RESOLVER}")" == 9.8.7 ]]
+[[ "$(GITHUB_REF=refs/tags/chart-v7.8.9 "${RESOLVER}")" == "${chart_version}" ]]
+[[ "$(KEEL_APP_VERSION=3.2.1 GITHUB_REF=refs/tags/9.8.7 "${RESOLVER}")" == 3.2.1 ]]
+
+if GITHUB_REF=refs/tags/not-semver "${RESOLVER}" >/dev/null 2>&1; then
+  printf '[release-version-test] ERROR: invalid application tag was accepted\n' >&2
+  exit 1
+fi
+
+printf '[release-version-test] application version resolution passed\n'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,4 @@
 Agent skills live in `.agents/skills/<name>/SKILL.md` and are readable by opencode, codex, and other AGENTS-compatible tools.
 
 - `keel-dev-stack` (`.agents/skills/keel-dev-stack/SKILL.md`): Start, verify, and tear down the local Keel dev stack — k3s (k3d) cluster on :6443, the Keel backend/dashboard on :9300, and the React UI (built `ui/dist` served by Keel, plus the Vite dev server on :8000). Use when asked to start the dev server, bring up k3s/k3d with Keel, or fix the dashboard not opening.
-
+- `release-keel` (`.agents/skills/release-keel/SKILL.md`): Prepare, validate, publish, verify, and recover Keel application and Helm chart releases. Use when asked to release Keel, bump application or chart versions, create release tags, inspect release readiness, or recover a failed release.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ARMFLAGS		+= -X github.com/keel-hq/keel/version.BuildDate=$(JOBDATE)
 
 release-lint:
 	bash -n .test/*.sh scripts/*.sh
+	./.test/release-version.sh
 	go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
 
 release-package:

--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 name: keel
 description: Open source tool for automating Kubernetes deployment updates.
-# The chart version number here is just a template. The actual version number is
-# replaced during the chart build, see .github/workflows/releasechart.yaml
-# The way to trigger a chart release is using a tag "chart-{CHART_VERSION}"
+# Bump this version for each chart release, then push tag "chart-v{version}".
+# See .github/workflows/releasecharts.yaml and the release-keel agent skill.
 version: 1.2.0
-appVersion: 0.21.1
+appVersion: 0.22.1
 keywords:
 - kubernetes deployment
 - helm release

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,23 +1,24 @@
 # Release process and validation
 
-This document describes the release path as audited on 2026-08-05. Release validation is read-only with respect to GitHub and public registries. It never creates tags, releases, images, or charts.
+This document describes the release path as audited on 2026-08-14. Local release validation is read-only with respect to GitHub and public registries. It never creates tags, releases, images, or charts.
 
 ## Release paths and version contract
 
 Keel has two related release paths.
 
-An application release starts with a SemVer Git tag such as `0.21.1`. `.github/workflows/ci.yml` runs Go tests, the UI install/typecheck/lint/test/build, API generation checks, and the packaged-chart k3s suite before any image job can publish. Native amd64 and arm64 jobs build `Dockerfile`, push content-addressed images without tags, and the manifest job creates the GHCR tag and `latest` only after both digests exist. It then verifies that every produced tag resolves to the same amd64/arm64 index. The workflow needs `contents: read`; only image publication jobs receive `packages: write`. Pull requests do not log in or push. GitHub application releases are currently created outside this repository's workflows after the tag/image succeeds; that manual boundary is not changed here.
+An application release starts with a SemVer Git tag such as `0.22.1`. `.github/workflows/ci.yml` runs Go tests, the UI install/typecheck/lint/test/build, API generation checks, and the packaged-chart k3s suite before any image job can publish. Native amd64 and arm64 jobs build `Dockerfile`, push content-addressed images without tags, and the manifest job creates the GHCR version tag and `latest` only after both digests exist. It then verifies that every produced tag resolves to the same amd64/arm64 index. Only after that verification does the final job create the public GitHub Release from the existing tag. The workflow needs `contents: read`; only image publication jobs receive `packages: write`, and only the final release job receives `contents: write`. Pull requests do not log in or publish.
 
 A chart release starts with `chart-v<Chart.yaml version>`. `.github/workflows/releasecharts.yaml` validates the tag, packages the source chart without editing it, and confirms that `Chart.yaml.appVersion` already has a public GitHub application release and amd64/arm64 GHCR image. Only then does chart-releaser package the chart, create the `keel-v<chart version>` GitHub release asset, and update the GitHub Pages Helm index. The validation job has `contents: read`; only chart-releaser receives `contents: write`. The workflow cannot run from `pull_request`.
 
 `chart/keel/Chart.yaml` is the release contract:
 
-- `appVersion` is the canonical application version and must exactly equal an application Git tag.
+- The SemVer application Git tag is the canonical application build version. `scripts/resolve-application-version.sh` uses it for application-tag builds, so an application release is not blocked by a chart that intentionally references an older application.
+- `appVersion` is the application version installed by the source chart. Before publishing that chart, it must exactly match an existing application GitHub Release and amd64/arm64 GHCR image.
 - `version` is the canonical source chart version; the trigger must be `chart-v${version}`. The shared packager and the chart release's temporary checkout add the historical leading `v` to packaged chart metadata and filenames.
 - `Dockerfile` receives the validated application version and Git revision as build arguments. Its fallback tag discovery remains available for ordinary developer builds.
 - The chart defaults its image tag to `appVersion`. Validation renders and inspects that exact wiring and packages with explicit `--version` and `--app-version` arguments.
 
-This makes tag, binary, container, and chart drift fail before publication. A chart release also refuses to run when its GitHub release or Helm index version already exists. An application image release refuses to overwrite an existing GHCR release tag. Branch tags such as `master` retain their existing mutable semantics.
+This makes tag, binary, container, and chart drift fail before publication without coupling the application release train to chart publication. A chart release also refuses to run when its GitHub release or Helm index version already exists. An application image release refuses to overwrite an existing GHCR release tag. Branch tags such as `master` retain their existing mutable semantics. Application and chart releases use global concurrency groups so two versions cannot race while updating `latest` or the Helm index.
 
 ## Local commands
 
@@ -42,9 +43,29 @@ make published-release-check
 For a tag rehearsal without publishing, set `GITHUB_REF` locally. These examples should pass only when metadata agrees:
 
 ```bash
-GITHUB_REF=refs/tags/0.21.1 make release-package
+GITHUB_REF=refs/tags/0.22.1 make release-package
 GITHUB_REF=refs/tags/chart-v1.2.0 KEEL_RELEASE_SKIP_IMAGE=true make release-package
 ```
+
+## Publishing sequence
+
+Prepare release metadata through a PR and run `make release-validate` whenever the chart changes. After the release commit is merged and its `master` CI succeeds, push only an annotated application tag:
+
+```bash
+git tag -a 0.22.1 -m "Keel 0.22.1" <release-commit>
+git push origin 0.22.1
+```
+
+Do not create the GitHub Release manually. The tag CI publishes and verifies the versioned GHCR image and `latest`, then creates the GitHub Release as its final job. Creating a GitHub Release first publishes user-visible metadata before the release artifacts have passed validation.
+
+To publish the chart after the application release is verified, push the chart tag from the same release commit:
+
+```bash
+git tag -a chart-v1.2.0 -m "Keel chart v1.2.0" <release-commit>
+git push origin chart-v1.2.0
+```
+
+Follow `.agents/skills/release-keel/SKILL.md` for the agent-operated readiness, publication, verification, and recovery workflow.
 
 ## Kubernetes coverage
 
@@ -63,7 +84,7 @@ CI first builds one release-equivalent image and chart package, then transfers t
 
 Failures retain `.test/artifacts/<run>/` locally and upload it in CI only on failure. The bundle includes Helm status/history/values/manifest, Kubernetes objects and events, Pod descriptions and current/previous logs, registry logs, k3s/containerd logs, rendered chart output, chart archive metadata/checksum, image inspection, and embedded version output. Expensive live-cluster diagnostics are collected only after a failure; successful runs proceed directly to bounded resource teardown. It deliberately excludes Secrets, kubeconfig contents, tokens, and environment dumps.
 
-The public release paths are not transactionally atomic. Application architecture digests become public before their manifest tag; chart-releaser creates a GitHub release asset and updates the Pages index in separate remote operations. On failure, do not retag or overwrite. Inspect the workflow logs and public state, leave orphaned content-addressed blobs alone, correct the source, and use a new version. A successful Helm rollback is:
+The public release paths are not transactionally atomic. Application architecture digests become public before their manifest tag, and the GitHub Release becomes public only after manifest verification. Chart-releaser creates a GitHub release asset and updates the Pages index in separate remote operations. On failure, do not retag or overwrite. Inspect the workflow logs and public state, leave orphaned content-addressed blobs alone, correct the source, and use a new version. A successful Helm rollback is:
 
 ```bash
 helm history keel --namespace <namespace>
@@ -85,4 +106,4 @@ The published `keelhq/keel:0.20.0` image used by chart `v1.0.5` reports an empty
 
 The chart supports repository and tag fields but has no native digest value; consequently, published chart defaults remain vulnerable if an external registry tag is moved. Candidate tests use a run-unique local tag and separately record the image inspection result. Adding digest-native chart wiring would be a compatibility-affecting chart feature and is left for a separately scoped change.
 
-The current application GitHub release creation step is manual and therefore cannot be proven or recovered by repository CI alone. The release jobs also cannot make GitHub Release, GHCR, and GitHub Pages publication atomic; the new preflight checks, dependency gates, immutable-version refusal, and diagnostics limit rather than eliminate that residual risk.
+The release jobs cannot make GitHub Release, GHCR, and GitHub Pages publication atomic. Ordered publication, global concurrency, preflight checks, dependency gates, immutable-version refusal, and diagnostics limit rather than eliminate that residual risk.

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -7,12 +7,19 @@ readonly REPO_ROOT
 ARTIFACT_DIR="${KEEL_RELEASE_ARTIFACT_DIR:-${REPO_ROOT}/.test/release-artifacts}"
 HELM_BIN="${HELM_BIN:-${ARTIFACT_DIR}/bin/helm}"
 CHART_DIR="${REPO_ROOT}/chart/keel"
-APP_VERSION="${KEEL_APP_VERSION:-$(awk '$1 == "appVersion:" {print $2; exit}' "${CHART_DIR}/Chart.yaml")}"
+APP_VERSION="$("${REPO_ROOT}/scripts/resolve-application-version.sh")"
 CHART_VERSION="${KEEL_CHART_VERSION:-$(awk '$1 == "version:" {print $2; exit}' "${CHART_DIR}/Chart.yaml")}"
 PACKAGED_CHART_VERSION="v${CHART_VERSION#v}"
 REVISION="${KEEL_BUILD_REVISION:-$(git -C "${REPO_ROOT}" rev-parse --short=12 HEAD)}"
 BUILD_EPOCH="${SOURCE_DATE_EPOCH:-$(git -C "${REPO_ROOT}" show -s --format=%ct HEAD)}"
-BUILD_DATE="$(date -u -d "@${BUILD_EPOCH}" +%Y-%m-%dT%H%M%SZ)"
+if BUILD_DATE="$(date -u -d "@${BUILD_EPOCH}" +%Y-%m-%dT%H%M%SZ 2>/dev/null)"; then
+  :
+elif BUILD_DATE="$(date -u -r "${BUILD_EPOCH}" +%Y-%m-%dT%H%M%SZ 2>/dev/null)"; then
+  :
+else
+  printf '[release-package] ERROR: could not convert build epoch: %s\n' "${BUILD_EPOCH}" >&2
+  exit 1
+fi
 IMAGE="${KEEL_RELEASE_IMAGE:-keel-release-validation:${APP_VERSION}-${REVISION}}"
 
 fail() { printf '[release-package] ERROR: %s\n' "$*" >&2; exit 1; }
@@ -49,7 +56,7 @@ if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
   fi
 fi
 
-if [[ ! -x "${HELM_BIN}" ]]; then
+if [[ ! -x "${HELM_BIN}" ]] || ! "${HELM_BIN}" version --short >/dev/null 2>&1; then
   "${REPO_ROOT}/.test/install-helm.sh" "${HELM_BIN}"
 fi
 

--- a/scripts/resolve-application-version.sh
+++ b/scripts/resolve-application-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT
+CHART_FILE="${REPO_ROOT}/chart/keel/Chart.yaml"
+
+if [[ -n "${KEEL_APP_VERSION:-}" ]]; then
+  app_version="${KEEL_APP_VERSION}"
+elif [[ "${GITHUB_REF:-}" == refs/tags/* && "${GITHUB_REF:-}" != refs/tags/chart-* ]]; then
+  app_version="${GITHUB_REF#refs/tags/}"
+else
+  app_version="$(awk '$1 == "appVersion:" {print $2; exit}' "${CHART_FILE}")"
+fi
+
+if [[ ! "${app_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
+  printf '[release-version] ERROR: invalid application version: %s\n' "${app_version}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${app_version}"


### PR DESCRIPTION
## What changed

- derive application-tag build versions from the SemVer tag instead of stale Helm metadata
- publish GitHub Releases only after the amd64/arm64 GHCR manifest is verified
- serialize application and chart publication across versions
- pass deterministic commit timestamps into release image builds
- prepare chart `1.2.0` with `appVersion: 0.22.1`
- make pinned Helm packaging work on Linux and macOS
- add and register the `release-keel` agent skill

## Root cause

Release `0.22.0` was made public while `Chart.yaml.appVersion` still contained `0.21.1`. The tag workflow correctly rejected the mismatch, but it did so after the public GitHub Release already existed. The old release habit and the new validation contract had incompatible ordering.

## Validation

- `make release-lint`
- `GITHUB_REF=refs/tags/0.22.1 make release-package`
- release image executed and reported exact version `0.22.1`
- Helm `v3.18.4` lint/render/package passed for chart `v1.2.0`
- skill creator `quick_validate.py .agents/skills/release-keel`
- `make release-validate` reached the native-k3s preflight but the macOS host lacks Linux `findmnt`; require this PR's Linux install/upgrade k3s jobs to pass before merge
