### PR TITLE
fix(security): keep webhook signing secrets and credentials out of log output

### DIFF
--- a/extension/notification/discord/discord.go
+++ b/extension/notification/discord/discord.go
@@ -40,7 +40,9 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		return false, nil
 	}
 	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
-		return false, fmt.Errorf("could not parse endpoint URL: %s", err)
+		// The parse error is not returned: url.ParseRequestURI echoes the
+		// input in its message and the endpoint may carry a secret.
+		return false, fmt.Errorf("could not parse endpoint URL: not a valid absolute URL")
 	}
 	s.endpoint = httpConfig.Endpoint
 
@@ -50,10 +52,18 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		Timeout:   timeout,
 	}
 
+	// The endpoint URL may embed the webhook signing secret in its path or
+	// query string, so only a redacted form is ever logged.
 	log.WithFields(log.Fields{
 		"name":     "discord",
-		"endpoint": s.endpoint,
+		"endpoint": notification.SafeURL(s.endpoint),
 	}).Info("extension.notification.discord: sender configured")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"name":     "discord",
+			"endpoint": notification.DebugURL(s.endpoint),
+		}).Debug("extension.notification.discord: sender endpoint (secrets redacted)")
+	}
 	return true, nil
 }
 

--- a/extension/notification/discord/discord.go
+++ b/extension/notification/discord/discord.go
@@ -40,8 +40,8 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		return false, nil
 	}
 	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
-		// The parse error is not returned: url.ParseRequestURI echoes the
-		// input in its message and the endpoint may carry a secret.
+		// The raw parse error is not logged/returned: url.ParseRequestURI
+		// echoes the input in its message and the endpoint may carry a secret.
 		return false, fmt.Errorf("could not parse endpoint URL: not a valid absolute URL")
 	}
 	s.endpoint = httpConfig.Endpoint

--- a/extension/notification/discord/discord_log_test.go
+++ b/extension/notification/discord/discord_log_test.go
@@ -97,3 +97,32 @@ func TestConfigureDoesNotLogWebhookSecret(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigureInvalidEndpointRejected proves that a malformed Discord
+// webhook URL is rejected with an error instead of silently accepted with an
+// unusable endpoint, and that the raw endpoint leaks neither into the
+// returned error nor into log output.
+func TestConfigureInvalidEndpointRejected(t *testing.T) {
+	bad := "discord.com/api/webhooks/1038689483310731242/9f8e7d6c5b4a39281706f5e4d3c2b1a0"
+
+	out := captureLogs(t, log.DebugLevel)
+
+	s := &sender{}
+	enabled, err := s.Configure(&notification.Config{
+		Notifications: config.NotificationConfig{
+			Discord: config.DiscordConfig{WebhookURL: bad},
+		},
+	})
+	if enabled {
+		t.Fatalf("Configure = enabled %v, want false", enabled)
+	}
+	if err == nil {
+		t.Fatal("Configure = nil error, want an error for an unparsable webhook URL")
+	}
+	if strings.Contains(err.Error(), bad) {
+		t.Errorf("returned error echoes the raw endpoint: %s", err)
+	}
+	if captured := out(); strings.Contains(captured, bad) {
+		t.Errorf("captured log output contains the raw endpoint:\n%s", captured)
+	}
+}

--- a/extension/notification/discord/discord_log_test.go
+++ b/extension/notification/discord/discord_log_test.go
@@ -1,0 +1,99 @@
+package discord
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/pkg/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logCapture) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, line)
+	return nil
+}
+
+func (l *logCapture) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (l *logCapture) Output() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// captureLogs attaches a hook to the global logrus logger at the given level
+// and returns a function that reads everything captured so far. The previous
+// level and hooks are restored when the test finishes.
+func captureLogs(t *testing.T, level log.Level) func() string {
+	t.Helper()
+	std := log.StandardLogger()
+	prevLevel := std.GetLevel()
+	prevHooks := cloneHooks(std.Hooks)
+	std.SetLevel(level)
+	capture := &logCapture{}
+	std.AddHook(capture)
+	t.Cleanup(func() {
+		std.SetLevel(prevLevel)
+		std.Hooks = prevHooks
+	})
+	return capture.Output
+}
+
+// cloneHooks deep-copies the level hooks so they can be restored later.
+func cloneHooks(hooks log.LevelHooks) log.LevelHooks {
+	clone := make(log.LevelHooks, len(hooks))
+	for lvl, hs := range hooks {
+		copied := make([]log.Hook, len(hs))
+		copy(copied, hs)
+		clone[lvl] = copied
+	}
+	return clone
+}
+
+// TestConfigureDoesNotLogWebhookSecret proves that a Discord webhook token
+// embedded in the URL never appears in log output, neither at info level nor
+// in the debug-only endpoint detail.
+func TestConfigureDoesNotLogWebhookSecret(t *testing.T) {
+	token := "9f8e7d6c5b4a39281706f5e4d3c2b1a0"
+	endpoint := "https://discord.com/api/webhooks/1038689483310731242/" + token
+
+	for _, level := range []log.Level{log.InfoLevel, log.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			out := captureLogs(t, level)
+
+			s := &sender{}
+			enabled, err := s.Configure(&notification.Config{
+				Notifications: config.NotificationConfig{
+					Discord: config.DiscordConfig{WebhookURL: endpoint},
+				},
+			})
+			if err != nil || !enabled {
+				t.Fatalf("Configure = enabled %v, err %v", enabled, err)
+			}
+
+			captured := out()
+			if !strings.Contains(captured, "discord.com") {
+				t.Fatalf("expected the endpoint host to be logged, got: %s", captured)
+			}
+			if strings.Contains(captured, token) {
+				t.Errorf("captured log output contains endpoint secret:\n%s", captured)
+			}
+		})
+	}
+}

