### PR TITLE
fix(kubernetes): retry conflict on workload updates (fixes #818)

### DIFF
--- a/provider/kubernetes/implementer.go
+++ b/provider/kubernetes/implementer.go
@@ -37,7 +37,7 @@ type Implementer interface {
 // https://github.com/kubernetes/client-go v3.0.0-beta.0
 type KubernetesImplementer struct {
 	cfg    *rest.Config
-	client *kubernetes.Clientset
+	client kubernetes.Interface
 }
 
 // Opts - implementer options, usually for k8s deployments
@@ -95,8 +95,9 @@ func NewKubernetesImplementer(opts *Opts) (*KubernetesImplementer, error) {
 	return &KubernetesImplementer{client: client, cfg: cfg}, nil
 }
 
+// Client returns the underlying kubernetes clientset.
 func (i *KubernetesImplementer) Client() *kubernetes.Clientset {
-	return i.client
+	return i.client.(*kubernetes.Clientset)
 }
 
 func (i *KubernetesImplementer) Config() *rest.Config {

--- a/provider/kubernetes/implementer.go
+++ b/provider/kubernetes/implementer.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+
 	"github.com/keel-hq/keel/internal/k8s"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -13,6 +14,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	core_v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -125,41 +127,49 @@ func (i *KubernetesImplementer) Deployments(namespace string) (*apps_v1.Deployme
 	return l, err
 }
 
-// Update converts generic resource into specific kubernetes type and updates it
+// Update converts generic resource into specific kubernetes type and updates it.
+// Updates are retried on conflict (HTTP 409) using exponential backoff, re-fetching
+// the latest object before each attempt so the retried write carries a fresh
+// resourceVersion.
 func (i *KubernetesImplementer) Update(obj *k8s.GenericResource) error {
-	// retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-	// 	// Retrieve the latest version of Deployment before attempting update
-	// 	// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-	// 	_, updateErr := i.client.Extensions().Deployments(deployment.Namespace).Update(deployment)
-	// 	return updateErr
-	// })
-	// return retryErr
-
-	switch resource := obj.GetResource().(type) {
-	case *apps_v1.Deployment:
-		_, err := i.client.AppsV1().Deployments(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
-		if err != nil {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		switch resource := obj.GetResource().(type) {
+		case *apps_v1.Deployment:
+			latest, err := i.client.AppsV1().Deployments(resource.Namespace).Get(context.TODO(), resource.Name, meta_v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			resource.ResourceVersion = latest.ResourceVersion
+			_, err = i.client.AppsV1().Deployments(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
 			return err
-		}
-	case *apps_v1.StatefulSet:
-		_, err := i.client.AppsV1().StatefulSets(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
-		if err != nil {
+		case *apps_v1.StatefulSet:
+			latest, err := i.client.AppsV1().StatefulSets(resource.Namespace).Get(context.TODO(), resource.Name, meta_v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			resource.ResourceVersion = latest.ResourceVersion
+			_, err = i.client.AppsV1().StatefulSets(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
 			return err
-		}
-	case *apps_v1.DaemonSet:
-		_, err := i.client.AppsV1().DaemonSets(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
-		if err != nil {
+		case *apps_v1.DaemonSet:
+			latest, err := i.client.AppsV1().DaemonSets(resource.Namespace).Get(context.TODO(), resource.Name, meta_v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			resource.ResourceVersion = latest.ResourceVersion
+			_, err = i.client.AppsV1().DaemonSets(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
 			return err
-		}
-	case *batch_v1.CronJob:
-		_, err := i.client.BatchV1().CronJobs(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
-		if err != nil {
+		case *batch_v1.CronJob:
+			latest, err := i.client.BatchV1().CronJobs(resource.Namespace).Get(context.TODO(), resource.Name, meta_v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			resource.ResourceVersion = latest.ResourceVersion
+			_, err = i.client.BatchV1().CronJobs(resource.Namespace).Update(context.TODO(), resource, meta_v1.UpdateOptions{})
 			return err
+		default:
+			return fmt.Errorf("unsupported object type")
 		}
-	default:
-		return fmt.Errorf("unsupported object type")
-	}
-	return nil
+	})
 }
 
 // Secret - get secret

--- a/provider/kubernetes/implementer_test.go
+++ b/provider/kubernetes/implementer_test.go
@@ -1,0 +1,138 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const (
+	conflictTestNamespace = "xxxx"
+	conflictTestName      = "dep-1"
+)
+
+// testDeployment builds a minimal deployment with the given resourceVersion
+// and container image.
+func testDeployment(resourceVersion, image string) *apps_v1.Deployment {
+	return &apps_v1.Deployment{
+		meta_v1.TypeMeta{},
+		meta_v1.ObjectMeta{
+			Name:            conflictTestName,
+			Namespace:       conflictTestNamespace,
+			ResourceVersion: resourceVersion,
+		},
+		apps_v1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Image: image}},
+				},
+			},
+		},
+		apps_v1.DeploymentStatus{},
+	}
+}
+
+// TestUpdateRetriesOnConflict verifies that a 409 Conflict on the first update
+// attempt is retried: the retried attempt re-fetches the object, carries the
+// fresh resourceVersion, and succeeds.
+func TestUpdateRetriesOnConflict(t *testing.T) {
+	const (
+		staleRV  = "1"
+		freshRV  = "10"
+		oldImage = "gcr.io/v2-namespace/hello-world:1.0.0"
+		newImage = "gcr.io/v2-namespace/hello-world:2.0.0"
+	)
+
+	// The object as it currently exists on the API server.
+	latest := testDeployment(freshRV, oldImage)
+	client := fake.NewSimpleClientset(latest)
+
+	// The first update attempt is rejected with 409 Conflict; subsequent
+	// attempts fall through to the default (object tracker) behavior.
+	var updateRVs []string
+	client.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		dep, ok := action.(k8stesting.UpdateAction).GetObject().(*apps_v1.Deployment)
+		if !ok {
+			t.Fatalf("expected a deployment update action, got %T", action)
+		}
+		updateRVs = append(updateRVs, dep.ResourceVersion)
+		if len(updateRVs) == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "apps", Resource: "deployments"},
+				conflictTestName,
+				errors.New("object has been modified; if applying changes, get a newer version and try again"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	// Keel holds a stale copy: same name/namespace, older resourceVersion,
+	// with the new image to be applied.
+	stale := testDeployment(staleRV, newImage)
+
+	impl := &KubernetesImplementer{client: client}
+	err := impl.Update(MustParseGR(stale))
+	if err != nil {
+		t.Fatalf("expected Update to succeed after conflict retry, got: %v", err)
+	}
+
+	if len(updateRVs) != 2 {
+		t.Fatalf("expected the update to be attempted twice, got %d attempts", len(updateRVs))
+	}
+	for i, rv := range updateRVs {
+		if rv != freshRV {
+			t.Errorf("update attempt %d carried resourceVersion %q, want the fresh %q from the re-fetch", i+1, rv, freshRV)
+		}
+	}
+
+	updated, err := client.AppsV1().Deployments(conflictTestNamespace).Get(context.TODO(), conflictTestName, meta_v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated deployment: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != newImage {
+		t.Errorf("expected deployment image %q, got %q", newImage, got)
+	}
+	if updated.ResourceVersion != freshRV {
+		t.Errorf("expected updated object to carry the fresh resourceVersion %q, got %q", freshRV, updated.ResourceVersion)
+	}
+}
+
+// TestUpdateDoesNotRetryOnForbidden verifies that non-conflict API errors are
+// returned immediately without retry.
+func TestUpdateDoesNotRetryOnForbidden(t *testing.T) {
+	latest := testDeployment("10", "gcr.io/v2-namespace/hello-world:1.0.0")
+	client := fake.NewSimpleClientset(latest)
+
+	var updateCount int
+	client.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			conflictTestName,
+			errors.New("forbidden: cannot update deployment"),
+		)
+	})
+
+	stale := testDeployment("1", "gcr.io/v2-namespace/hello-world:2.0.0")
+
+	impl := &KubernetesImplementer{client: client}
+	err := impl.Update(MustParseGR(stale))
+	if err == nil {
+		t.Fatal("expected an error from Update, got nil")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected a forbidden error, got: %v", err)
+	}
+	if updateCount != 1 {
+		t.Fatalf("expected the update to be attempted exactly once without retry, got %d attempts", updateCount)
+	}
+}


### PR DESCRIPTION
Retry workload updates on `409 Conflict` so a stale `resourceVersion` no longer causes a missed rollout (keel-hq/keel#818).

## Changes

- `provider/kubernetes/implementer.go`: `KubernetesImplementer.Update()` now wraps the per-kind update in `retry.RetryOnConflict(retry.DefaultRetry, ...)` for Deployment, StatefulSet, DaemonSet, and CronJob. Each attempt re-fetches the latest object by namespace/name and copies its `resourceVersion` onto the update payload, so a retried write carries a fresh resourceVersion instead of repeatedly failing on the stale one (standard Kubernetes controller pattern; replaces the old commented-out `RetryOnConflict` block).
- Non-conflict API errors (e.g. `403 Forbidden`, `404 Not Found`) are returned immediately without retry. The `unsupported object type` error path and `context.TODO()` usage are preserved.
- The implementer's unexported `client` field is now `kubernetes.Interface` so a fake clientset can be injected in tests; `Client()` keeps its `*kubernetes.Clientset` signature. No event handling, policy, or other resource types are touched.

## Tests

`provider/kubernetes/implementer_test.go` (fake clientset):
- `TestUpdateRetriesOnConflict`: first update returns 409 Conflict, second succeeds. Asserts `Update()` returns nil, both attempts carry the fresh resourceVersion from the re-fetch, and the stored object is updated with the new image and resourceVersion.
- `TestUpdateDoesNotRetryOnForbidden`: 403 Forbidden is returned immediately; asserts exactly one update attempt.

## Verification

- `gofmt` clean on changed files
- `go test ./provider/kubernetes/...` — pass
- `go test ./...` — pass (all packages)

Spec: helix-specs `design/tasks/000333_retry-conflict-on-update` (design.md / requirements.md / tasks.md).

Note: opened from the session-assigned branch `feature/000390-complete-existing-spec` — the sandbox only permits pushing to the session's assigned branch name. The change itself is spec task 000333 for keel-hq/keel#818, originally developed on `feature/000333-retry-conflict-on-update`.