### PR TITLE
Add nightly pre-release workflow with unit tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,278 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Build even when master has no new commits since the last nightly
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check for New Commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+      nightly_date: ${{ steps.decide.outputs.nightly_date }}
+      dated_tag: ${{ steps.decide.outputs.dated_tag }}
+      app_version: ${{ steps.decide.outputs.app_version }}
+      build_date: ${{ steps.decide.outputs.build_date }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Decide whether a nightly build is needed
+        id: decide
+        env:
+          FORCE_BUILD: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
+        run: |
+          head_sha=$(git rev-parse HEAD)
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+          nightly_date=$(date -u +%Y%m%d)
+          echo "nightly_date=$nightly_date" >> "$GITHUB_OUTPUT"
+          echo "dated_tag=nightly-$nightly_date" >> "$GITHUB_OUTPUT"
+
+          epoch=$(git show -s --format=%ct "$head_sha")
+          echo "build_date=$(date -u -d "@$epoch" +%Y-%m-%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+          chart_version=$(./scripts/resolve-application-version.sh)
+          app_version="$chart_version-nightly.$nightly_date"
+          KEEL_APP_VERSION="$app_version" ./scripts/resolve-application-version.sh >/dev/null
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+
+          previous_sha=$(git rev-parse --verify --quiet refs/tags/nightly^{commit} || true)
+          if [[ "$FORCE_BUILD" == "true" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Forced nightly build of $head_sha" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ -z "$previous_sha" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "No previous nightly tag; building $head_sha" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$previous_sha" == "$head_sha" ]]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "No new commits since nightly ($previous_sha); skipping build" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "New commits since $previous_sha; building $head_sha" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  test:
+    name: Unit Tests
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.check.outputs.head_sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.5"
+
+      - name: Run tests
+        run: make test
+
+      - name: Check documented API operations
+        run: go test -v ./pkg/http -run TestOpenAPIContract
+
+  build:
+    name: Build and Publish Nightly Image (${{ matrix.arch }})
+    needs: [check, test]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.check.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.check.outputs.app_version }}
+            REVISION=${{ needs.check.outputs.head_sha }}
+            BUILD_DATE=${{ needs.check.outputs.build_date }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=keel-nightly-${{ matrix.arch }}
+            type=gha,scope=keel-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=keel-nightly-${{ matrix.arch }}
+
+      - name: Export image digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unexpected image digest: $IMAGE_DIGEST" >&2
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  manifest:
+    name: Publish Nightly Manifest
+    needs: [check, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: /tmp/digests
+          pattern: nightly-digest-*
+
+      - name: Create multi-architecture manifest
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          DATED_TAG: ${{ needs.check.outputs.dated_tag }}
+        run: |
+          mapfile -t digest_files < <(find /tmp/digests -mindepth 2 -maxdepth 2 -type f | sort)
+          digests=()
+          for digest_file in "${digest_files[@]}"; do
+            digests+=("$(basename "$digest_file")")
+          done
+          if [[ "${#digests[@]}" -ne 2 ]]; then
+            echo "Expected exactly two architecture digests, found ${#digests[@]}" >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in "${digests[@]}"; do
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Unexpected digest artifact name: $digest" >&2
+              exit 1
+            fi
+            sources+=("$IMAGE_NAME@sha256:$digest")
+          done
+
+          docker buildx imagetools create \
+            --tag "$IMAGE_NAME:nightly" \
+            --tag "$IMAGE_NAME:$DATED_TAG" \
+            "${sources[@]}"
+
+      - name: Verify published manifest
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          DATED_TAG: ${{ needs.check.outputs.dated_tag }}
+        run: |
+          expected_hash=""
+          for tag in "nightly" "$DATED_TAG"; do
+            manifest=$(docker buildx imagetools inspect "$IMAGE_NAME:$tag" --raw)
+            jq -e '
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64") and
+              any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")
+            ' <<< "$manifest" >/dev/null
+
+            manifest_hash=$(sha256sum <<< "$manifest" | cut -d " " -f 1)
+            if [[ -n "$expected_hash" && "$manifest_hash" != "$expected_hash" ]]; then
+              echo "Published nightly tags do not point to identical manifests" >&2
+              exit 1
+            fi
+            expected_hash="$manifest_hash"
+          done
+
+      - name: Move nightly git tags to the published commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+          DATED_TAG: ${{ needs.check.outputs.dated_tag }}
+        run: |
+          update_tag() {
+            local tag="$1"
+            local current
+            current=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" --jq .object.sha 2>/dev/null || true)
+            if [[ "$current" == "$HEAD_SHA" ]]; then
+              echo "Tag $tag already points at $HEAD_SHA"
+            elif [[ -z "$current" ]]; then
+              gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+                -f "ref=refs/tags/$tag" -f "sha=$HEAD_SHA" >/dev/null
+              echo "Created tag $tag at $HEAD_SHA"
+            else
+              gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/$tag" \
+                -f "sha=$HEAD_SHA" -F force=true >/dev/null
+              echo "Moved tag $tag from $current to $HEAD_SHA"
+            fi
+          }
+
+          update_tag nightly
+          update_tag "$DATED_TAG"
+
+      - name: Summarise published nightly
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          DATED_TAG: ${{ needs.check.outputs.dated_tag }}
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: |
+          {
+            echo "Published \`$IMAGE_NAME:nightly\` and \`$IMAGE_NAME:$DATED_TAG\`"
+            echo ""
+            echo "Commit: \`$HEAD_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,23 @@ resource "helm_release" "keel" {
 
 That's it, see [Configuration](https://github.com/keel-hq/keel#configuration) section now.
 
+### Nightly pre-release images
+
+To try out changes on `master` before they are part of a tagged release, use the
+nightly images. They are built every night from `master` (only when there are new
+commits), after the unit test suite passes, for both `linux/amd64` and
+`linux/arm64`:
+
+```bash
+helm upgrade --install keel --namespace=keel keel/keel \
+  --set image.repository="ghcr.io/keel-hq/keel" \
+  --set image.tag="nightly"
+```
+
+Two tags are published: the rolling `nightly` tag and a date-stamped
+`nightly-YYYYMMDD` tag if you want to pin a specific night's build. Nightly
+images are pre-releases — they are not supported for production use.
+
 ### Quick Start
 
 <p align="center">


### PR DESCRIPTION
## Summary
Implements keel-hq/keel#852: users currently have to build from source to try changes that have landed on `master` but are not yet part of a tagged release. This adds a `Nightly` GitHub Actions workflow that publishes multi-architecture pre-release images to GHCR.

New `.github/workflows/nightly.yml`, structured as four jobs that mirror the existing release path in `ci.yml`:

1. **check** — resolves `master`'s HEAD, computes the `nightly-YYYYMMDD` tag from the run date and a `<appVersion>-nightly.YYYYMMDD` build version validated through `scripts/resolve-application-version.sh`, then compares HEAD against the existing `nightly` git tag. Emits `should_build=false` when no new commits have landed, which skips the whole build. A `workflow_dispatch` `force` input overrides the check.
2. **test** — runs `make test` (which already excludes the cluster-dependent `/tests` suite) plus the OpenAPI contract test. Gates every downstream job.
3. **build** — builds `linux/amd64` on `ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm`, pushing by digest. Uses the GitHub Actions cache under a `keel-nightly-<arch>` scope, seeded from CI's `keel-<arch>` scope.
4. **manifest** — joins both digests into `ghcr.io/keel-hq/keel:nightly` and `:nightly-YYYYMMDD`, verifies both tags resolve to identical two-architecture manifests, then idempotently creates-or-moves both git tags via the GitHub API (no-op when already at HEAD, POST when the ref is absent, PATCH otherwise) so re-runs and same-day re-dispatches are safe.

Every job checks out the exact `head_sha` resolved by the `check` job, so a commit landing mid-run cannot make the tested tree and the published image diverge. The workflow runs at 03:00 UTC daily under a non-cancelling `nightly` concurrency group, with `contents: read` by default and write permissions narrowed to the jobs that need them.

`readme.md` gains a "Nightly pre-release images" section documenting the two tags, the Helm values to consume them, and that these are pre-releases not supported for production use.

## Testing
- `actionlint` (v1.7.7, the version pinned by `make release-lint`) runs clean across all workflows including the new one.
- `bash -n` on all eight `run:` scripts embedded in the workflow: no syntax errors.
- Exercised the `check` job's decision logic against the local repository through all four paths: no `nightly` tag → build, tag at HEAD → skip, tag at HEAD with `force=true` → build, tag behind HEAD → build. Each produced the expected `should_build` output.
- Confirmed the generated version string `0.22.1-nightly.20260814` is accepted by `scripts/resolve-application-version.sh`, so the nightly build args satisfy the repository's existing version validation.

Not run: `make release-validate`. `make` is not installed in this environment, and this change touches only CI configuration and the readme — neither application startup nor the Helm chart is affected.

LFG!