--- a/extension/notification/mattermost/mattermost.go
+++ b/extension/notification/mattermost/mattermost.go
@@ -51,11 +51,13 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		s.name = httpConfig.Name // setting default name
 	}
 	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
+		// Never log the raw endpoint (it may carry a secret) and never the
+		// parse error either, since url.ParseRequestURI echoes the input in
+		// its message.
 		log.WithFields(log.Fields{
-			"endpoint": httpConfig.Endpoint,
-			"error":    err,
-		}).Error("extension.notification.mattermost: endpoint invalid")
-		return false, fmt.Errorf("could not parse endpoint URL: %s", err)
+			"endpoint": notification.SafeURL(httpConfig.Endpoint),
+		}).Error("extension.notification.mattermost: endpoint invalid, not a valid absolute URL")
+		return false, fmt.Errorf("could not parse endpoint URL: not a valid absolute URL")
 	}
 	s.endpoint = httpConfig.Endpoint
 
@@ -66,10 +68,18 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		CheckRedirect: rejectRedirect,
 	}
 
+	// The endpoint URL may embed the webhook signing secret in its path or
+	// query string, so only a redacted form is ever logged.
 	log.WithFields(log.Fields{
 		"name":     "mattermost",
-		"endpoint": s.endpoint,
+		"endpoint": notification.SafeURL(s.endpoint),
 	}).Info("extension.notification.mattermost: sender configured")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"name":     "mattermost",
+			"endpoint": notification.DebugURL(s.endpoint),
+		}).Debug("extension.notification.mattermost: sender endpoint (secrets redacted)")
+	}
 
 	return true, nil
 }

