### PR TITLE
Make node metadata access failures actionable

### DIFF
--- a/deployment/deployment-template.yaml
+++ b/deployment/deployment-template.yaml
@@ -25,7 +25,9 @@ rules:
       - ""
     resources:
       - namespaces
+      - nodes
     verbs:
+      - get
       - watch
       - list
   - apiGroups:

--- a/deployment/deployment_template_test.go
+++ b/deployment/deployment_template_test.go
@@ -1,0 +1,50 @@
+package deployment
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	rbac_v1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestDeploymentTemplateGrantsNodeMetadataAccess(t *testing.T) {
+	contents, err := os.ReadFile("deployment-template.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var clusterRole rbac_v1.ClusterRole
+	found := false
+	for _, document := range strings.Split(string(contents), "---") {
+		if !strings.Contains(document, "kind: ClusterRole\n") {
+			continue
+		}
+		if err := yaml.Unmarshal([]byte(document), &clusterRole); err != nil {
+			t.Fatalf("parse ClusterRole: %v", err)
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatal("deployment template does not contain a ClusterRole")
+	}
+
+	for _, rule := range clusterRole.Rules {
+		if contains(rule.APIGroups, "") && contains(rule.Resources, "nodes") &&
+			contains(rule.Verbs, "get") && contains(rule.Verbs, "list") && contains(rule.Verbs, "watch") {
+			return
+		}
+	}
+	t.Fatal("deployment template ClusterRole must grant get, list, and watch on core/v1 nodes")
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/k8s/platform.go
+++ b/internal/k8s/platform.go
@@ -8,10 +8,15 @@ import (
 	"time"
 
 	"github.com/keel-hq/keel/types"
+	"github.com/sirupsen/logrus"
 	core_v1 "k8s.io/api/core/v1"
 )
 
-const nodeCacheTTL = 30 * time.Second
+const (
+	nodeCacheTTL         = 30 * time.Second
+	nodeErrorLogThrottle = 30 * time.Second
+	nodeRBACRemediation  = "grant Keel's service account get, list, and watch access to the core/v1 nodes resource"
+)
 
 // NodeLister supplies Kubernetes node scheduling and platform metadata.
 type NodeLister interface {
@@ -25,15 +30,18 @@ type podLister interface {
 // PlatformResolver derives a conservative eligible platform set for workloads.
 type PlatformResolver struct {
 	nodes NodeLister
+	log   logrus.FieldLogger
 
-	mu        sync.Mutex
-	cached    []core_v1.Node
-	expiresAt time.Time
+	mu                      sync.Mutex
+	cached                  []core_v1.Node
+	expiresAt               time.Time
+	lastNodeListError       string
+	lastNodeListErrorLogged time.Time
 }
 
 // NewPlatformResolver creates a resolver backed by Kubernetes Node metadata.
 func NewPlatformResolver(nodes NodeLister) *PlatformResolver {
-	return &PlatformResolver{nodes: nodes}
+	return &PlatformResolver{nodes: nodes, log: logrus.StandardLogger()}
 }
 
 // Resolve returns every platform on which the workload may be scheduled.
@@ -107,14 +115,35 @@ func (r *PlatformResolver) listNodes() ([]core_v1.Node, error) {
 	}
 	list, err := r.nodes.Nodes()
 	if err != nil {
+		r.logNodeListFailure(err)
 		return nil, err
 	}
+	r.lastNodeListError = ""
+	r.lastNodeListErrorLogged = time.Time{}
 	if list == nil {
 		return nil, fmt.Errorf("node list is nil")
 	}
 	r.cached = append(r.cached[:0], list.Items...)
 	r.expiresAt = time.Now().Add(nodeCacheTTL)
 	return append([]core_v1.Node(nil), r.cached...), nil
+}
+
+// logNodeListFailure emits the Kubernetes API error with an actionable RBAC
+// hint. Node resolution runs once per workload, so identical errors are
+// throttled to avoid flooding the logs when a cluster contains many workloads.
+// r.mu must be held by the caller.
+func (r *PlatformResolver) logNodeListFailure(err error) {
+	message := err.Error()
+	now := time.Now()
+	if message == r.lastNodeListError && now.Sub(r.lastNodeListErrorLogged) < nodeErrorLogThrottle {
+		return
+	}
+	r.lastNodeListError = message
+	r.lastNodeListErrorLogged = now
+	r.log.WithFields(logrus.Fields{
+		"error":       err,
+		"remediation": nodeRBACRemediation,
+	}).Warn("platform resolver: failed to list Kubernetes nodes; workload updates are blocked because platform compatibility cannot be verified")
 }
 
 func nodePlatform(node *core_v1.Node) (types.Platform, bool) {

--- a/internal/k8s/platform_test.go
+++ b/internal/k8s/platform_test.go
@@ -2,9 +2,11 @@ package k8s
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/keel-hq/keel/types"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	core_v1 "k8s.io/api/core/v1"
@@ -172,6 +174,37 @@ func TestPlatformResolverFailsClosed(t *testing.T) {
 				t.Fatalf("got %v (%s), want no platforms and %s", platforms, resolutionErr, test.want)
 			}
 		})
+	}
+}
+
+func TestPlatformResolverExplainsNodeAPIFailure(t *testing.T) {
+	resource, err := NewGenericResource(&apps_v1.Deployment{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger, hook := logrustest.NewNullLogger()
+	resolver := NewPlatformResolver(&fakePlatformSource{err: fmt.Errorf("nodes is forbidden")})
+	resolver.log = logger
+
+	for range 2 {
+		if _, resolutionErr := resolver.Resolve(resource); resolutionErr != types.PlatformErrorNodeMetadata {
+			t.Fatalf("got %s, want %s", resolutionErr, types.PlatformErrorNodeMetadata)
+		}
+	}
+
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("got %d diagnostic entries, want one throttled entry", len(entries))
+	}
+	entry := entries[0]
+	if !strings.Contains(entry.Message, "workload updates are blocked") {
+		t.Fatalf("diagnostic message is not actionable: %q", entry.Message)
+	}
+	if got := entry.Data["remediation"]; got != nodeRBACRemediation {
+		t.Fatalf("got remediation %q, want %q", got, nodeRBACRemediation)
+	}
+	if got := fmt.Sprint(entry.Data["error"]); got != "nodes is forbidden" {
+		t.Fatalf("got underlying error %q", got)
 	}
 }
 

--- a/trigger/poll/multi_tags_watcher.go
+++ b/trigger/poll/multi_tags_watcher.go
@@ -102,10 +102,14 @@ func (j *WatchRepositoryTagsJob) computeEvents(tags []string) ([]types.Event, er
 			if reason == types.PlatformErrorNone {
 				reason = types.PlatformErrorWorkloadMetadata
 			}
-			log.WithFields(log.Fields{
+			fields := log.Fields{
 				"image":  trackedImage.Image.Repository(),
 				"reason": reason,
-			}).Warn("trigger.poll.WatchRepositoryTagsJob: skipping workload because its eligible platforms could not be established")
+			}
+			if reason == types.PlatformErrorNodeMetadata {
+				fields["remediation"] = "verify Keel's service account can list core/v1 nodes and that each node reports status.nodeInfo.operatingSystem and architecture"
+			}
+			log.WithFields(fields).Warn("trigger.poll.WatchRepositoryTagsJob: skipping workload because its eligible platforms could not be established")
 			continue
 		}
 

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -3,6 +3,7 @@ package poll
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -656,6 +657,14 @@ func TestCandidateSelectionFailsClosedForUnresolvedWorkload(t *testing.T) {
 		t.Fatalf("unresolved workload evaluated a candidate: events=%#v calls=%v", events, registryClient.platformCalls)
 	}
 	assertLogMessage(t, hook, "skipping workload because its eligible platforms could not be established")
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, "skipping workload because its eligible platforms could not be established") {
+			if !strings.Contains(fmt.Sprint(entry.Data["remediation"]), "service account can list core/v1 nodes") {
+				t.Fatalf("missing actionable node remediation in log fields: %#v", entry.Data)
+			}
+			return
+		}
+	}
 }
 
 func assertLogMessage(t *testing.T, hook *logrustest.Hook, message string) {


### PR DESCRIPTION
## Summary

- log the original Kubernetes Node API error when workload platform resolution fails
- explain that updates are blocked and include the required Node RBAC remediation
- throttle repeated Node API diagnostics across workloads
- add the same actionable remediation to the polling skip warning
- bring the legacy static deployment template's Node RBAC in line with the Helm chart
- add regression coverage for the diagnostics, throttling, and static manifest permissions

Related to #909.

## Testing

- `go test ./...`
- `go test -race ./internal/k8s ./trigger/poll ./deployment`
- `git diff --check`
- independent review found no blocking correctness, concurrency, RBAC, or compatibility issues

`make release-validate` completed chart lint/render and the release-equivalent image build, including UI checks. The required k3s rollout, probe, and end-to-end validation could not start in the current macOS environment because the harness requires Linux commands that are unavailable here: `findmnt`, `ip`, `setsid`, and `ss`.
