### PR TITLE
Clarify Harbor registry support and mutable-tag updates

### DIFF
--- a/chart/keel/README.md
+++ b/chart/keel/README.md
@@ -15,7 +15,7 @@ Keel provides several key features:
 
 * __Automatic [Google Container Registry](https://cloud.google.com/container-registry/) configuration__ - Keel automatically sets up topic and subscriptions for your deployment images by periodically scanning your environment.
 
-* __[Native, DockerHub and Quay webhooks](https://keel.sh/user-guide/triggers/#webhooks) support__ -  once webhook is received impacted deployments will be identified and updated.
+* __[Native, DockerHub, Harbor and Quay webhooks](https://keel.sh/user-guide/triggers/#webhooks) support__ -  once webhook is received impacted deployments will be identified and updated.
 
 *  __[Polling](https://keel.sh/user-guide/#polling-deployment-example)__ - when webhooks and pubsub aren't available - Keel can still be useful by checking Docker Registry for new tags (if current tag is semver) or same tag SHA digest change (ie: `latest`).
 

--- a/pkg/http/harbor_webhook_trigger.go
+++ b/pkg/http/harbor_webhook_trigger.go
@@ -125,6 +125,7 @@ func (s *TriggerServer) harborHandler(resp http.ResponseWriter, req *http.Reques
 			event.TriggerName = "harbor"
 			event.Repository.Name = imageRepo.Repository()
 			event.Repository.Tag = imageRepo.Tag()
+			event.Repository.Digest = e.Digest
 
 			log.WithFields(log.Fields{
 				"action":     hn.Type,

--- a/pkg/http/harbor_webhook_trigger_test.go
+++ b/pkg/http/harbor_webhook_trigger_test.go
@@ -17,15 +17,15 @@ var fakeHarborWebhook = ` {
             {
                 "digest": "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848",
                 "tag": "1.2.3",
-                "resource_url": "quay.io/mynamespace/repository:1.2.3"
+                "resource_url": "harbor.mydomain.com/library/ai-rag:1.2.3"
             }
         ],
         "repository": {
             "date_created": 1582634337,
-            "name": "repository",
-            "namespace": "mynamespace",
-            "repo_full_name": "mynamespace/repository",
-            "repo_type": "private"
+            "name": "ai-rag",
+            "namespace": "library",
+            "repo_full_name": "library/ai-rag",
+            "repo_type": "public"
         }
     }
 }
@@ -80,12 +80,16 @@ func TestHarborWebhookHandler(t *testing.T) {
 		t.Fatalf("unexpected number of events submitted: %d", len(fp.submitted))
 	}
 
-	if fp.submitted[0].Repository.Name != "quay.io/mynamespace/repository" {
-		t.Errorf("expected quay.io/mynamespace/repository but got %s", fp.submitted[0].Repository.Name)
+	if fp.submitted[0].Repository.Name != "harbor.mydomain.com/library/ai-rag" {
+		t.Errorf("expected harbor.mydomain.com/library/ai-rag but got %s", fp.submitted[0].Repository.Name)
 	}
 
 	if fp.submitted[0].Repository.Tag != "1.2.3" {
 		t.Errorf("expected 1.2.3 but got %s", fp.submitted[0].Repository.Tag)
+	}
+
+	if fp.submitted[0].Repository.Digest != "sha256:b4758aaed11c155a476b9857e1178f157759c99cb04c907a04993f5481eff848" {
+		t.Errorf("unexpected digest %s", fp.submitted[0].Repository.Digest)
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Keel provides several key features:
 
 * __Automatic [Google Container Registry](https://cloud.google.com/container-registry/) configuration__ - Keel automatically sets up topic and subscriptions for your deployment images by periodically scanning your environment.
 
-* __[Native, DockerHub, Quay and Azure container registry webhooks](https://keel.sh/docs/#triggers) support__ -  once webhook is received impacted deployments will be identified and updated.
+* __[Native, DockerHub, Harbor, Quay and Azure container registry webhooks](https://keel.sh/docs/#triggers) support__ -  once webhook is received impacted deployments will be identified and updated.
 
 *  __[Polling](https://keel.sh/docs/#polling)__ - when webhooks and pubsub aren't available - Keel can still be useful by checking Docker Registry for new tags (if current tag is semver) or same tag SHA digest change (ie: `latest`).
 
@@ -159,6 +159,44 @@ spec:
 ```
 
 No additional configuration is required. Enabling continuous delivery for your workloads has never been this easy!
+
+#### Harbor registries
+
+Harbor is supported through both polling and its native webhook. Harbor project
+names remain part of the repository path, so an image such as
+`harbor.example.com/library/ai-rag:latest` is polled at
+`/v2/library/ai-rag/...`. Public projects need no registry-specific
+configuration. For private projects, reference a Docker registry pull secret
+from the workload in the usual Kubernetes `imagePullSecrets` field or with the
+`keel.sh/imagePullSecret` annotation.
+
+Use a semantic-version policy such as `all`, `major`, `minor`, or `patch` when
+the image tag is versioned. A mutable tag such as `latest` must use the `force`
+policy with tag matching so polling compares its manifest digest:
+
+```yaml
+metadata:
+  annotations:
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/matchTag: "true"
+spec:
+  template:
+    spec:
+      containers:
+        - name: ai-rag
+          image: harbor.example.com/library/ai-rag:latest
+          imagePullPolicy: Always
+```
+
+`imagePullPolicy: Always` tells the kubelet how to pull after a rollout; it does
+not make Keel treat `latest` as a semantic version. With `keel.sh/policy: all`
+and a Harbor repository whose only tag is `latest`, an empty event list is
+expected because there is no newer semantic-version tag.
+
+For push-based updates, configure a Harbor project webhook with the default
+payload format and the `PUSH_ARTIFACT` event, targeting
+`POST /v1/webhooks/harbor` on the Keel service.
 
 #### Tracking OCI image volumes (Kubernetes 1.31+)
 

--- a/registry/docker/tags_test.go
+++ b/registry/docker/tags_test.go
@@ -1,8 +1,31 @@
 package docker
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func TestTagsSupportsHarborProjectPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/library/ai-rag/tags/list" {
+			t.Errorf("unexpected registry path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(tagsResponse{Tags: []string{"latest", "1.2.3"}})
+	}))
+	defer server.Close()
+
+	tags, err := New(server.URL, "", "").Tags("library/ai-rag")
+	if err != nil {
+		t.Fatalf("failed to get Harbor repository tags: %s", err)
+	}
+	if len(tags) != 2 || tags[0] != "latest" || tags[1] != "1.2.3" {
+		t.Fatalf("unexpected tags: %v", tags)
+	}
+}
 
 func TestGetDigestDockerHub(t *testing.T) {
 	client := New("https://index.docker.io", "", "")

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -774,6 +774,40 @@ func TestWatchWithAuthenticationError(t *testing.T) {
 	}
 }
 
+func TestWatchTagJobSupportsHarborProjectPath(t *testing.T) {
+	fp := &fakeProvider{}
+	store, teardown := newTestingUtils()
+	defer teardown()
+	providers := provider.New([]provider.Provider{fp}, approvals.New(&approvals.Opts{Store: store}))
+
+	ref, err := image.Parse("harbor.mydomain.com/library/ai-rag:latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	registryClient := &fakeRegistryClient{digestToReturn: "sha256:new"}
+	job := NewWatchTagJob(providers, registryClient, &watchDetails{
+		trackedImage: &types.TrackedImage{
+			Image:   ref,
+			Trigger: types.TriggerTypePoll,
+			Policy:  policy.NewForcePolicy(true),
+		},
+		digest: "sha256:old",
+	})
+
+	job.Run()
+
+	if registryClient.opts.Registry != "https://harbor.mydomain.com" || registryClient.opts.Name != "library/ai-rag" || registryClient.opts.Tag != "latest" {
+		t.Fatalf("unexpected Harbor registry options: %+v", registryClient.opts)
+	}
+	if len(fp.submitted) != 1 {
+		t.Fatalf("expected one digest update, got %d", len(fp.submitted))
+	}
+	event := fp.submitted[0]
+	if event.Repository.Name != "harbor.mydomain.com/library/ai-rag" || event.Repository.Tag != "latest" || event.Repository.Digest != "sha256:new" {
+		t.Fatalf("unexpected Harbor update event: %+v", event.Repository)
+	}
+}
+
 func TestWatchTagJobLatestECR(t *testing.T) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
 		t.Skip()


### PR DESCRIPTION
## Summary
Document that Keel supports Harbor through Docker Registry v2 polling and native Harbor webhooks. Explain that mutable tags such as `latest` require the `force` policy with tag matching, add regression coverage for Harbor project paths and digest polling, and preserve Harbor webhook digests in submitted events.

## Testing
`go test -count=1 ./...` passed.

LFG!