--- a/extension/notification/mattermost/mattermost_log_test.go
+++ b/extension/notification/mattermost/mattermost_log_test.go
@@ -1,0 +1,121 @@
+package mattermost
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/pkg/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logCapture) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, line)
+	return nil
+}
+
+func (l *logCapture) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (l *logCapture) Output() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// captureLogs attaches a hook to the global logrus logger at the given level
+// and returns a function that reads everything captured so far. The previous
+// level and hooks are restored when the test finishes.
+func captureLogs(t *testing.T, level log.Level) func() string {
+	t.Helper()
+	std := log.StandardLogger()
+	prevLevel := std.GetLevel()
+	prevHooks := cloneHooks(std.Hooks)
+	std.SetLevel(level)
+	capture := &logCapture{}
+	std.AddHook(capture)
+	t.Cleanup(func() {
+		std.SetLevel(prevLevel)
+		std.Hooks = prevHooks
+	})
+	return capture.Output
+}
+
+// cloneHooks deep-copies the level hooks so they can be restored later.
+func cloneHooks(hooks log.LevelHooks) log.LevelHooks {
+	clone := make(log.LevelHooks, len(hooks))
+	for lvl, hs := range hooks {
+		copied := make([]log.Hook, len(hs))
+		copy(copied, hs)
+		clone[lvl] = copied
+	}
+	return clone
+}
+
+// TestConfigureDoesNotLogEndpointSecret proves that a Mattermost webhook
+// token embedded in the URL never appears in log output, neither at info
+// level nor in the debug-only endpoint detail.
+func TestConfigureDoesNotLogEndpointSecret(t *testing.T) {
+	secret := "mm-hook-token-abc123xyz789"
+	endpoint := "https://mattermost.example.com/hooks/" + secret + "?foo=bar"
+
+	for _, level := range []log.Level{log.InfoLevel, log.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			out := captureLogs(t, level)
+
+			s := &sender{}
+			enabled, err := s.Configure(&notification.Config{
+				Notifications: config.NotificationConfig{
+					Mattermost: config.MattermostConfig{Endpoint: endpoint},
+				},
+			})
+			if err != nil || !enabled {
+				t.Fatalf("Configure = enabled %v, err %v", enabled, err)
+			}
+
+			captured := out()
+			if !strings.Contains(captured, "mattermost.example.com") {
+				t.Fatalf("expected the endpoint host to be logged, got: %s", captured)
+			}
+			if strings.Contains(captured, secret) {
+				t.Errorf("captured log output contains endpoint secret:\n%s", captured)
+			}
+		})
+	}
+}
+
+// TestConfigureInvalidEndpointNotLogged proves that an unparsable endpoint is
+// never logged verbatim on the error path either.
+func TestConfigureInvalidEndpointNotLogged(t *testing.T) {
+	bad := "://broken-with-secret-token-0a1b2c3d4e5f"
+
+	out := captureLogs(t, log.ErrorLevel)
+
+	s := &sender{}
+	enabled, err := s.Configure(&notification.Config{
+		Notifications: config.NotificationConfig{
+			Mattermost: config.MattermostConfig{Endpoint: bad},
+		},
+	})
+	if err == nil || enabled {
+		t.Fatalf("Configure = enabled %v, err %v, want error", enabled, err)
+	}
+
+	if captured := out(); strings.Contains(captured, bad) || strings.Contains(captured, "secret-token-0a1b2c3d4e5f") {
+		t.Errorf("captured log output contains the raw endpoint:\n%s", captured)
+	}
+}

