### PR TITLE
feat(notifications): report image digests in update notifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,7 +185,7 @@ Set via `keel.sh/approvals: "2"` annotation to require N approvals.
 | `keel.sh/notify` | Override notification channel | `#deployments` |
 | `keel.sh/matchTag` | Force tag matching | `true` |
 | `keel.sh/matchPreRelease` | Match pre-release versions | `true` |
-| `keel.sh/digest` | Track by digest (internal) | SHA256 digest |
+| `keel.sh/digest` | Track by digest (internal) | SHA256 digest of the image keel deployed last to the resource; update notifications report previous/new digests (visible e.g. as `latest (sha256:…) -> latest (sha256:…)`), preferring digests observed on running pods |
 | `keel.sh/imagePullSecret` | Registry credentials secret | `my-registry-secret` |
 | `keel.sh/releaseNotes` | Release notes URL | `https://...` |
 | `keel.sh/initContainers` | Track init containers | `true` |

--- a/provider/helm3/helm3.go
+++ b/provider/helm3/helm3.go
@@ -83,6 +83,12 @@ type UpdatePlan struct {
 	CurrentVersion string
 	// New version that's already in the deployment
 	NewVersion string
+	// Current digest of the image being replaced, known when the release
+	// workloads report one, empty otherwise
+	CurrentDigest string
+	// New digest taken from the event repository, empty when the trigger
+	// did not provide one
+	NewDigest string
 
 	// ReleaseNotes is a slice of combined release notes.
 	ReleaseNotes []string
@@ -321,6 +327,11 @@ func (p *Provider) createUpdatePlans(event *types.Event) ([]*UpdatePlan, error) 
 		}
 
 		if update {
+			// report the digest the release workloads are currently running
+			// so notifications can show the full image transition
+			if eventRepoRef, parseErr := image.Parse(event.Repository.String()); parseErr == nil {
+				plan.CurrentDigest = p.currentReleaseImageDigest(release.Namespace, release.Name, eventRepoRef.Repository(), plan.CurrentVersion)
+			}
 			if event.Repository.PlatformVerified {
 				ref, parseErr := image.Parse(event.Repository.String())
 				if parseErr != nil {
@@ -349,20 +360,19 @@ func (p *Provider) createUpdatePlans(event *types.Event) ([]*UpdatePlan, error) 
 func (p *Provider) applyPlans(plans []*UpdatePlan) error {
 	for _, plan := range plans {
 
+		currentVersion := formatVersionWithDigest(plan.CurrentVersion, plan.CurrentDigest)
+		newVersion := formatVersionWithDigest(plan.NewVersion, plan.NewDigest)
+
 		p.sender.Send(types.EventNotification{
 			ResourceKind: "chart",
 			Identifier:   fmt.Sprintf("%s/%s/%s", "chart", plan.Namespace, plan.Name),
 			Name:         "update release",
-			Message:      fmt.Sprintf("Preparing to update release %s/%s %s->%s (%s)", plan.Namespace, plan.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(mapToSlice(plan.Values), ", ")),
+			Message:      fmt.Sprintf("Preparing to update release %s/%s %s->%s (%s)", plan.Namespace, plan.Name, currentVersion, newVersion, strings.Join(mapToSlice(plan.Values), ", ")),
 			CreatedAt:    time.Now(),
 			Type:         types.NotificationPreReleaseUpdate,
 			Level:        types.LevelDebug,
 			Channels:     plan.Config.NotificationChannels,
-			Metadata: map[string]string{
-				"provider":  p.GetName(),
-				"namespace": plan.Namespace,
-				"name":      plan.Name,
-			},
+			Metadata:     releaseMetadata(plan, p.GetName()),
 		})
 
 		// err := updateHelmRelease(p.implementer, plan.Name, plan.Chart, plan.Values)
@@ -378,16 +388,12 @@ func (p *Provider) applyPlans(plans []*UpdatePlan) error {
 				ResourceKind: "chart",
 				Identifier:   fmt.Sprintf("%s/%s/%s", "chart", plan.Namespace, plan.Name),
 				Name:         "update release",
-				Message:      fmt.Sprintf("Release update failed %s/%s %s->%s (%s), error: %s", plan.Namespace, plan.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(mapToSlice(plan.Values), ", "), err),
+				Message:      fmt.Sprintf("Release update failed %s/%s %s->%s (%s), error: %s", plan.Namespace, plan.Name, currentVersion, newVersion, strings.Join(mapToSlice(plan.Values), ", "), err),
 				CreatedAt:    time.Now(),
 				Type:         types.NotificationReleaseUpdate,
 				Level:        types.LevelError,
 				Channels:     plan.Config.NotificationChannels,
-				Metadata: map[string]string{
-					"provider":  p.GetName(),
-					"namespace": plan.Namespace,
-					"name":      plan.Name,
-				},
+				Metadata:     releaseMetadata(plan, p.GetName()),
 			})
 			continue
 		}
@@ -403,9 +409,9 @@ func (p *Provider) applyPlans(plans []*UpdatePlan) error {
 
 		var msg string
 		if len(plan.ReleaseNotes) == 0 {
-			msg = fmt.Sprintf("Successfully updated release %s/%s %s->%s (%s)", plan.Namespace, plan.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(mapToSlice(plan.Values), ", "))
+			msg = fmt.Sprintf("Successfully updated release %s/%s %s->%s (%s)", plan.Namespace, plan.Name, currentVersion, newVersion, strings.Join(mapToSlice(plan.Values), ", "))
 		} else {
-			msg = fmt.Sprintf("Successfully updated release %s/%s %s->%s (%s). Release notes: %s", plan.Namespace, plan.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(mapToSlice(plan.Values), ", "), strings.Join(plan.ReleaseNotes, ", "))
+			msg = fmt.Sprintf("Successfully updated release %s/%s %s->%s (%s). Release notes: %s", plan.Namespace, plan.Name, currentVersion, newVersion, strings.Join(mapToSlice(plan.Values), ", "), strings.Join(plan.ReleaseNotes, ", "))
 		}
 
 		p.sender.Send(types.EventNotification{
@@ -417,11 +423,7 @@ func (p *Provider) applyPlans(plans []*UpdatePlan) error {
 			Type:         types.NotificationReleaseUpdate,
 			Level:        types.LevelSuccess,
 			Channels:     plan.Config.NotificationChannels,
-			Metadata: map[string]string{
-				"provider":  p.GetName(),
-				"namespace": plan.Namespace,
-				"name":      plan.Name,
-			},
+			Metadata:     releaseMetadata(plan, p.GetName()),
 		})
 
 	}
@@ -457,6 +459,33 @@ func mapToSlice(values map[string]string) []string {
 		converted = append(converted, concat)
 	}
 	return converted
+}
+
+// formatVersionWithDigest renders a version for notification messages,
+// appending the image digest when known. It makes tag updates that keep the
+// same tag (e.g. latest -> latest) identifiable by the image hash they move.
+func formatVersionWithDigest(version, digest string) string {
+	if digest == "" {
+		return version
+	}
+	return fmt.Sprintf("%s (%s)", version, digest)
+}
+
+// releaseMetadata builds notification metadata for a release update, carrying
+// the image digests alongside the identity fields when known.
+func releaseMetadata(plan *UpdatePlan, providerName string) map[string]string {
+	metadata := map[string]string{
+		"provider":  providerName,
+		"namespace": plan.Namespace,
+		"name":      plan.Name,
+	}
+	if plan.CurrentDigest != "" {
+		metadata["previousDigest"] = plan.CurrentDigest
+	}
+	if plan.NewDigest != "" {
+		metadata["newDigest"] = plan.NewDigest
+	}
+	return metadata
 }
 
 // parse

--- a/provider/helm3/running_digests.go
+++ b/provider/helm3/running_digests.go
@@ -12,7 +12,29 @@ import (
 // the mapping or the runtime information is unavailable, which callers treat as
 // "unknown" rather than "no drift".
 func (p *Provider) releaseImageRunningDigests(namespace, releaseName string, trackedImage *types.TrackedImage) []string {
-	if p.runningDigests == nil || p.resources == nil || trackedImage == nil || trackedImage.Image == nil {
+	if trackedImage == nil || trackedImage.Image == nil {
+		return nil
+	}
+	return p.workloadRunningDigests(namespace, releaseName, trackedImage.Image.Repository(), trackedImage.Image.Tag())
+}
+
+// currentReleaseImageDigest returns the single digest the release workloads
+// are running for the image identified by repository and tag, or an empty
+// string when none is observable.
+func (p *Provider) currentReleaseImageDigest(namespace, releaseName, repository, tag string) string {
+	digests := p.workloadRunningDigests(namespace, releaseName, repository, tag)
+	if len(digests) == 0 {
+		return ""
+	}
+	return digests[0]
+}
+
+// workloadRunningDigests returns the sorted, de-duplicated digests that the
+// Kubernetes workloads belonging to a release are running for an image
+// identified by repository and tag. It returns nil when the runtime
+// information is unavailable.
+func (p *Provider) workloadRunningDigests(namespace, releaseName, repository, tag string) []string {
+	if p.runningDigests == nil || p.resources == nil {
 		return nil
 	}
 
@@ -24,7 +46,7 @@ func (p *Provider) releaseImageRunningDigests(namespace, releaseName string, tra
 		}
 		for img, digests := range p.runningDigests.Resolve(resource) {
 			ref, err := image.Parse(img)
-			if err != nil || ref.Repository() != trackedImage.Image.Repository() || ref.Tag() != trackedImage.Image.Tag() {
+			if err != nil || ref.Repository() != repository || ref.Tag() != tag {
 				continue
 			}
 			for _, digest := range digests {

--- a/provider/helm3/updates.go
+++ b/provider/helm3/updates.go
@@ -107,6 +107,7 @@ func checkRelease(repo *types.Repository, namespace, name string, chart *hapi_ch
 		plan.Values[path] = value
 		plan.NewVersion = repo.Tag
 		plan.CurrentVersion = imageRef.Tag()
+		plan.NewDigest = repo.Digest
 		plan.Config = keelCfg
 		shouldUpdateRelease = true
 		if imageDetails.ReleaseNotes != "" {

--- a/provider/helm3/updates_digest_test.go
+++ b/provider/helm3/updates_digest_test.go
@@ -1,0 +1,158 @@
+package helm3
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+
+	core_v1 "k8s.io/api/core/v1"
+
+	"helm.sh/helm/v3/pkg/release"
+)
+
+// TestReleaseUpdateNotificationShowsImageDigests covers the latest -> latest
+// transition for a force policy: nothing changes in the tag, so the image
+// digests are what make the update identifiable in the notification.
+func TestReleaseUpdateNotificationShowsImageDigests(t *testing.T) {
+	oldDigest := "sha256:" + strings.Repeat("a", 64)
+	newDigest := "sha256:" + strings.Repeat("b", 64)
+
+	chartVals := `
+name: al Rashid
+where:
+  city: Basrah
+image:
+  repository: karolisr/webhook-demo
+  tag: latest
+
+keel:
+  policy: force
+  trigger: poll
+  images:
+    - repository: image.repository
+      tag: image.tag
+`
+	myChart, err := testingStringToChart(chartVals)
+	if err != nil {
+		t.Errorf("chartutil.ReadValues error = %v", err)
+	}
+
+	fakeImpl := &fakeImplementer{
+		listReleasesResponse: []*release.Release{
+			{
+				Name:      "release-1",
+				Namespace: "default",
+				Chart:     myChart,
+				Config:    make(map[string]interface{}),
+			},
+		},
+	}
+
+	approver, teardown := approver()
+	defer teardown()
+
+	// the release workload is still running the previous latest build
+	resources := &platformResourceCache{resources: []*k8s.GenericResource{
+		helmWorkloadWithSelector(t, "release-1", "owned", "karolisr/webhook-demo:latest"),
+	}}
+	pods := &helmPodSource{pods: map[string]*core_v1.PodList{
+		"app=owned": helmRunningPods("karolisr/webhook-demo:latest", "karolisr/webhook-demo@"+oldDigest),
+	}}
+
+	fs := &fakeSender{}
+	provider := NewProvider(fakeImpl, fs, approver,
+		WithWorkloadPlatforms(nil, resources),
+		WithRunningDigests(k8s.NewRunningDigestResolver(pods)),
+	)
+
+	err = provider.processEvent(&types.Event{
+		Repository: types.Repository{
+			Name:   "karolisr/webhook-demo",
+			Tag:    "latest",
+			Digest: newDigest,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to process event, error: %s", err)
+	}
+
+	if fakeImpl.updatedRlsName != "release-1" {
+		t.Fatalf("unexpected release updated: %s", fakeImpl.updatedRlsName)
+	}
+
+	expectedMessage := fmt.Sprintf(
+		"Successfully updated release default/release-1 latest (%s)->latest (%s) (image.tag=latest)",
+		oldDigest, newDigest,
+	)
+	if fs.sentEvent.Message != expectedMessage {
+		t.Errorf("expected message %q, got: %s", expectedMessage, fs.sentEvent.Message)
+	}
+	if fs.sentEvent.Level != types.LevelSuccess {
+		t.Errorf("expected level %s, got: %s", types.LevelSuccess, fs.sentEvent.Level)
+	}
+	if got := fs.sentEvent.Metadata["newDigest"]; got != newDigest {
+		t.Errorf("expected metadata newDigest %s, got: %s", newDigest, got)
+	}
+	if got := fs.sentEvent.Metadata["previousDigest"]; got != oldDigest {
+		t.Errorf("expected metadata previousDigest %s, got: %s", oldDigest, got)
+	}
+}
+
+// TestReleaseUpdateNotificationWithoutKnownDigests keeps the traditional
+// message shape when neither the event nor the runtime provide digests.
+func TestReleaseUpdateNotificationWithoutKnownDigests(t *testing.T) {
+	chartVals := `
+name: al Rashid
+where:
+  city: Basrah
+image:
+  repository: karolisr/webhook-demo
+  tag: latest
+
+keel:
+  policy: force
+  trigger: poll
+  images:
+    - repository: image.repository
+      tag: image.tag
+`
+	myChart, err := testingStringToChart(chartVals)
+	if err != nil {
+		t.Errorf("chartutil.ReadValues error = %v", err)
+	}
+
+	fakeImpl := &fakeImplementer{
+		listReleasesResponse: []*release.Release{
+			{
+				Name:      "release-1",
+				Namespace: "default",
+				Chart:     myChart,
+				Config:    make(map[string]interface{}),
+			},
+		},
+	}
+
+	approver, teardown := approver()
+	defer teardown()
+
+	fs := &fakeSender{}
+	provider := NewProvider(fakeImpl, fs, approver)
+
+	err = provider.processEvent(&types.Event{
+		Repository: types.Repository{
+			Name: "karolisr/webhook-demo",
+			Tag:  "latest",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to process event, error: %s", err)
+	}
+
+	expectedMessage := "Successfully updated release default/release-1 latest->latest (image.tag=latest)"
+	if fs.sentEvent.Message != expectedMessage {
+		t.Errorf("expected message %q, got: %s", expectedMessage, fs.sentEvent.Message)
+	}
+}

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -70,6 +70,12 @@ type UpdatePlan struct {
 	CurrentVersion string
 	// New version that's already in the deployment
 	NewVersion string
+	// Current digest of the image being replaced, known when observable
+	// (running pods or keel.sh/digest annotation), empty otherwise
+	CurrentDigest string
+	// New digest taken from the event repository, empty when the trigger
+	// did not provide one
+	NewDigest string
 }
 
 func (p *UpdatePlan) String() string {
@@ -77,6 +83,33 @@ func (p *UpdatePlan) String() string {
 		return fmt.Sprintf("%s %s->%s", p.Resource.Identifier, p.CurrentVersion, p.NewVersion)
 	}
 	return "empty plan"
+}
+
+// formatVersionWithDigest renders a version for notification messages,
+// appending the image digest when known. It makes tag updates that keep the
+// same tag (e.g. latest -> latest) identifiable by the image hash they move.
+func formatVersionWithDigest(version, digest string) string {
+	if digest == "" {
+		return version
+	}
+	return fmt.Sprintf("%s (%s)", version, digest)
+}
+
+// updateMetadata builds notification metadata for a resource update,
+// carrying the image digests alongside the identity fields when known.
+func updateMetadata(resource *k8s.GenericResource, plan *UpdatePlan, providerName string) map[string]string {
+	metadata := map[string]string{
+		"provider":  providerName,
+		"namespace": resource.GetNamespace(),
+		"name":      resource.GetName(),
+	}
+	if plan.CurrentDigest != "" {
+		metadata["previousDigest"] = plan.CurrentDigest
+	}
+	if plan.NewDigest != "" {
+		metadata["newDigest"] = plan.NewDigest
+	}
+	return metadata
 }
 
 // Provider - kubernetes provider for auto update
@@ -401,26 +434,33 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 			images = append(images, resource.GetImageVolumeReferences(GetMonitorVolumesFromMeta(labels, annotations))...)
 		}
 
+		currentVersion := formatVersionWithDigest(plan.CurrentVersion, plan.CurrentDigest)
+		newVersion := formatVersionWithDigest(plan.NewVersion, plan.NewDigest)
+
 		p.sender.Send(types.EventNotification{
 			ResourceKind: resource.Kind(),
 			Identifier:   resource.Identifier,
 			Name:         "preparing to update resource",
-			Message:      fmt.Sprintf("Preparing to update %s %s/%s %s->%s (%s)", resource.Kind(), resource.Namespace, resource.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(images, ", ")),
+			Message:      fmt.Sprintf("Preparing to update %s %s/%s %s->%s (%s)", resource.Kind(), resource.Namespace, resource.Name, currentVersion, newVersion, strings.Join(images, ", ")),
 			CreatedAt:    time.Now(),
 			Type:         types.NotificationPreDeploymentUpdate,
 			Level:        types.LevelDebug,
 			Channels:     notificationChannels,
-			Metadata: map[string]string{
-				"provider":  p.GetName(),
-				"namespace": resource.GetNamespace(),
-				"name":      resource.GetName(),
-			},
+			Metadata:     updateMetadata(resource, plan, p.GetName()),
 		})
 
 		var err error
 
 		timestamp := time.Now().Format(time.RFC3339)
-		annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update, version %s -> %s [%s]", plan.CurrentVersion, plan.NewVersion, timestamp)
+		annotations["kubernetes.io/change-cause"] = fmt.Sprintf("keel automated update, version %s -> %s [%s]", currentVersion, newVersion, timestamp)
+
+		// record the digest keel is deploying so the next update can report
+		// the previous image hash too (e.g. latest (x) -> latest (y))
+		if plan.NewDigest != "" {
+			annotations[types.KeelDigestAnnotation] = plan.NewDigest
+		} else {
+			delete(annotations, types.KeelDigestAnnotation)
+		}
 
 		resource.SetAnnotations(annotations)
 
@@ -432,23 +472,19 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 				"namespace":  resource.Namespace,
 				"deployment": resource.Name,
 				"kind":       resource.Kind(),
-				"update":     fmt.Sprintf("%s->%s", plan.CurrentVersion, plan.NewVersion),
+				"update":     fmt.Sprintf("%s->%s", currentVersion, newVersion),
 			}).Error("provider.kubernetes: got error while updating resource")
 
 			p.sender.Send(types.EventNotification{
 				Name:         "update resource",
 				ResourceKind: resource.Kind(),
 				Identifier:   resource.Identifier,
-				Message:      fmt.Sprintf("%s %s/%s update %s->%s failed, error: %s", resource.Kind(), resource.Namespace, resource.Name, plan.CurrentVersion, plan.NewVersion, err),
+				Message:      fmt.Sprintf("%s %s/%s update %s->%s failed, error: %s", resource.Kind(), resource.Namespace, resource.Name, currentVersion, newVersion, err),
 				CreatedAt:    time.Now(),
 				Type:         types.NotificationDeploymentUpdate,
 				Level:        types.LevelError,
 				Channels:     notificationChannels,
-				Metadata: map[string]string{
-					"provider":  p.GetName(),
-					"namespace": resource.GetNamespace(),
-					"name":      resource.GetName(),
-				},
+				Metadata:     updateMetadata(resource, plan, p.GetName()),
 			})
 
 			continue
@@ -467,9 +503,9 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 		var msg string
 		releaseNotes := types.ParseReleaseNotesURL(resource.GetAnnotations())
 		if releaseNotes != "" {
-			msg = fmt.Sprintf("Successfully updated %s %s/%s %s->%s (%s). Release notes: %s", resource.Kind(), resource.Namespace, resource.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(images, ", "), releaseNotes)
+			msg = fmt.Sprintf("Successfully updated %s %s/%s %s->%s (%s). Release notes: %s", resource.Kind(), resource.Namespace, resource.Name, currentVersion, newVersion, strings.Join(images, ", "), releaseNotes)
 		} else {
-			msg = fmt.Sprintf("Successfully updated %s %s/%s %s->%s (%s)", resource.Kind(), resource.Namespace, resource.Name, plan.CurrentVersion, plan.NewVersion, strings.Join(images, ", "))
+			msg = fmt.Sprintf("Successfully updated %s %s/%s %s->%s (%s)", resource.Kind(), resource.Namespace, resource.Name, currentVersion, newVersion, strings.Join(images, ", "))
 		}
 
 		err = p.sender.Send(types.EventNotification{
@@ -481,11 +517,7 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 			Type:         types.NotificationDeploymentUpdate,
 			Level:        types.LevelSuccess,
 			Channels:     notificationChannels,
-			Metadata: map[string]string{
-				"provider":  p.GetName(),
-				"namespace": resource.GetNamespace(),
-				"name":      resource.GetName(),
-			},
+			Metadata:     updateMetadata(resource, plan, p.GetName()),
 		})
 		if err != nil {
 			log.WithFields(log.Fields{
@@ -499,11 +531,13 @@ func (p *Provider) updateDeployments(plans []*UpdatePlan) (updated []*k8s.Generi
 		}
 
 		log.WithFields(log.Fields{
-			"name":      resource.Name,
-			"kind":      resource.Kind(),
-			"previous":  plan.CurrentVersion,
-			"new":       plan.NewVersion,
-			"namespace": resource.Namespace,
+			"name":           resource.Name,
+			"kind":           resource.Kind(),
+			"previous":       plan.CurrentVersion,
+			"new":            plan.NewVersion,
+			"previousDigest": plan.CurrentDigest,
+			"newDigest":      plan.NewDigest,
+			"namespace":      resource.Namespace,
 		}).Info("provider.kubernetes: resource updated")
 		updated = append(updated, resource)
 	}
@@ -573,6 +607,7 @@ func (p *Provider) createUpdatePlansForTrigger(repo *types.Repository, triggerNa
 		}
 
 		if shouldUpdateDeployment {
+			updated.CurrentDigest = p.currentDigest(resource, repo, updated)
 			if repo.PlatformVerified {
 				platforms, resolutionErr := p.platforms.Resolve(resource)
 				if resolutionErr != types.PlatformErrorNone || !types.PlatformsSupportAll(repo.Platforms, platforms) {
@@ -592,6 +627,44 @@ func (p *Provider) createUpdatePlansForTrigger(repo *types.Repository, triggerNa
 	}
 
 	return impacted, nil
+}
+
+// currentDigest determines the image digest the resource is currently
+// running for the image being replaced. It prefers the digest reported by
+// the running pods (per image reference, accurate for multi-container
+// resources) and falls back to the keel.sh/digest annotation, which records
+// the digest keel deployed last time. Empty string when neither is known.
+func (p *Provider) currentDigest(resource *k8s.GenericResource, repo *types.Repository, plan *UpdatePlan) string {
+	if digest := p.runningDigest(resource, repo, plan); digest != "" {
+		return digest
+	}
+	return resource.GetAnnotations()[types.KeelDigestAnnotation]
+}
+
+// runningDigest resolves the digest a workload is actually running for the
+// image being replaced (same repository, current tag).
+func (p *Provider) runningDigest(resource *k8s.GenericResource, repo *types.Repository, plan *UpdatePlan) string {
+	if p.runningDigests == nil || plan.CurrentVersion == "" {
+		return ""
+	}
+	running := p.runningDigests.Resolve(resource)
+	if len(running) == 0 {
+		return ""
+	}
+	repoRef, err := image.Parse(repo.String())
+	if err != nil {
+		return ""
+	}
+	for img, digests := range running {
+		ref, err := image.Parse(img)
+		if err != nil {
+			continue
+		}
+		if ref.Repository() == repoRef.Repository() && ref.Tag() == plan.CurrentVersion && len(digests) > 0 {
+			return digests[0]
+		}
+	}
+	return ""
 }
 
 func (p *Provider) namespaces() (*v1.NamespaceList, error) {

--- a/provider/kubernetes/updates.go
+++ b/provider/kubernetes/updates.go
@@ -96,6 +96,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 
 			updatePlan.CurrentVersion = volumeImageRef.Tag()
 			updatePlan.NewVersion = repo.Tag
+			updatePlan.NewDigest = repo.Digest
 			updatePlan.Resource = resource
 		}
 	}
@@ -162,6 +163,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 
 			updatePlan.CurrentVersion = containerImageRef.Tag()
 			updatePlan.NewVersion = repo.Tag
+			updatePlan.NewDigest = repo.Digest
 			updatePlan.Resource = resource
 		}
 	}
@@ -226,6 +228,7 @@ func checkForUpdate(plc policy.Policy, repo *types.Repository, resource *k8s.Gen
 
 		updatePlan.CurrentVersion = containerImageRef.Tag()
 		updatePlan.NewVersion = repo.Tag
+		updatePlan.NewDigest = repo.Digest
 		updatePlan.Resource = resource
 	}
 

--- a/provider/kubernetes/updates_digest_test.go
+++ b/provider/kubernetes/updates_digest_test.go
@@ -1,0 +1,290 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/keel-hq/keel/internal/k8s"
+	"github.com/keel-hq/keel/types"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// digests used by the latest -> latest notification tests
+var (
+	oldImageDigest = "sha256:" + strings.Repeat("a", 64)
+	newImageDigest = "sha256:" + strings.Repeat("b", 64)
+)
+
+func latestToLatestDeployment(annotations map[string]string) *apps_v1.Deployment {
+	return &apps_v1.Deployment{
+		meta_v1.TypeMeta{},
+		meta_v1.ObjectMeta{
+			Name:        "deployment-1",
+			Namespace:   "xxxx",
+			Labels:      map[string]string{types.KeelPolicyLabel: "force"},
+			Annotations: annotations,
+		},
+		apps_v1.DeploymentSpec{
+			Selector: &meta_v1.LabelSelector{MatchLabels: map[string]string{"app": "hello-world"}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{Labels: map[string]string{"app": "hello-world"}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "app", Image: "gcr.io/v2-namespace/hello-world:latest"},
+					},
+				},
+			},
+		},
+		apps_v1.DeploymentStatus{},
+	}
+}
+
+func latestToLatestPods(imageID string) *v1.PodList {
+	return &v1.PodList{
+		Items: []v1.Pod{
+			{
+				meta_v1.TypeMeta{},
+				meta_v1.ObjectMeta{Name: "deployment-1-pod", Namespace: "xxxx"},
+				v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "app", Image: "gcr.io/v2-namespace/hello-world:latest"},
+					},
+				},
+				v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:    "app",
+							ImageID: imageID,
+							State:   v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLatestToLatestUpdateNotificationShowsImageDigests(t *testing.T) {
+	fp := &fakeImplementer{
+		namespaces: &v1.NamespaceList{
+			Items: []v1.Namespace{
+				{
+					meta_v1.TypeMeta{},
+					meta_v1.ObjectMeta{Name: "xxxx"},
+					v1.NamespaceSpec{},
+					v1.NamespaceStatus{},
+				},
+			},
+		},
+		// workloads still report the digest of the previous latest push
+		podList: latestToLatestPods("docker-pullable://gcr.io/v2-namespace/hello-world@" + oldImageDigest),
+	}
+
+	deps := []*apps_v1.Deployment{latestToLatestDeployment(map[string]string{})}
+	grs := MustParseGRS(deps)
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	fs := &fakeSender{}
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, fs, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	event := &types.Event{
+		Repository: types.Repository{
+			Name:   "gcr.io/v2-namespace/hello-world",
+			Tag:    "latest",
+			Digest: newImageDigest,
+		},
+	}
+	_, err = provider.processEvent(event)
+	if err != nil {
+		t.Fatalf("got error while processing event: %s", err)
+	}
+
+	expectedMessage := fmt.Sprintf(
+		"Successfully updated deployment xxxx/deployment-1 latest (%s)->latest (%s) (gcr.io/v2-namespace/hello-world:latest)",
+		oldImageDigest, newImageDigest,
+	)
+	if fs.sentEvent.Message != expectedMessage {
+		t.Errorf("expected message %q, got: %s", expectedMessage, fs.sentEvent.Message)
+	}
+	if fs.sentEvent.Level != types.LevelSuccess {
+		t.Errorf("expected level %s, got: %s", types.LevelSuccess, fs.sentEvent.Level)
+	}
+	if got := fs.sentEvent.Metadata["newDigest"]; got != newImageDigest {
+		t.Errorf("expected metadata newDigest %s, got: %s", newImageDigest, got)
+	}
+	if got := fs.sentEvent.Metadata["previousDigest"]; got != oldImageDigest {
+		t.Errorf("expected metadata previousDigest %s, got: %s", oldImageDigest, got)
+	}
+
+	// the digest keel deployed is recorded so the next update can report it
+	if got := fp.updated.GetAnnotations()[types.KeelDigestAnnotation]; got != newImageDigest {
+		t.Errorf("expected %s annotation %s, got: %s", types.KeelDigestAnnotation, newImageDigest, got)
+	}
+	changeCause := fp.updated.GetAnnotations()["kubernetes.io/change-cause"]
+	if !strings.Contains(changeCause, fmt.Sprintf("latest (%s) -> latest (%s)", oldImageDigest, newImageDigest)) {
+		t.Errorf("expected change-cause to contain the digest transition, got: %s", changeCause)
+	}
+}
+
+func TestLatestToLatestUpdateNotificationFallsBackToDigestAnnotation(t *testing.T) {
+	fp := &fakeImplementer{
+		namespaces: &v1.NamespaceList{
+			Items: []v1.Namespace{
+				{
+					meta_v1.TypeMeta{},
+					meta_v1.ObjectMeta{Name: "xxxx"},
+					v1.NamespaceSpec{},
+					v1.NamespaceStatus{},
+				},
+			},
+		},
+		// no pods to observe, the previous digest comes from the annotation
+	}
+
+	deps := []*apps_v1.Deployment{
+		latestToLatestDeployment(map[string]string{types.KeelDigestAnnotation: oldImageDigest}),
+	}
+	grs := MustParseGRS(deps)
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	fs := &fakeSender{}
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, fs, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	event := &types.Event{
+		Repository: types.Repository{
+			Name:   "gcr.io/v2-namespace/hello-world",
+			Tag:    "latest",
+			Digest: newImageDigest,
+		},
+	}
+	_, err = provider.processEvent(event)
+	if err != nil {
+		t.Fatalf("got error while processing event: %s", err)
+	}
+
+	expectedMessage := fmt.Sprintf(
+		"Successfully updated deployment xxxx/deployment-1 latest (%s)->latest (%s) (gcr.io/v2-namespace/hello-world:latest)",
+		oldImageDigest, newImageDigest,
+	)
+	if fs.sentEvent.Message != expectedMessage {
+		t.Errorf("expected message %q, got: %s", expectedMessage, fs.sentEvent.Message)
+	}
+	if got := fp.updated.GetAnnotations()[types.KeelDigestAnnotation]; got != newImageDigest {
+		t.Errorf("expected %s annotation %s, got: %s", types.KeelDigestAnnotation, newImageDigest, got)
+	}
+}
+
+func TestCurrentDigestPrefersRunningDigestOverAnnotation(t *testing.T) {
+	fp := &fakeImplementer{
+		namespaces: &v1.NamespaceList{
+			Items: []v1.Namespace{
+				{
+					meta_v1.TypeMeta{},
+					meta_v1.ObjectMeta{Name: "xxxx"},
+					v1.NamespaceSpec{},
+					v1.NamespaceStatus{},
+				},
+			},
+		},
+		podList: latestToLatestPods("gcr.io/v2-namespace/hello-world@" + oldImageDigest),
+	}
+
+	staleAnnotationDigest := "sha256:" + strings.Repeat("c", 64)
+	deps := []*apps_v1.Deployment{
+		latestToLatestDeployment(map[string]string{types.KeelDigestAnnotation: staleAnnotationDigest}),
+	}
+	grs := MustParseGRS(deps)
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, &fakeSender{}, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	repo := &types.Repository{
+		Name:   "gcr.io/v2-namespace/hello-world",
+		Tag:    "latest",
+		Digest: newImageDigest,
+	}
+	plans, err := provider.createUpdatePlans(repo)
+	if err != nil {
+		t.Fatalf("got error while creating update plans: %s", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 update plan, got %d", len(plans))
+	}
+	if plans[0].CurrentDigest != oldImageDigest {
+		t.Errorf("expected current digest from running pods %s, got: %s", oldImageDigest, plans[0].CurrentDigest)
+	}
+	if plans[0].NewDigest != newImageDigest {
+		t.Errorf("expected new digest %s, got: %s", newImageDigest, plans[0].NewDigest)
+	}
+}
+
+func TestLatestToLatestUpdateNotificationWithoutKnownDigests(t *testing.T) {
+	fp := &fakeImplementer{
+		namespaces: &v1.NamespaceList{
+			Items: []v1.Namespace{
+				{
+					meta_v1.TypeMeta{},
+					meta_v1.ObjectMeta{Name: "xxxx"},
+					v1.NamespaceSpec{},
+					v1.NamespaceStatus{},
+				},
+			},
+		},
+	}
+
+	deps := []*apps_v1.Deployment{latestToLatestDeployment(map[string]string{})}
+	grs := MustParseGRS(deps)
+	grc := &k8s.GenericResourceCache{}
+	grc.Add(grs...)
+
+	fs := &fakeSender{}
+	approver, teardown := approver()
+	defer teardown()
+	provider, err := NewProvider(fp, fs, approver, grc)
+	if err != nil {
+		t.Fatalf("failed to get provider: %s", err)
+	}
+
+	// triggers such as some webhooks do not provide the image digest
+	event := &types.Event{
+		Repository: types.Repository{
+			Name: "gcr.io/v2-namespace/hello-world",
+			Tag:  "latest",
+		},
+	}
+	_, err = provider.processEvent(event)
+	if err != nil {
+		t.Fatalf("got error while processing event: %s", err)
+	}
+
+	// without any digest information the message keeps its traditional shape
+	expectedMessage := "Successfully updated deployment xxxx/deployment-1 latest->latest (gcr.io/v2-namespace/hello-world:latest)"
+	if fs.sentEvent.Message != expectedMessage {
+		t.Errorf("expected message %q, got: %s", expectedMessage, fs.sentEvent.Message)
+	}
+	if fp.updated.GetAnnotations()[types.KeelDigestAnnotation] != "" {
+		t.Errorf("expected no %s annotation to be recorded without a digest", types.KeelDigestAnnotation)
+	}
+}


### PR DESCRIPTION
## Summary
`latest -> latest` upgrades (poll trigger with `force`/`matchTag` policy) already work — `WatchTagJob` detects the digest change on the same tag and submits an event carrying the new digest — but the notifications were useless in that case: they rendered `Successfully updated deployment xxxx/deployment-1 latest->latest (gcr.io/image:latest)` with no way to see what actually changed. The new digest from the event was dropped before reaching the notification layer, and the previous digest was never tracked.

This change makes update notifications report the image hashes:

- All three notification messages (preparing, success, failure) for both the `kubernetes` and `helm3` providers now show the digest transition, e.g. `Successfully updated deployment xxxx/deployment-1 latest (sha256:old…)->latest (sha256:new…) (gcr.io/…)`.
- The **new digest** comes from the event's repository: the poll trigger always resolves it, and the GCR pubsub, ACR, Harbor, and GitHub Container Registry webhooks also provide it.
- The **previous digest** is resolved from the workloads' running pods (matched per image reference), falling back to the `keel.sh/digest` annotation, which was previously defined but unused and now records the digest keel last deployed.
- Notifications gain structured metadata (`previousDigest`, `newDigest`) for webhook/audit consumers, and the `kubernetes.io/change-cause` annotation also includes the digest transition.
- Backward compatible: when no digest is known (e.g. no running pods, tag-based updates with no event digest), the traditional message shape is preserved.
- `ARCHITECTURE.md` documents the new `keel.sh/digest` annotation behavior.

## Testing
- `gofmt` clean on all changed files; `go build ./...` passes.
- Full unit test suite: all 31 packages pass, including 7 new digest tests covering running-pod resolution, annotation fallback, resolution preference order, the no-digest legacy message shape, and the helm3 release variants.
- Full k3s e2e suite (`make e2e`): Keel deployed from the source-built image with this change; all 5 scenarios pass (polling eligible/ineligible, webhook eligible, init-container isolation, OAuth proxy). The change touches no startup or chart code.

LFG!