### PR TITLE
fix(poll): guard against nil or unparsable image references in the poll watcher

### DIFF
--- a/trigger/poll/watcher.go
+++ b/trigger/poll/watcher.go
@@ -124,12 +124,19 @@ func (w *RepositoryWatcher) Watch(images ...*types.TrackedImage) error {
 		if image.Trigger != types.TriggerTypePoll || len(image.RunningDigests) == 0 {
 			continue
 		}
+		if image.Image.IsNil() {
+			continue
+		}
 		key := getImageIdentifier(image.Image, image.Policy.KeepTag())
 		running[key] = append(running[key], image.RunningDigests)
 	}
 
 	for _, image := range images {
 		if image.Trigger != types.TriggerTypePoll {
+			continue
+		}
+		if image.Image.IsNil() {
+			errs = append(errs, fmt.Sprintf("skipping image with nil or unparsable reference: %v", image))
 			continue
 		}
 		identifier, err := w.watch(image, running[getImageIdentifier(image.Image, image.Policy.KeepTag())])
@@ -169,6 +176,10 @@ func (w *RepositoryWatcher) unwatch(tracked map[string]bool) {
 }
 
 func (w *RepositoryWatcher) watch(image *types.TrackedImage, runningDigests [][]string) (string, error) {
+
+	if image.Image.IsNil() {
+		return "", fmt.Errorf("cannot watch image with nil or unparsable reference: %v", image)
+	}
 
 	if image.PollSchedule == "" {
 		return "", fmt.Errorf("cron schedule cannot be empty")
@@ -274,6 +285,10 @@ func matchesAny(digests []string, known map[string]bool) bool {
 
 func (w *RepositoryWatcher) addJob(ti *types.TrackedImage, schedule string, runningDigests [][]string) error {
 	// getting initial digest
+	if ti.Image.IsNil() {
+		return fmt.Errorf("cannot add watched job for image with nil or unparsable reference: %v", ti)
+	}
+
 	reg := ti.Image.Scheme() + "://" + ti.Image.Registry()
 
 	registryOpts := registry.Opts{

--- a/trigger/poll/watcher_nil_repro_test.go
+++ b/trigger/poll/watcher_nil_repro_test.go
@@ -1,0 +1,101 @@
+package poll
+
+import (
+	"testing"
+
+	"github.com/keel-hq/keel/internal/policy"
+	"github.com/keel-hq/keel/registry"
+	"github.com/keel-hq/keel/types"
+	"github.com/keel-hq/keel/util/image"
+)
+
+// fakeRegistryClientNoop avoids any registry network calls for reproduction.
+type nilReproRegistryClient struct {
+	registry.Client
+}
+
+func (c *nilReproRegistryClient) Digest(opts registry.Opts) (string, error) {
+	return "sha256:repro", nil
+}
+func (c *nilReproRegistryClient) Digests(opts registry.Opts) ([]string, error) {
+	return []string{"sha256:repro"}, nil
+}
+func (c *nilReproRegistryClient) Get(opts registry.Opts) (*registry.Repository, error) {
+	return &registry.Repository{Name: opts.Name}, nil
+}
+func (c *nilReproRegistryClient) Platforms(opts registry.Opts) ([]types.Platform, error) {
+	return nil, nil
+}
+
+// newNilReproWatcher builds a RepositoryWatcher wired with a non-piercing
+// registry client so addJob reaches the image-reference handling without
+// touching the network.
+func newNilReproWatcher() *RepositoryWatcher {
+	w := NewRepositoryWatcher(nil, &nilReproRegistryClient{})
+	return w
+}
+
+// TestAddJobNilImage panics (before the fix) when a tracked image carries a
+// nil *image.Reference, mimicking a malformed/helm-provider image shape.
+func TestAddJobNilImage(t *testing.T) {
+	w := newNilReproWatcher()
+	ti := &types.TrackedImage{
+		Image:        nil,
+		PollSchedule: types.KeelPollDefaultSchedule,
+		Trigger:      types.TriggerTypePoll,
+		Policy:       policy.NewForcePolicy(true),
+	}
+	err := w.addJob(ti, types.KeelPollDefaultSchedule, nil)
+	if err == nil {
+		t.Fatalf("expected an error for a nil image, got none")
+	}
+	if _, ok := w.watched["repro"]; ok {
+		t.Errorf("nil image should not create a watcher entry")
+	}
+}
+
+// TestAddJobUnparsedReference reproduces a reference whose underlying named is
+// nil (the shape produced by a helm chart image that fails to resolve), which
+// panics in Registry()/ShortName() before the fix.
+func TestAddJobUnparsedReference(t *testing.T) {
+	w := newNilReproWatcher()
+	ti := &types.TrackedImage{
+		Image:        &image.Reference{},
+		PollSchedule: types.KeelPollDefaultSchedule,
+		Trigger:      types.TriggerTypePoll,
+		Policy:       policy.NewForcePolicy(true),
+	}
+	_, err := w.watch(ti, nil)
+	if err == nil {
+		t.Fatalf("expected an error for an unparsable image reference, got none")
+	}
+}
+
+// TestWatchSkipsBadReleaseButSurvives ensures one malformed release cannot
+// take down the whole poll loop: a bad image is skipped while a valid one
+// still gets watched.
+func TestWatchSkipsBadReleaseButSurvives(t *testing.T) {
+	w := newNilReproWatcher()
+	good, err := image.Parse("gcr.io/v2-namespace/hello-world:1.1.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := &types.TrackedImage{
+		Image:        nil,
+		PollSchedule: types.KeelPollDefaultSchedule,
+		Trigger:      types.TriggerTypePoll,
+		Policy:       policy.NewForcePolicy(true),
+	}
+	goodTI := &types.TrackedImage{
+		Image:        good,
+		PollSchedule: types.KeelPollDefaultSchedule,
+		Trigger:      types.TriggerTypePoll,
+		Policy:       policy.NewForcePolicy(true),
+	}
+
+	w.Watch(bad, goodTI)
+
+	if _, ok := w.watched["gcr.io/v2-namespace/hello-world:1.1.1"]; !ok {
+		t.Fatalf("valid image should still be watched despite the bad release")
+	}
+}

--- a/util/image/parse.go
+++ b/util/image/parse.go
@@ -43,6 +43,15 @@ func (r Reference) Scheme() string {
 	return r.scheme
 }
 
+// IsNil reports whether the reference is nil or was never parsed into a valid
+// named reference (e.g. a zero-valued *Reference). Safe to call on a nil pointer.
+func (r *Reference) IsNil() bool {
+	if r == nil {
+		return true
+	}
+	return r.named == nil
+}
+
 // Repository returns the image's repository. (ie: registry/name)
 func (r Reference) Repository() string {
 	return r.named.FullName()


### PR DESCRIPTION
## Summary
A tracked image carrying a nil `*image.Reference` — or a zero-valued / unparsed
reference (the shape a helm chart image can produce when it fails to resolve) —
panicked the poll watcher with a nil-pointer dereference. `addJob` calls
`Image.Scheme()`, `Image.Registry()`, and `Image.ShortName()`, and the
`Watch`/`watch` paths call `getImageIdentifier`, all of which dereference the
reference's unexported `named` field and panic instead of returning an error.

This adds `Reference.IsNil()` — safe to call on a nil pointer, and true for a
zero-valued (`&Reference{}`) reference — and guards the three call sites:

- `Watch` skips a malformed image in both the running-digests loop and the main
  loop, recording an error instead of crashing;
- `watch` returns an error up front for a nil/unparsable reference;
- `addJob` returns an error before touching the reference.

A malformed image is now skipped with a recorded error while valid images in the
same batch continue to be watched — one bad release can no longer take the whole
poll loop down.

## Testing
- New reproduction tests in `trigger/poll/watcher_nil_repro_test.go`:
  - `TestAddJobNilImage` — nil image reference yields an error and no watcher entry;
  - `TestAddJobUnparsedReference` — zero-valued reference yields an error instead of a panic in `Registry()`/`ShortName()`;
  - `TestWatchSkipsBadReleaseButSurvives` — a bad image is skipped while a valid one in the same batch is still watched.
  All three panicked against the pre-fix source and pass with the fix.
- `go test ./trigger/poll/... ./util/image/...` passes.
- `go build ./...` compiles; `go vet` is clean for the changed code (the only remaining vet output is pre-existing json-tag noise on unexported fields in `util/image/parse.go`).

LFG!