--- a/extension/notification/sanitize.go
+++ b/extension/notification/sanitize.go
@@ -1,0 +1,84 @@
+package notification
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Redacted is substituted for URL components that may carry a secret
+// (webhook signing keys, bot tokens, passwords) before a URL is logged.
+const Redacted = "[REDACTED]"
+
+// SafeURL returns a version of rawURL that is safe to log at any level.
+// Webhook endpoint URLs commonly embed signing secrets in the path or query
+// string (e.g. Teams, Discord and Mattermost incoming-webhook URLs), so only
+// the scheme and host are retained.
+func SafeURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return Redacted
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+// DebugURL returns a version of rawURL that may be logged at debug level
+// only. The path structure is preserved for diagnostics, while userinfo,
+// any path segment that looks like a secret, and every query value are
+// redacted. Callers must ensure the result is only logged when debug
+// logging is enabled (see log.IsLevelEnabled(log.DebugLevel)).
+func DebugURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" {
+		return Redacted
+	}
+
+	var b strings.Builder
+	b.WriteString(parsed.Scheme)
+	b.WriteString("://")
+	if parsed.Host != "" {
+		b.WriteString(parsed.Host)
+	}
+	// parsed.User is intentionally ignored: userinfo may carry credentials.
+
+	for _, seg := range strings.Split(strings.Trim(parsed.Path, "/"), "/") {
+		if seg == "" {
+			continue
+		}
+		b.WriteString("/")
+		b.WriteString(sanitizePathSegment(seg))
+	}
+
+	if parsed.RawQuery != "" {
+		b.WriteString("?")
+		first := true
+		for _, pair := range strings.Split(parsed.RawQuery, "&") {
+			if !first {
+				b.WriteString("&")
+			}
+			first = false
+			key, _, _ := strings.Cut(pair, "=")
+			if key == "" {
+				b.WriteString(Redacted)
+			} else {
+				b.WriteString(key)
+				b.WriteString("=")
+				b.WriteString(Redacted)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// sanitizePathSegment redacts path segments that look like secrets: anything
+// long enough to be a random token (>= 16 characters, which also covers
+// UUIDs/GUIDs) or containing '@' (e.g. Teams webhook keys of the form
+// "<guid>@<tenant>"). Short structural segments such as "webhook",
+// "IncomingWebhook" or "hooks" are preserved so the debug output still
+// identifies the endpoint.
+func sanitizePathSegment(seg string) string {
+	if len(seg) >= 16 || strings.ContainsRune(seg, '@') {
+		return Redacted
+	}
+	return seg
+}

--- a/extension/notification/sanitize_test.go
+++ b/extension/notification/sanitize_test.go
@@ -1,0 +1,166 @@
+package notification
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSafeURLStripsSecrets verifies that SafeURL keeps only the scheme and
+// host, so webhook signing secrets in the path, query string or userinfo can
+// never reach log output.
+func TestSafeURLStripsSecrets(t *testing.T) {
+	const (
+		teamsKey   = "2c1a3b4c5d6e7f8091a2b3c4d5e6f708"
+		discordTok = "9f8e7d6c5b4a39281706f5e4d3c2b1a0"
+		mmToken    = "mm-hook-token-abc123xyz789"
+		queryTok   = "query-secret-0a1b2c3d4e5f"
+		smtpPass   = "smtp-password-9z8y7x"
+	)
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		secrets []string
+	}{
+		{
+			name:   "teams webhook key in path",
+			rawURL: "https://outlook.office.com/webhook/" + teamsKey + "@contoso.com/IncomingWebhook/1a2b3c4d5e6f708192a3b4c5d6e7f809/webhook",
+			want:   "https://outlook.office.com",
+			secrets: []string{
+				teamsKey,
+				"1a2b3c4d5e6f708192a3b4c5d6e7f809",
+			},
+		},
+		{
+			name:    "discord token in path",
+			rawURL:  "https://discord.com/api/webhooks/1038689483310731242/" + discordTok,
+			want:    "https://discord.com",
+			secrets: []string{discordTok},
+		},
+		{
+			name:    "mattermost token in path",
+			rawURL:  "https://mattermost.example.com/hooks/" + mmToken,
+			want:    "https://mattermost.example.com",
+			secrets: []string{mmToken},
+		},
+		{
+			name:    "token in query string",
+			rawURL:  "https://hooks.example.com/notify?token=" + queryTok,
+			want:    "https://hooks.example.com",
+			secrets: []string{queryTok},
+		},
+		{
+			name:    "credentials in userinfo",
+			rawURL:  "https://bot:" + smtpPass + "@hooks.example.com/hook",
+			want:    "https://hooks.example.com",
+			secrets: []string{smtpPass, "bot"},
+		},
+		{
+			name:    "unparsable input",
+			rawURL:  "://not-a-url",
+			want:    Redacted,
+			secrets: []string{"not-a-url"},
+		},
+		{
+			name:    "missing scheme",
+			rawURL:  "hooks.example.com/hook",
+			want:    Redacted,
+			secrets: []string{"hook"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeURL(tt.rawURL)
+			if got != tt.want {
+				t.Errorf("SafeURL(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+			for _, secret := range tt.secrets {
+				if strings.Contains(got, secret) {
+					t.Errorf("SafeURL(%q) = %q leaks secret %q", tt.rawURL, got, secret)
+				}
+			}
+		})
+	}
+}
+
+// TestDebugURLRedactsSecretsButKeepsStructure verifies that DebugURL keeps
+// the endpoint identifiable (host and structural path segments) while the
+// secret parts are still redacted.
+func TestDebugURLRedactsSecretsButKeepsStructure(t *testing.T) {
+	const (
+		teamsKey  = "2c1a3b4c5d6e7f8091a2b3c4d5e6f708"
+		discordID = "1038689483310731242"
+		discordTk = "9f8e7d6c5b4a39281706f5e4d3c2b1a0"
+		queryTok  = "query-secret-0a1b2c3d4e5f"
+		smtpUser  = "botuser"
+		smtpPass  = "smtp-password-9z8y7x"
+	)
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		secrets []string
+		keep    []string
+	}{
+		{
+			name:   "teams webhook keeps path structure",
+			rawURL: "https://outlook.office.com/webhook/" + teamsKey + "@contoso.com/IncomingWebhook/1a2b3c4d5e6f708192a3b4c5d6e7f809/webhook",
+			want:   "https://outlook.office.com/webhook/" + Redacted + "/IncomingWebhook/" + Redacted + "/webhook",
+			secrets: []string{
+				teamsKey,
+				"contoso.com",
+				"1a2b3c4d5e6f708192a3b4c5d6e7f809",
+			},
+			keep: []string{"outlook.office.com", "webhook", "IncomingWebhook"},
+		},
+		{
+			name:    "discord keeps path structure",
+			rawURL:  "https://discord.com/api/webhooks/" + discordID + "/" + discordTk,
+			want:    "https://discord.com/api/webhooks/" + Redacted + "/" + Redacted,
+			secrets: []string{discordTk},
+			keep:    []string{"discord.com", "api", "webhooks"},
+		},
+		{
+			name:    "query value redacted, key kept",
+			rawURL:  "https://hooks.example.com/notify?token=" + queryTok,
+			want:    "https://hooks.example.com/notify?token=" + Redacted,
+			secrets: []string{queryTok},
+			keep:    []string{"hooks.example.com", "notify", "token="},
+		},
+		{
+			name:    "userinfo redacted",
+			rawURL:  "https://" + smtpUser + ":" + smtpPass + "@hooks.example.com/hook",
+			want:    "https://hooks.example.com/hook",
+			secrets: []string{smtpUser, smtpPass},
+			keep:    []string{"hooks.example.com", "hook"},
+		},
+		{
+			name:    "unparsable input",
+			rawURL:  "://not-a-url",
+			want:    Redacted,
+			secrets: []string{"not-a-url"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DebugURL(tt.rawURL)
+			if got != tt.want {
+				t.Errorf("DebugURL(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+			for _, secret := range tt.secrets {
+				if strings.Contains(got, secret) {
+					t.Errorf("DebugURL(%q) = %q leaks secret %q", tt.rawURL, got, secret)
+				}
+			}
+			for _, k := range tt.keep {
+				if !strings.Contains(got, k) {
+					t.Errorf("DebugURL(%q) = %q lost diagnostic part %q", tt.rawURL, got, k)
+				}
+			}
+		})
+	}
+}

--- a/extension/notification/teams/teams.go
+++ b/extension/notification/teams/teams.go
@@ -43,7 +43,9 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		return false, nil
 	}
 	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
-		return false, fmt.Errorf("could not parse endpoint URL: %s\n", err)
+		// The parse error is not returned: url.ParseRequestURI echoes the
+		// input in its message and the endpoint may carry a secret.
+		return false, fmt.Errorf("could not parse endpoint URL: not a valid absolute URL")
 	}
 	s.endpoint = httpConfig.Endpoint
 
@@ -53,10 +55,18 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		Timeout:   timeout,
 	}
 
