### PR TITLE
fix(poll): force policy must not downgrade to older tags (fixes #823)

### DIFF
--- a/.test/e2e-k3s.sh
+++ b/.test/e2e-k3s.sh
@@ -547,7 +547,10 @@ seed_fixture_repositories() {
     "${RUN_ID}/negative:1.0.0" "${RUN_ID}/negative:1.1.0" \
     "${RUN_ID}/webhook-regression:main_0000000000000000000000000000000000000000" \
     "${RUN_ID}/webhook-regression:main_1111111111111111111111111111111111111111" \
-    "${RUN_ID}/webhook-regression:main_ffffffffffffffffffffffffffffffffffffffff"; do
+    "${RUN_ID}/webhook-regression:main_ffffffffffffffffffffffffffffffffffffffff" \
+    "${RUN_ID}/force-latest:1.0.0" "${RUN_ID}/force-latest:1.0.1" "${RUN_ID}/force-latest:1.0.2" \
+    "${RUN_ID}/force-nodowngrade:1.0.0" "${RUN_ID}/force-nodowngrade:1.0.1" \
+    "${RUN_ID}/force-prerelease:3.0.0" "${RUN_ID}/force-prerelease:5.0.0" "${RUN_ID}/force-prerelease:7.9.1-1-ubi8"; do
     ctr images tag "${FIXTURE_IMAGE}" "${REGISTRY_ADDRESS}/${destination}"
     ctr images push --plain-http "${REGISTRY_ADDRESS}/${destination}"
   done

--- a/internal/policy/force.go
+++ b/internal/policy/force.go
@@ -1,6 +1,11 @@
 package policy
 
-import "github.com/keel-hq/keel/types"
+import (
+	"sort"
+
+	"github.com/Masterminds/semver"
+	"github.com/keel-hq/keel/types"
+)
 
 type ForcePolicy struct {
 	matchTag bool
@@ -12,16 +17,53 @@ func NewForcePolicy(matchTag bool) *ForcePolicy {
 	}
 }
 
+// ShouldUpdate - the force policy accepts non-version tags (e.g. "latest")
+// for which no ordering exists, but it must never downgrade a versioned
+// image: when both tags parse as semantic versions the new tag has to be
+// strictly newer. A re-push of the current tag (same tag, new digest) is
+// still an update.
 func (fp *ForcePolicy) ShouldUpdate(current, new string) (bool, error) {
 	if fp.matchTag && current != new {
 		return false, nil
 	}
+
+	if current != new {
+		currentVersion, currentErr := semver.NewVersion(current)
+		newVersion, newErr := semver.NewVersion(new)
+		if currentErr == nil && newErr == nil {
+			return newVersion.GreaterThan(currentVersion), nil
+		}
+	}
+
 	return true, nil
 }
 
+// Filter - orders the candidate tags so the newest one is tried first, like
+// the other policies do: semantic-version tags are sorted in descending
+// order, non-version tags (e.g. "latest") have no ordering so they keep
+// their relative order and trail the versioned tags. Registries return tag
+// lists in creation order (oldest first), so leaving the list unsorted
+// would make the oldest tag in the repository win
+// (https://github.com/keel-hq/keel/issues/823).
 func (fp *ForcePolicy) Filter(tags []string) []string {
-	// todo: why is this not sorting?
-	return append([]string{}, tags...)
+	var versions []*semver.Version
+	var others []string
+
+	for _, tag := range tags {
+		if v, err := semver.NewVersion(tag); err == nil {
+			versions = append(versions, v)
+		} else {
+			others = append(others, tag)
+		}
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(versions)))
+
+	filtered := make([]string, 0, len(tags))
+	for _, v := range versions {
+		filtered = append(filtered, v.Original())
+	}
+	return append(filtered, others...)
 }
 
 func (fp *ForcePolicy) Name() string {

--- a/internal/policy/force_test.go
+++ b/internal/policy/force_test.go
@@ -1,0 +1,171 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestForcePolicyShouldUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		matchTag   bool
+		current    string
+		new        string
+		wantUpdate bool
+	}{
+		{
+			name:       "force, same tag is an update (mutable tag re-push)",
+			matchTag:   false,
+			current:    "latest",
+			new:        "latest",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, non semver tags have no ordering",
+			matchTag:   false,
+			current:    "latest",
+			new:        "main",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, non semver current, semver new",
+			matchTag:   false,
+			current:    "latest",
+			new:        "1.2.3",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, semver new is higher",
+			matchTag:   false,
+			current:    "7.9.1-1-ubi8",
+			new:        "8.0.0",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, semver new is lower, issue 823 cp-kafka 7.9.1-1-ubi8 -> 3.0.0",
+			matchTag:   false,
+			current:    "7.9.1-1-ubi8",
+			new:        "3.0.0",
+			wantUpdate: false,
+		},
+		{
+			name:       "force, semver new is lower, issue 823 8.1.0 -> 8.0.0",
+			matchTag:   false,
+			current:    "8.1.0",
+			new:        "8.0.0",
+			wantUpdate: false,
+		},
+		{
+			name:       "force, same semver tag re-push is an update",
+			matchTag:   false,
+			current:    "8.1.0",
+			new:        "8.1.0",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, patch bump",
+			matchTag:   false,
+			current:    "1.4.5",
+			new:        "1.4.6",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, same semver with different prerelease is lower",
+			matchTag:   false,
+			current:    "1.2.3-4",
+			new:        "1.2.3-3",
+			wantUpdate: false,
+		},
+		{
+			name:       "force, same semver with different prerelease is higher",
+			matchTag:   false,
+			current:    "1.2.3-3",
+			new:        "1.2.3-4",
+			wantUpdate: true,
+		},
+		{
+			name:       "force, prerelease to release is higher",
+			matchTag:   false,
+			current:    "7.9.1-1-ubi8",
+			new:        "7.9.1",
+			wantUpdate: true,
+		},
+		{
+			name:       "force tag match, same tag is an update",
+			matchTag:   true,
+			current:    "latest",
+			new:        "latest",
+			wantUpdate: true,
+		},
+		{
+			name:       "force tag match, different tag is not an update",
+			matchTag:   true,
+			current:    "latest",
+			new:        "main",
+			wantUpdate: false,
+		},
+		{
+			name:       "force tag match, different higher semver tag is not an update",
+			matchTag:   true,
+			current:    "1.2.3",
+			new:        "1.2.4",
+			wantUpdate: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := NewForcePolicy(tt.matchTag)
+			got, err := fp.ShouldUpdate(tt.current, tt.new)
+			if err != nil {
+				t.Errorf("ShouldUpdate() unexpected error = %v", err)
+				return
+			}
+			if got != tt.wantUpdate {
+				t.Errorf("ShouldUpdate(%q, %q) = %v, want %v", tt.current, tt.new, got, tt.wantUpdate)
+			}
+		})
+	}
+}
+
+func TestForcePolicyFilter(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want []string
+	}{
+		{
+			name: "mixed tags, semver descending first, registry order otherwise (issue 823)",
+			tags: []string{"3.0.0", "3.0.1", "7.9.1-1-ubi8", "8.0.0", "latest", "8.3.1"},
+			want: []string{"8.3.1", "8.0.0", "7.9.1-1-ubi8", "3.0.1", "3.0.0", "latest"},
+		},
+		{
+			name: "non semver tags keep their relative order",
+			tags: []string{"latest", "main", "beta"},
+			want: []string{"latest", "main", "beta"},
+		},
+		{
+			name: "semver tags only, descending",
+			tags: []string{"1.3", "2.5", "2.7", "3.8"},
+			want: []string{"3.8", "2.7", "2.5", "1.3"},
+		},
+		{
+			name: "v prefix is preserved",
+			tags: []string{"v1.0.0", "v1.2.0", "v1.1.0"},
+			want: []string{"v1.2.0", "v1.1.0", "v1.0.0"},
+		},
+		{
+			name: "empty tags",
+			tags: []string{},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := NewForcePolicy(false)
+			got := fp.Filter(tt.tags)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/e2e_scenarios_test.go
+++ b/tests/e2e_scenarios_test.go
@@ -82,6 +82,47 @@ func (s *E2ESuite) TestPollingRejectsIneligibleImage() {
 	s.Require().NoError(ensureDeploymentImageUnchanged(ctx, s.client, s.testNamespace, "negative", current))
 }
 
+// https://github.com/keel-hq/keel/issues/823: with the force policy, the poll
+// trigger must converge on the newest available tag instead of picking the
+// first tag in the registry tag list.
+func (s *E2ESuite) TestPollingForcePolicyUpdatesToNewestTag() {
+	s.requireRegistryTags("force-latest", "1.0.0", "1.0.1", "1.0.2")
+	repository := s.cfg.repositoryPrefix + "/force-latest"
+	s.createWorkload("force-latest", repository+":1.0.0", "force", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	s.Require().NoError(waitForDeploymentImage(ctx, s.client, s.testNamespace, "force-latest", repository+":1.0.2"))
+}
+
+// https://github.com/keel-hq/keel/issues/823 (8.1.0 -> 8.0.0 report): the
+// force policy must never update a workload to an older semantic version.
+func (s *E2ESuite) TestPollingForcePolicyDoesNotDowngrade() {
+	s.requireRegistryTags("force-nodowngrade", "1.0.0", "1.0.1")
+	repository := s.cfg.repositoryPrefix + "/force-nodowngrade"
+	current := repository + ":1.0.1"
+	s.createWorkload("force-nodowngrade", current, "force", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	s.Require().NoError(ensureDeploymentImageUnchanged(ctx, s.client, s.testNamespace, "force-nodowngrade", current))
+}
+
+// https://github.com/keel-hq/keel/issues/823 (original report): a workload on
+// cp-kafka:7.9.1-1-ubi8 was "updated" to cp-kafka:3.0.0 because the oldest
+// tag in the registry list won. With no newer tag available the image must
+// remain untouched.
+func (s *E2ESuite) TestPollingForcePolicyIgnoresOlderTagsForPrereleaseCurrent() {
+	s.requireRegistryTags("force-prerelease", "3.0.0", "5.0.0", "7.9.1-1-ubi8")
+	repository := s.cfg.repositoryPrefix + "/force-prerelease"
+	current := repository + ":7.9.1-1-ubi8"
+	s.createWorkload("force-prerelease", current, "force", true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	s.Require().NoError(ensureDeploymentImageUnchanged(ctx, s.client, s.testNamespace, "force-prerelease", current))
+}
+
 func (s *E2ESuite) TestWebhookStatefulSetInitContainerRemainsIsolatedFromPolling() {
 	const (
 		initialTag = "main_0000000000000000000000000000000000000000"

--- a/trigger/poll/multi_tags_watcher_test.go
+++ b/trigger/poll/multi_tags_watcher_test.go
@@ -115,15 +115,15 @@ func testRunHelper(testCases []runTestCase, availableTags []string, t *testing.T
 		}
 		t.Errorf("expected "+strconv.Itoa(nbEvents)+" events, got: %d [%s]", len(fp.submitted), strings.Join(tags, ", "))
 	} else {
-		for i, testCase := range testCases {
+		for i := 0; i < len(fp.submitted); i++ {
 			submitted := fp.submitted[i]
 
 			if submitted.Repository.Name != "index.docker.io/foo/bar" {
 				t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
 			}
 
-			if submitted.Repository.Tag != testCase.expectedTag {
-				t.Errorf("expected event repository tag "+testCase.expectedTag+", but got: %s", submitted.Repository.Tag)
+			if submitted.Repository.Tag != testCases[i].expectedTag {
+				t.Errorf("expected event repository tag "+testCases[i].expectedTag+", but got: %s", submitted.Repository.Tag)
 			}
 		}
 	}
@@ -217,6 +217,27 @@ func TestWatchAllTagsMixedPolicyAll(t *testing.T) {
 		{"1.0.0", "1.5.0", policy.NewSemverPolicy(policy.SemverPolicyTypeMajor, true)},
 		{"1.6.0-alpha", "1.8.0-alpha", policy.NewSemverPolicy(policy.SemverPolicyTypeAll, true)}}
 	testRunHelper(testCases, availableTags, t)
+}
+
+// Regression test for https://github.com/keel-hq/keel/issues/823: with the
+// force policy, the tag list returned by the registry is in creation order
+// (oldest first), not version order. The oldest tag in the repository must
+// not win: keel has to pick the newest tag that is newer than the current
+// one, and must not downgrade when no newer tag exists.
+func TestWatchAllTagsJobWithForcePolicy(t *testing.T) {
+	availableTags := []string{"3.0.0", "3.0.1", "5.0.0", "7.9.1-1-ubi8", "8.0.0", "8.3.1", "latest"}
+
+	// cp-kafka style: current 7.9.1-1-ubi8 must update to 8.3.1, not 3.0.0
+	testRunHelper([]runTestCase{{"7.9.1-1-ubi8", "8.3.1", policy.NewForcePolicy(false)}}, availableTags, t)
+
+	// already at the newest tag: no event
+	testRunHelper([]runTestCase{{"8.3.1", "8.3.1", policy.NewForcePolicy(false)}}, availableTags, t)
+
+	// 8.1.0 -> 8.0.0 style downgrade must not happen
+	testRunHelper([]runTestCase{{"8.1.0", "8.2.0", policy.NewForcePolicy(false)}}, []string{"8.0.0", "8.1.0", "8.2.0"}, t)
+
+	// no newer tag available: no event, even though older tags exist
+	testRunHelper([]runTestCase{{"7.9.1-1-ubi8", "7.9.1-1-ubi8", policy.NewForcePolicy(false)}}, []string{"3.0.0", "5.0.0"}, t)
 }
 
 type testingCredsHelper struct {


### PR DESCRIPTION
## Summary
With `keel.sh/policy: force` (without `keel.sh/matchTag: "true"`), the poll trigger's tag watcher picked the first tag in the registry tag list that was not the current tag. Registries return tag lists in creation order (oldest first), `ForcePolicy.Filter` did not sort them, and `ForcePolicy.ShouldUpdate` accepted every tag without any version comparison, so the oldest tag in the repository won: `cp-kafka:7.9.1-1-ubi8` was "updated" to `cp-kafka:3.0.0` (issue #823) and, more recently, `8.1.0` to `8.0.0`.

Changes:
- `ForcePolicy.ShouldUpdate`: when both tags parse as semantic versions, only update to a strictly newer tag (a re-push of the same tag is still an update; non-semver tags keep the previous behavior, since `force` exists for tags like `latest`).
- `ForcePolicy.Filter`: order candidates newest first, like the other policies do — semver tags descending, non-semver tags keeping their relative order and trailing the versioned tags — so the watcher picks the latest available tag in one hop.
- Regression tests for the policy (`internal/policy/force_test.go`) and the tag watcher (`TestWatchAllTagsJobWithForcePolicy`, covering the cp-kafka and 8.1.0→8.0.0 scenarios plus the no-newer-tag case); fix a latent panic in the `testRunHelper` fixture when zero events are expected.
- Behavioral e2e coverage for the k3s suite (`tests/e2e_scenarios_test.go`, seeded by `.test/e2e-k3s.sh`): `force-latest` (workload on `1.0.0` converges on the newest tag `1.0.2`), `force-nodowngrade` (workload on `1.0.1` with an older `1.0.0` tag stays put, the 8.1.0→8.0.0 report), and `force-prerelease` (workload on `7.9.1-1-ubi8` with only older tags stays put, the original cp-kafka report).

## Testing
- `go build ./...` and full `go test ./...`: all 32 packages pass; `go vet` and `gofmt` clean.
- Verified the real `confluentinc/cp-kafka` registry tag ordering via `/v2/confluentinc/cp-kafka/tags/list` (`3.0.0` is tag #0 of 1519; `7.9.1-1-ubi8` is #1336) and confirmed the fixed selection: current `7.9.1-1-ubi8` → `8.3.1` (never `3.0.0`); current `8.1.0` → `8.2.0` (never `8.0.0`); only older tags available → no event emitted.
- `make e2e` (task-owned k3s v1.35.6 + in-cluster registry, the same harness CI runs): full suite passes, including the three new force-policy scenarios `TestPollingForcePolicyUpdatesToNewestTag`, `TestPollingForcePolicyDoesNotDowngrade`, and `TestPollingForcePolicyIgnoresOlderTagsForPrereleaseCurrent`, alongside all pre-existing webhook/polling/OAuth scenarios (438s total, under the 15m CI timeout).
- `make release-validate` packaged-release scenario is not applicable: the change is version-comparison and test-harness logic, not application startup or the Helm chart, which is the condition AGENTS.md uses to require that validation.

LFG!