+	// The endpoint URL may embed the webhook signing secret in its path or
+	// query string, so only a redacted form is ever logged.
 	log.WithFields(log.Fields{
 		"name":    "teams",
-		"webhook": s.endpoint,
+		"webhook": notification.SafeURL(s.endpoint),
 	}).Info("extension.notification.teams: sender configured")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"name":    "teams",
+			"webhook": notification.DebugURL(s.endpoint),
+		}).Debug("extension.notification.teams: sender endpoint (secrets redacted)")
+	}
 
 	return true, nil
 }

--- a/extension/notification/teams/teams_log_test.go
+++ b/extension/notification/teams/teams_log_test.go
@@ -1,0 +1,103 @@
+package teams
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/pkg/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logCapture) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, line)
+	return nil
+}
+
+func (l *logCapture) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (l *logCapture) Output() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// captureLogs attaches a hook to the global logrus logger at the given level
+// and returns a function that reads everything captured so far. The previous
+// level and hooks are restored when the test finishes.
+func captureLogs(t *testing.T, level log.Level) func() string {
+	t.Helper()
+	std := log.StandardLogger()
+	prevLevel := std.GetLevel()
+	prevHooks := cloneHooks(std.Hooks)
+	std.SetLevel(level)
+	capture := &logCapture{}
+	std.AddHook(capture)
+	t.Cleanup(func() {
+		std.SetLevel(prevLevel)
+		std.Hooks = prevHooks
+	})
+	return capture.Output
+}
+
+// cloneHooks deep-copies the level hooks so they can be restored later.
+func cloneHooks(hooks log.LevelHooks) log.LevelHooks {
+	clone := make(log.LevelHooks, len(hooks))
+	for lvl, hs := range hooks {
+		copied := make([]log.Hook, len(hs))
+		copy(copied, hs)
+		clone[lvl] = copied
+	}
+	return clone
+}
+
+// TestConfigureDoesNotLogWebhookSecret proves that a Teams webhook signing
+// key embedded in the URL (the <guid>@<tenant> path segment) never appears
+// in log output, neither at info level nor in the debug-only endpoint detail.
+func TestConfigureDoesNotLogWebhookSecret(t *testing.T) {
+	key := "2c1a3b4c5d6e7f8091a2b3c4d5e6f708"
+	tenant := "contoso.example"
+	hookID := "1a2b3c4d5e6f708192a3b4c5d6e7f809"
+	endpoint := "https://outlook.office.com/webhook/" + key + "@" + tenant + "/IncomingWebhook/" + hookID + "/webhook"
+
+	for _, level := range []log.Level{log.InfoLevel, log.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			out := captureLogs(t, level)
+
+			s := &sender{}
+			enabled, err := s.Configure(&notification.Config{
+				Notifications: config.NotificationConfig{
+					Teams: config.TeamsConfig{WebhookURL: endpoint},
+				},
+			})
+			if err != nil || !enabled {
+				t.Fatalf("Configure = enabled %v, err %v", enabled, err)
+			}
+
+			captured := out()
+			if !strings.Contains(captured, "outlook.office.com") {
+				t.Fatalf("expected the endpoint host to be logged, got: %s", captured)
+			}
+			for _, secret := range []string{key, tenant, hookID} {
+				if strings.Contains(captured, secret) {
+					t.Errorf("captured log output contains secret %q:\n%s", secret, captured)
+				}
+			}
+		})
+	}
+}

--- a/extension/notification/webhook/webhook.go
+++ b/extension/notification/webhook/webhook.go
@@ -41,7 +41,9 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		return false, nil
 	}
 	if _, err := url.ParseRequestURI(httpConfig.Endpoint); err != nil {
-		return false, fmt.Errorf("could not parse endpoint URL: %s\n", err)
+		// The parse error is not returned: url.ParseRequestURI echoes the
+		// input in its message and the endpoint may carry a secret.
+		return false, fmt.Errorf("could not parse endpoint URL: not a valid absolute URL")
 	}
 	s.endpoint = httpConfig.Endpoint
 
@@ -52,10 +54,18 @@ func (s *sender) Configure(config *notification.Config) (bool, error) {
 		CheckRedirect: rejectRedirect,
 	}
 
+	// The endpoint URL may embed the webhook signing secret in its path or
+	// query string, so only a redacted form is ever logged.
 	log.WithFields(log.Fields{
 		"name":     "webhook",
-		"endpoint": s.endpoint,
+		"endpoint": notification.SafeURL(s.endpoint),
 	}).Info("extension.notification.webhook: sender configured")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"name":     "webhook",
+			"endpoint": notification.DebugURL(s.endpoint),
+		}).Debug("extension.notification.webhook: sender endpoint (secrets redacted)")
+	}
 
 	return true, nil
 }

--- a/extension/notification/webhook/webhook_log_test.go
+++ b/extension/notification/webhook/webhook_log_test.go
@@ -1,0 +1,99 @@
+package webhook
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keel-hq/keel/extension/notification"
+	"github.com/keel-hq/keel/pkg/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logCapture) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, line)
+	return nil
+}
+
+func (l *logCapture) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (l *logCapture) Output() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// captureLogs attaches a hook to the global logrus logger at the given level
+// and returns a function that reads everything captured so far. The previous
+// level and hooks are restored when the test finishes.
+func captureLogs(t *testing.T, level log.Level) func() string {
+	t.Helper()
+	std := log.StandardLogger()
+	prevLevel := std.GetLevel()
+	prevHooks := cloneHooks(std.Hooks)
+	std.SetLevel(level)
+	capture := &logCapture{}
+	std.AddHook(capture)
+	t.Cleanup(func() {
+		std.SetLevel(prevLevel)
+		std.Hooks = prevHooks
+	})
+	return capture.Output
+}
+
+// cloneHooks deep-copies the level hooks so they can be restored later.
+func cloneHooks(hooks log.LevelHooks) log.LevelHooks {
+	clone := make(log.LevelHooks, len(hooks))
+	for lvl, hs := range hooks {
+		copied := make([]log.Hook, len(hs))
+		copy(copied, hs)
+		clone[lvl] = copied
+	}
+	return clone
+}
+
+// TestConfigureDoesNotLogEndpointSecret proves that a webhook signing secret
+// embedded in the configured endpoint (path or query) never appears in log
+// output, neither at info level nor in the debug-only endpoint detail.
+func TestConfigureDoesNotLogEndpointSecret(t *testing.T) {
+	secret := "super-secret-webhook-token-9f86d0"
+	endpoint := "https://hooks.example.com/hooks/" + secret + "?api_key=" + secret
+
+	for _, level := range []log.Level{log.InfoLevel, log.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			out := captureLogs(t, level)
+
+			s := &sender{}
+			enabled, err := s.Configure(&notification.Config{
+				Notifications: config.NotificationConfig{
+					Webhook: config.WebhookConfig{Endpoint: endpoint},
+				},
+			})
+			if err != nil || !enabled {
+				t.Fatalf("Configure = enabled %v, err %v", enabled, err)
+			}
+
+			captured := out()
+			if !strings.Contains(captured, "hooks.example.com") {
+				t.Fatalf("expected the endpoint host to be logged, got: %s", captured)
+			}
+			if strings.Contains(captured, secret) {
+				t.Errorf("captured log output contains endpoint secret:\n%s", captured)
+			}
+		})
+	}
+}

--- a/pkg/http/auth.go
+++ b/pkg/http/auth.go
@@ -55,11 +55,13 @@ func (s *TriggerServer) requireAdminAuthorization(next http.HandlerFunc) http.Ha
 			})
 
 			if err != nil {
+				// Never log the password (or the full authorization
+				// header): a failed webhook request must not leak its
+				// credentials into log output.
 				log.WithFields(log.Fields{
 					"error": err,
 					"user":  username,
-					"pas":   password,
-				}).Error("failed uath")
+				}).Error("authentication failed")
 				// rw.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 				http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 				return
@@ -81,7 +83,8 @@ func (s *TriggerServer) requireAdminAuthorization(next http.HandlerFunc) http.Ha
 		if err != nil {
 			// rw.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 
-			log.Warnf("authentication by token failed, token: %s, err: %s", extractToken(r), err)
+			// Never log the token itself: it is the caller's credential.
+			log.WithField("error", err).Warn("authentication by token failed")
 			http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}

--- a/pkg/http/webhook_log_redaction_test.go
+++ b/pkg/http/webhook_log_redaction_test.go
@@ -1,0 +1,158 @@
+package http
+
+import (
+	"bytes"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keel-hq/keel/approvals"
+	"github.com/keel-hq/keel/pkg/auth"
+	"github.com/keel-hq/keel/provider"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type capturingLogHook struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (h *capturingLogHook) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lines = append(h.lines, line)
+	return nil
+}
+
+func (h *capturingLogHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (h *capturingLogHook) Output() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return strings.Join(h.lines, "\n")
+}
+
+// captureLogEntries sets the global logrus logger to level, records every
+// emitted entry and returns a reader for what was captured. The previous
+// level and hooks are restored when the test finishes.
+func captureLogEntries(t *testing.T, level log.Level) func() string {
+	t.Helper()
+	std := log.StandardLogger()
+	prevLevel := std.GetLevel()
+	prevHooks := cloneHooks(std.Hooks)
+	std.SetLevel(level)
+	hook := &capturingLogHook{}
+	std.AddHook(hook)
+	t.Cleanup(func() {
+		std.SetLevel(prevLevel)
+		std.Hooks = prevHooks
+	})
+	return hook.Output
+}
+
+// cloneHooks deep-copies the level hooks so they can be restored later.
+func cloneHooks(hooks log.LevelHooks) log.LevelHooks {
+	clone := make(log.LevelHooks, len(hooks))
+	for lvl, hs := range hooks {
+		copied := make([]log.Hook, len(hs))
+		copy(copied, hs)
+		clone[lvl] = copied
+	}
+	return clone
+}
+
+// newAuthenticatedWebhookTestingServer builds a trigger server with webhook
+// authentication enabled, like a deployment that protects its webhook
+// endpoints with basic/bearer auth.
+func newAuthenticatedWebhookTestingServer(fp provider.Provider) (*TriggerServer, func()) {
+	store, teardown := NewTestingUtils()
+
+	am := approvals.New(&approvals.Opts{
+		Store: store,
+	})
+
+	authenticator := auth.New(&auth.Opts{
+		Username: "user-1",
+		Password: "correct-horse-battery-staple",
+	})
+
+	providers := provider.New([]provider.Provider{fp}, am)
+	srv := NewTriggerServer(&Opts{
+		Providers:             providers,
+		ApprovalManager:       am,
+		Authenticator:         authenticator,
+		Store:                 store,
+		AuthenticatedWebhooks: true,
+	})
+	srv.registerRoutes(srv.router)
+
+	return srv, teardown
+}
+
+// TestWebhookHandlerNeverLogsCredentials processes webhook requests that
+// carry credentials and proves that none of the captured log output contains
+// the credentials, at info level and at debug level.
+func TestWebhookHandlerNeverLogsCredentials(t *testing.T) {
+	fp := &fakeProvider{}
+	srv, teardown := newAuthenticatedWebhookTestingServer(fp)
+	defer teardown()
+
+	const basicPassword = "S3cr3t-Basic-P@ssw0rd-9f86d0"
+	const bearerToken = "S3cr3t-Bearer-T0ken-4b7c1e"
+	payload := `{"name": "gcr.io/v2-namespace/hello-world", "tag": "1.1.1"}`
+
+	for _, level := range []log.Level{log.InfoLevel, log.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			out := captureLogEntries(t, level)
+
+			// Basic auth with a wrong password exercises the failure path
+			// that used to log the password verbatim.
+			req, err := http.NewRequest("POST", "/v1/webhooks/native", bytes.NewBufferString(payload))
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+			req.Header.Set("Authorization",
+				"Basic "+base64.StdEncoding.EncodeToString([]byte("user-1:"+basicPassword)))
+			rec := httptest.NewRecorder()
+			srv.router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("basic auth: expected 401, got %d", rec.Code)
+			}
+
+			// Bearer auth with an unknown token exercises the failure path
+			// that used to log the token verbatim.
+			req2, err := http.NewRequest("POST", "/v1/webhooks/native", bytes.NewBufferString(payload))
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+			req2.Header.Set("Authorization", "Bearer "+bearerToken)
+			rec2 := httptest.NewRecorder()
+			srv.router.ServeHTTP(rec2, req2)
+			if rec2.Code != http.StatusUnauthorized {
+				t.Fatalf("bearer auth: expected 401, got %d", rec2.Code)
+			}
+
+			// The requests were rejected before any event was submitted.
+			if len(fp.submitted) != 0 {
+				t.Fatalf("expected no submitted events, got %d", len(fp.submitted))
+			}
+
+			captured := out()
+			for _, secret := range []string{basicPassword, bearerToken} {
+				if strings.Contains(captured, secret) {
+					t.Errorf("captured log output contains secret %q:\n%s", secret, captured)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Supersedes and extends community PR #844 (https://github.com/keel-hq/keel/pull/844), which redacted only the Microsoft Teams sender and still logged the full signed URL in debug mode. PR #844 is intentionally left open and unmerged.

Webhook-related log statements could leak secrets into log output:

- `pkg/http` auth middleware logged the Basic auth **password** at error level and the **bearer token** at warn level whenever an authenticated webhook request failed authentication.
- The `teams`, `discord`, `webhook` and `mattermost` notification senders logged the **full configured endpoint URL** at info level. These URLs embed the webhook signing secret in the path (e.g. Teams `<guid>@<tenant>`, Discord/Mattermost token segments) or query string.
- `mattermost` additionally logged the raw endpoint on the invalid-endpoint error path, and all four senders returned `url.ParseRequestURI` errors — which echo the input — back to the notification manager, which logs returned configure errors.

Changes:

- New `extension/notification/sanitize.go` with two helpers:
  - `SafeURL` — safe at any log level: keeps only `scheme://host`; path, query and userinfo (which may carry tokens) are dropped.
  - `DebugURL` — for debug level only: keeps the path structure for diagnostics while redacting userinfo, token-like path segments (≥16 chars, UUIDs/GUIDs, `@`-suffixed keys) and all query values.
- All four webhook senders now log only `SafeURL` at info level. The more detailed endpoint is logged **only when debug logging is enabled** (`log.IsLevelEnabled(log.DebugLevel)`) and is redacted via `DebugURL` even there.
- Auth middleware no longer logs passwords or tokens on failed authentication (also fixes the `failed uath` typo).
- Endpoint parse-error messages no longer echo the raw URL.

Audit scope: every log statement in the inbound webhook trigger handlers (`pkg/http/*_webhook_trigger.go`, `registry_notifications.go`, `auth.go`) and the outbound notification senders, plus any code logging request paths, query strings, headers or payloads. No other statement can carry a secret: remaining payload logs (jfrog, harbor, registry notifications) are debug-level only, and the shoutrrr sender already redacts (covered by its existing tests). `bot/` and `cmd/keel/main.go` log no request data or secrets.

## Testing

- New log-capture unit tests (logrus hook capturing all emitted entries):
  - `pkg/http/webhook_log_redaction_test.go` — `TestWebhookHandlerNeverLogsCredentials`: sends real webhook requests to the `/v1/webhooks/native` endpoint (authenticated-webhooks mode) with a Basic auth password and a bearer token, and asserts neither secret appears in captured log output at info level **and** debug level. A mutation check confirmed the test fails when the original leak is re-introduced.
  - Sender tests (`webhook`, `teams`, `discord`, `mattermost`) — configure each sender with an endpoint embedding a signing secret and assert the captured log output never contains the secret at info or debug level, while the host is still logged for operability.
  - `mattermost` — invalid-endpoint error path: the raw endpoint is never logged.
  - `discord` — `TestConfigureInvalidEndpointRejected`: a malformed webhook URL (no scheme) makes `Configure` return `(false, err)`, and the raw endpoint leaks neither into the error message nor into captured log output at debug level.
  - `extension/notification/sanitize_test.go` — table tests for `SafeURL`/`DebugURL` across Teams, Discord, Mattermost, query-token and user:info URL shapes.
- `gofmt`: clean on all changed files.
- `go test ./...`: passes (exit 0, all packages).

LFG!