### PR TITLE
Automate matching Helm chart releases

### DIFF
--- a/.agents/skills/release-keel/SKILL.md
+++ b/.agents/skills/release-keel/SKILL.md
@@ -14,13 +14,15 @@ Release application images before publishing the GitHub Release, then release an
 - Never move, overwrite, or reuse a public release tag. Correct the source and choose a new version after a failed publication.
 - Use a clean release commit on `master`. Do not tag an unmerged feature branch or a commit whose required CI failed.
 - Treat the application Git tag as the application build version. Treat `Chart.yaml.appVersion` as the version installed by that chart release.
+- Before tagging an application release, bump `Chart.yaml.version` and set `Chart.yaml.appVersion` to the application version. CI rejects an application tag when these versions drift.
+- Any change under `chart/keel/` must increase `Chart.yaml.version`; CI enforces this on pull requests and direct `master` pushes.
 - Run `make release-validate` for any chart metadata or template change and confirm the Deployment, probes, and k3s suite pass.
 
 ## Inspect readiness
 
 1. Run `git status -sb`, `gh auth status`, and inspect the latest application and chart releases.
 2. Confirm the proposed application tag, GHCR tag, GitHub Release, chart tag, chart GitHub Release, and Helm index version do not already exist.
-3. Inspect `chart/keel/Chart.yaml`. To publish a chart for the new application, set `appVersion` to the application version and choose an unused chart `version`.
+3. Inspect `chart/keel/Chart.yaml`. Set `appVersion` to the application version and choose an unused, increased chart `version`; the application release automatically publishes that chart.
 4. Run a tag rehearsal before creating remote state:
 
    ```bash
@@ -39,20 +41,21 @@ Release application images before publishing the GitHub Release, then release an
    git push origin <app-version>
    ```
 
-4. Monitor the tag's `CI` workflow. Require unit, UI, package, k3s release, behavioral, amd64, arm64, manifest, and GitHub Release jobs to succeed.
-5. Verify `ghcr.io/keel-hq/keel:<app-version>` is an amd64/arm64 index and the GitHub Release exists only after it.
+4. Monitor the tag's `CI` workflow. Require unit, UI, package, k3s release, behavioral, amd64, arm64, manifest, GitHub Release, and matching Helm chart jobs to succeed.
+5. Verify `ghcr.io/keel-hq/keel:<app-version>` is an amd64/arm64 index, the GitHub Release exists only after it, and the public chart references the same application version.
 
 Do not manually create the GitHub Release before the image. The `github-release` CI job owns that step.
 
 ### Tag correspondence
 
-- Application Git tag `<app-version>` is plain SemVer, e.g. `0.22.1` (not `keel-v0.22.1`). It drives the `ghcr.io/keel-hq/keel:<app-version>` and `latest` image tags.
-- `keel-v<version>` is a chart release tag, created from the `chart-v<version>` Git tag by `releasecharts.yaml`; it is a GitHub release containing the Helm chart archive, not an application image tag.
+- Application Git tag `<app-version>` is plain SemVer, e.g. `0.22.2` (not `keel-v0.22.2`). It drives the `ghcr.io/keel-hq/keel:<app-version>` and `latest` image tags.
+- `keel-v<version>` is the chart-releaser GitHub release tag containing the Helm archive. For normal application releases it is created automatically after the application image and GitHub Release pass verification.
+- `chart-v<version>` remains available for an explicitly authorized chart-only release or recovery; it invokes the same guarded chart workflow.
 - Never publish an application image under a `keel-v*` tag, and never create `keel-v*` from an application Git tag.
 
-## Publish a chart
+## Publish a chart-only change
 
-Publish a chart only after its `appVersion` has both a non-draft GitHub application release and verified amd64/arm64 GHCR image.
+Normal application releases publish their matching chart automatically. Use a chart-only tag only when chart templates or defaults must be released without a new application, and only after its `appVersion` has both a non-draft GitHub application release and verified amd64/arm64 GHCR image.
 
 ```bash
 git tag -a chart-v<chart-version> -m "Keel chart v<chart-version>" <release-commit>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a chart version bump for chart changes
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/'))
+        env:
+          KEEL_CHART_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: ./scripts/check-chart-version-bump.sh
 
       - name: Build release-equivalent package
         env:
           KEEL_RELEASE_EXPORT_IMAGE: "true"
+          KEEL_ENFORCE_UNPUBLISHED: ${{ startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/chart-') }}
         run: make release-package
 
       - name: Share immutable release package
@@ -424,3 +433,12 @@ jobs:
             echo "Unexpected GitHub Release state: $release_state" >&2
             exit 1
           fi
+
+  chart-release:
+    name: Publish matching Helm chart
+    needs: github-release
+    if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/chart-') && needs.github-release.result == 'success'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/releasecharts.yaml
+    secrets: inherit

--- a/.github/workflows/releasecharts.yaml
+++ b/.github/workflows/releasecharts.yaml
@@ -1,5 +1,7 @@
 name: Release Charts
 on:
+  workflow_call:
+  workflow_dispatch:
   push:
     tags:
       - "chart-*"

--- a/.test/chart-version.sh
+++ b/.test/chart-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT
+CHECKER="${REPO_ROOT}/scripts/check-chart-version-bump.sh"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "${FIXTURE}"' EXIT
+
+git -C "${FIXTURE}" init --quiet
+git -C "${FIXTURE}" config user.name chart-version-test
+git -C "${FIXTURE}" config user.email chart-version-test@example.invalid
+mkdir -p "${FIXTURE}/chart/keel"
+printf 'version: 1.2.0\nappVersion: 0.22.1\n' >"${FIXTURE}/chart/keel/Chart.yaml"
+printf 'replicas: 1\n' >"${FIXTURE}/chart/keel/values.yaml"
+git -C "${FIXTURE}" add chart/keel
+git -C "${FIXTURE}" commit --quiet -m base
+base_ref="$(git -C "${FIXTURE}" rev-parse HEAD)"
+
+printf 'replicas: 2\n' >"${FIXTURE}/chart/keel/values.yaml"
+git -C "${FIXTURE}" add chart/keel/values.yaml
+git -C "${FIXTURE}" commit --quiet -m chart-change
+if (cd "${FIXTURE}" && KEEL_CHART_BASE_REF="${base_ref}" "${CHECKER}") >/dev/null 2>&1; then
+  printf '[chart-version-test] ERROR: chart change without a version bump was accepted\n' >&2
+  exit 1
+fi
+
+sed -i.bak 's/version: 1.2.0/version: 1.2.1/' "${FIXTURE}/chart/keel/Chart.yaml"
+rm "${FIXTURE}/chart/keel/Chart.yaml.bak"
+git -C "${FIXTURE}" add chart/keel/Chart.yaml
+git -C "${FIXTURE}" commit --quiet -m version-bump
+(cd "${FIXTURE}" && KEEL_CHART_BASE_REF="${base_ref}" "${CHECKER}") >/dev/null
+
+printf '[chart-version-test] chart changes require a version increase\n'

--- a/.test/release-version.sh
+++ b/.test/release-version.sh
@@ -17,4 +17,10 @@ if GITHUB_REF=refs/tags/not-semver "${RESOLVER}" >/dev/null 2>&1; then
   exit 1
 fi
 
+if GITHUB_REF=refs/tags/9.8.7 KEEL_RELEASE_SKIP_IMAGE=true \
+  "${REPO_ROOT}/scripts/package-release.sh" >/dev/null 2>&1; then
+  printf '[release-version-test] ERROR: application tag without matching chart appVersion was accepted\n' >&2
+  exit 1
+fi
+
 printf '[release-version-test] application version resolution passed\n'

--- a/.test/release-workflow.sh
+++ b/.test/release-workflow.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 readonly REPO_ROOT
 workflow="${REPO_ROOT}/.github/workflows/ci.yml"
+chart_workflow="${REPO_ROOT}/.github/workflows/releasecharts.yaml"
 
 if grep -Eq 'DOCKERHUB_|hub\.docker\.com|keelhq/keel' "${workflow}"; then
   printf '[release-workflow-test] ERROR: CI release workflow must publish only to GHCR\n' >&2
@@ -13,5 +14,10 @@ fi
 
 grep -Fq 'outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true' "${workflow}"
 grep -Fq 'IMAGE_NAME: ghcr.io/${{ github.repository }}' "${workflow}"
+grep -Fq 'run: ./scripts/check-chart-version-bump.sh' "${workflow}"
+grep -Fq 'KEEL_ENFORCE_UNPUBLISHED: ${{ startsWith(github.ref,' "${workflow}"
+grep -Fq 'needs: github-release' "${workflow}"
+grep -Fq 'uses: ./.github/workflows/releasecharts.yaml' "${workflow}"
+grep -Fq 'workflow_call:' "${chart_workflow}"
 
-printf '[release-workflow-test] GHCR-only publication passed\n'
+printf '[release-workflow-test] GHCR-only application and automatic chart publication passed\n'

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ARMFLAGS		+= -X github.com/keel-hq/keel/version.BuildDate=$(JOBDATE)
 
 release-lint:
 	bash -n .test/*.sh scripts/*.sh
+	./.test/chart-version.sh
 	./.test/release-version.sh
 	./.test/release-workflow.sh
 	go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7

--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 name: keel
 description: Open source tool for automating Kubernetes deployment updates.
-# Bump this version for each chart release, then push tag "chart-v{version}".
-# See .github/workflows/releasecharts.yaml and the release-keel agent skill.
-version: 1.2.0
-appVersion: 0.22.1
+# Increase this version for every chart change. Application releases publish the
+# matching chart automatically; chart-v{version} is reserved for chart-only releases.
+version: 1.2.1
+appVersion: 0.22.2
 keywords:
 - kubernetes deployment
 - helm release

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -6,20 +6,21 @@ This document describes the release path as audited on 2026-08-14. Local release
 
 Keel has two related release paths.
 
-An application release starts with a SemVer Git tag such as `0.22.1`. `.github/workflows/ci.yml` runs Go tests, the UI install/typecheck/lint/test/build, API generation checks, and the packaged-chart k3s suite before any image job can publish. Native amd64 and arm64 jobs build `Dockerfile`, push content-addressed images without tags to `ghcr.io/keel-hq/keel`, and the manifest job creates the version tag and `latest` only after both digests exist. It then verifies that every produced tag resolves to the same amd64/arm64 index. Only after that verification does the final job create the public GitHub Release from the existing tag. The workflow needs `contents: read`; only image publication jobs receive `packages: write`, and only the final release job receives `contents: write`. Pull requests do not log in or publish; they are validated by the both-arch `docker-pr` build.
+An application release starts with a SemVer Git tag such as `0.22.2`. `.github/workflows/ci.yml` runs Go tests, the UI install/typecheck/lint/test/build, API generation checks, and the packaged-chart k3s suite before any image job can publish. Native amd64 and arm64 jobs build `Dockerfile`, push content-addressed images without tags to `ghcr.io/keel-hq/keel`, and the manifest job creates the version tag and `latest` only after both digests exist. It then verifies that every produced tag resolves to the same amd64/arm64 index. Only after that verification does the workflow create the public GitHub Release from the existing tag and call the chart workflow to publish the matching `Chart.yaml.version`. The application tag must equal `Chart.yaml.appVersion`, so a successful application release always has a chart that installs the same image version. Pull requests do not log in or publish; they are validated by the both-arch `docker-pr` build.
 
-A chart release starts with `chart-v<Chart.yaml version>`. `.github/workflows/releasecharts.yaml` validates the tag, packages the source chart without editing it, and confirms that `Chart.yaml.appVersion` already has a public GitHub application release and amd64/arm64 GHCR image. Only then does chart-releaser package the chart, create the `keel-v<chart version>` GitHub release asset, and update the GitHub Pages Helm index. The validation job has `contents: read`; only chart-releaser receives `contents: write`. The workflow cannot run from `pull_request`.
+`.github/workflows/releasecharts.yaml` is a reusable workflow called automatically by a successful application-tag run. It can also be invoked by `workflow_dispatch` or an explicitly authorized `chart-v<Chart.yaml version>` tag for chart-only releases and recovery. It validates the source metadata, applies the historical leading `v` only to the packaged chart version, and confirms that `Chart.yaml.appVersion` already has a public GitHub application release and amd64/arm64 GHCR image. Only then does chart-releaser create the `keel-v<chart version>` GitHub release asset and update the GitHub Pages Helm index. The validation job has `contents: read`; only chart-releaser receives `contents: write`.
 
 `chart/keel/Chart.yaml` is the release contract:
 
-- The SemVer application Git tag is the canonical application build version. `scripts/resolve-application-version.sh` uses it for application-tag builds, so an application release is not blocked by a chart that intentionally references an older application.
-- `appVersion` is the application version installed by the source chart. Before publishing that chart, it must exactly match an existing application GitHub Release and amd64/arm64 GHCR image.
-- `version` is the canonical source chart version; the trigger must be `chart-v${version}`. The shared packager and the chart release's temporary checkout add the historical leading `v` to packaged chart metadata and filenames.
-- The application Git tag is plain SemVer (e.g. `0.22.1`). It names the `ghcr.io/keel-hq/keel:<version>` image tag plus `latest`. The `keel-v*` Git-tag form belongs **only** to chart releases (it is the GitHub release asset name emitted by a `chart-v*` tag); it is not an application image tag and must never be used to publish an application image.
+- The SemVer application Git tag is the canonical application build version. `scripts/resolve-application-version.sh` uses it for application-tag builds, and packaging rejects the tag unless it equals the source chart's `appVersion`.
+- `appVersion` is the application version installed by the source chart. Before tagging an application, it must be set to that application version; before publishing the chart, it must exactly match an existing application GitHub Release and amd64/arm64 GHCR image.
+- `version` is the canonical source chart version. Application releases publish it automatically; an optional chart-only trigger must be `chart-v${version}`. The shared packager and the chart release's temporary checkout add the historical leading `v` to packaged chart metadata and filenames.
+- Any committed change under `chart/keel/` must increase `version`. CI compares the candidate against the pull-request base or preceding `master` commit and fails before packaging when chart content changed without a version increase.
+- The application Git tag is plain SemVer (e.g. `0.22.2`). It names the `ghcr.io/keel-hq/keel:<version>` image tag plus `latest`. The `keel-v*` Git-tag form belongs **only** to chart releases (it is the GitHub release asset name emitted by chart-releaser); it is not an application image tag and must never be used to publish an application image.
 - `Dockerfile` receives the validated application version and Git revision as build arguments. Its fallback tag discovery remains available for ordinary developer builds.
 - The chart defaults its image tag to `appVersion`. Validation renders and inspects that exact wiring and packages with explicit `--version` and `--app-version` arguments.
 
-This makes tag, binary, container, and chart drift fail before publication without coupling the application release train to chart publication. A chart release also refuses to run when its GitHub release or Helm index version already exists. An application image release refuses to overwrite an existing GHCR release tag. Branch tags such as `master` retain their existing mutable semantics. Application and chart releases use global concurrency groups so two versions cannot race while updating `latest` or the Helm index.
+This makes tag, binary, container, and chart drift fail before publication. The application tag's package gate and the downstream chart workflow both refuse to proceed when the chart's GitHub release or Helm index version already exists. An application image release refuses to overwrite an existing GHCR release tag. Branch tags such as `master` retain their existing mutable semantics. Application and chart releases use global concurrency groups so two versions cannot race while updating `latest` or the Helm index.
 
 ## Local commands
 
@@ -44,26 +45,26 @@ make published-release-check
 For a tag rehearsal without publishing, set `GITHUB_REF` locally. These examples should pass only when metadata agrees:
 
 ```bash
-GITHUB_REF=refs/tags/0.22.1 make release-package
-GITHUB_REF=refs/tags/chart-v1.2.0 KEEL_RELEASE_SKIP_IMAGE=true make release-package
+GITHUB_REF=refs/tags/0.22.2 make release-package
+GITHUB_REF=refs/tags/chart-v1.2.1 KEEL_RELEASE_SKIP_IMAGE=true make release-package
 ```
 
 ## Publishing sequence
 
-Prepare release metadata through a PR and run `make release-validate` whenever the chart changes. After the release commit is merged and its `master` CI succeeds, push only an annotated application tag:
+Prepare release metadata through a PR: set `Chart.yaml.appVersion` to the application version and increase `Chart.yaml.version`. Run `make release-validate`, merge the PR, and wait for its `master` CI. Then push only an annotated application tag:
 
 ```bash
-git tag -a 0.22.1 -m "Keel 0.22.1" <release-commit>
-git push origin 0.22.1
+git tag -a 0.22.2 -m "Keel 0.22.2" <release-commit>
+git push origin 0.22.2
 ```
 
-Do not create the GitHub Release manually. The tag CI publishes and verifies the versioned GHCR image and `latest`, then creates the GitHub Release as its final job. Creating a GitHub Release first publishes user-visible metadata before the release artifacts have passed validation.
+Do not create the GitHub Release or ordinary matching chart release manually. The tag CI publishes and verifies the versioned GHCR image and `latest`, creates the GitHub Release, then invokes the guarded chart workflow. Creating either release first publishes user-visible metadata before its dependencies have passed validation.
 
-To publish the chart after the application release is verified, push the chart tag from the same release commit:
+For an explicitly authorized chart-only change, push the chart tag from its validated release commit:
 
 ```bash
-git tag -a chart-v1.2.0 -m "Keel chart v1.2.0" <release-commit>
-git push origin chart-v1.2.0
+git tag -a chart-v1.2.1 -m "Keel chart v1.2.1" <release-commit>
+git push origin chart-v1.2.1
 ```
 
 Follow `.agents/skills/release-keel/SKILL.md` for the agent-operated readiness, publication, verification, and recovery workflow.

--- a/scripts/check-chart-version-bump.sh
+++ b/scripts/check-chart-version-bump.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT
+BASE_REF="${KEEL_CHART_BASE_REF:-${1:-}}"
+TARGET_REF="${KEEL_CHART_TARGET_REF:-HEAD}"
+CHART_PATH="chart/keel"
+CHART_FILE="${CHART_PATH}/Chart.yaml"
+
+fail() { printf '[chart-version] ERROR: %s\n' "$*" >&2; exit 1; }
+log() { printf '[chart-version] %s\n' "$*"; }
+
+version_from_ref() {
+  git -C "${REPO_ROOT}" show "$1:${CHART_FILE}" |
+    awk '$1 == "version:" {print $2; exit}'
+}
+
+semver_gt() {
+  local candidate="${1#v}" previous="${2#v}"
+  local candidate_core="${candidate%%+*}" previous_core="${previous%%+*}"
+  local candidate_pre="" previous_pre=""
+  local -a candidate_parts previous_parts candidate_ids previous_ids
+  local index candidate_id previous_id
+
+  if [[ "${candidate_core}" == *-* ]]; then
+    candidate_pre="${candidate_core#*-}"
+    candidate_core="${candidate_core%%-*}"
+  fi
+  if [[ "${previous_core}" == *-* ]]; then
+    previous_pre="${previous_core#*-}"
+    previous_core="${previous_core%%-*}"
+  fi
+  [[ "${candidate_core}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  [[ "${previous_core}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+
+  IFS=. read -r -a candidate_parts <<<"${candidate_core}"
+  IFS=. read -r -a previous_parts <<<"${previous_core}"
+  for index in 0 1 2; do
+    if ((10#${candidate_parts[index]} > 10#${previous_parts[index]})); then
+      return 0
+    fi
+    if ((10#${candidate_parts[index]} < 10#${previous_parts[index]})); then
+      return 1
+    fi
+  done
+
+  [[ -z "${previous_pre}" && -n "${candidate_pre}" ]] && return 1
+  [[ -n "${previous_pre}" && -z "${candidate_pre}" ]] && return 0
+  [[ -z "${previous_pre}" && -z "${candidate_pre}" ]] && return 1
+
+  IFS=. read -r -a candidate_ids <<<"${candidate_pre}"
+  IFS=. read -r -a previous_ids <<<"${previous_pre}"
+  for ((index = 0; index < ${#candidate_ids[@]} || index < ${#previous_ids[@]}; index++)); do
+    [[ ${index} -ge ${#candidate_ids[@]} ]] && return 1
+    [[ ${index} -ge ${#previous_ids[@]} ]] && return 0
+    candidate_id="${candidate_ids[index]}"
+    previous_id="${previous_ids[index]}"
+    [[ "${candidate_id}" == "${previous_id}" ]] && continue
+    if [[ "${candidate_id}" =~ ^[0-9]+$ && "${previous_id}" =~ ^[0-9]+$ ]]; then
+      ((10#${candidate_id} > 10#${previous_id})) && return 0
+      return 1
+    fi
+    [[ "${candidate_id}" =~ ^[0-9]+$ ]] && return 1
+    [[ "${previous_id}" =~ ^[0-9]+$ ]] && return 0
+    [[ "${candidate_id}" > "${previous_id}" ]]
+    return
+  done
+  return 1
+}
+
+[[ -n "${BASE_REF}" ]] || fail "KEEL_CHART_BASE_REF or a base-ref argument is required"
+if [[ "${BASE_REF}" =~ ^0+$ ]]; then
+  log "no base commit exists; skipping the initial branch push"
+  exit 0
+fi
+git -C "${REPO_ROOT}" cat-file -e "${BASE_REF}:${CHART_FILE}" 2>/dev/null || \
+  fail "base ref ${BASE_REF} does not contain ${CHART_FILE}"
+git -C "${REPO_ROOT}" cat-file -e "${TARGET_REF}:${CHART_FILE}" 2>/dev/null || \
+  fail "target ref ${TARGET_REF} does not contain ${CHART_FILE}"
+
+if git -C "${REPO_ROOT}" diff --quiet "${BASE_REF}" "${TARGET_REF}" -- "${CHART_PATH}"; then
+  log "no Helm chart changes detected"
+  exit 0
+fi
+
+base_version="$(version_from_ref "${BASE_REF}")"
+target_version="$(version_from_ref "${TARGET_REF}")"
+[[ -n "${base_version}" && -n "${target_version}" ]] || fail "could not read chart versions"
+semver_gt "${target_version}" "${base_version}" || \
+  fail "chart files changed, but Chart.yaml version did not increase (${base_version} -> ${target_version})"
+
+log "chart version increased from ${base_version} to ${target_version}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -8,6 +8,7 @@ ARTIFACT_DIR="${KEEL_RELEASE_ARTIFACT_DIR:-${REPO_ROOT}/.test/release-artifacts}
 HELM_BIN="${HELM_BIN:-${ARTIFACT_DIR}/bin/helm}"
 CHART_DIR="${REPO_ROOT}/chart/keel"
 APP_VERSION="$("${REPO_ROOT}/scripts/resolve-application-version.sh")"
+SOURCE_APP_VERSION="$(awk '$1 == "appVersion:" {print $2; exit}' "${CHART_DIR}/Chart.yaml")"
 CHART_VERSION="${KEEL_CHART_VERSION:-$(awk '$1 == "version:" {print $2; exit}' "${CHART_DIR}/Chart.yaml")}"
 PACKAGED_CHART_VERSION="v${CHART_VERSION#v}"
 REVISION="${KEEL_BUILD_REVISION:-$(git -C "${REPO_ROOT}" rev-parse --short=12 HEAD)}"
@@ -34,25 +35,28 @@ if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
   if [[ "${tag}" == chart-* ]]; then
     [[ "${tag}" == "chart-v${CHART_VERSION#v}" ]] || \
       fail "chart tag ${tag} must equal chart-v${CHART_VERSION#v} from Chart.yaml"
-    if [[ "${KEEL_ENFORCE_UNPUBLISHED:-false}" == "true" ]]; then
-      release_tag="keel-v${CHART_VERSION#v}"
-      status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
-        "https://api.github.com/repos/keel-hq/keel/releases/tags/${release_tag}")"
-      case "${status}" in
-        404) ;;
-        200) fail "GitHub chart release ${release_tag} already exists; refusing to overwrite it" ;;
-        *) fail "could not establish whether GitHub chart release ${release_tag} exists (HTTP ${status})" ;;
-      esac
-      curl --fail --location --show-error --silent --output "${ARTIFACT_DIR}/public-index.yaml" \
-        https://keel-hq.github.io/keel/index.yaml || fail "could not read the public Helm index"
-      if awk -v wanted="${CHART_VERSION}" '$1 == "version:" {gsub(/\"/, "", $2); if ($2 == wanted || $2 == "v" wanted) found=1} END {exit !found}' \
-        "${ARTIFACT_DIR}/public-index.yaml"; then
-        fail "chart ${CHART_VERSION} already exists in the public Helm index; refusing to overwrite it"
-      fi
-    fi
   else
     [[ "${tag}" == "${APP_VERSION}" ]] || \
       fail "application tag ${tag} must equal appVersion ${APP_VERSION} from Chart.yaml"
+    [[ "${SOURCE_APP_VERSION}" == "${APP_VERSION}" ]] || \
+      fail "Chart.yaml appVersion ${SOURCE_APP_VERSION} must equal application tag ${tag} so the matching chart can be published"
+  fi
+fi
+
+if [[ "${KEEL_ENFORCE_UNPUBLISHED:-false}" == "true" ]]; then
+  release_tag="keel-v${CHART_VERSION#v}"
+  status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+    "https://api.github.com/repos/keel-hq/keel/releases/tags/${release_tag}")"
+  case "${status}" in
+    404) ;;
+    200) fail "GitHub chart release ${release_tag} already exists; refusing to overwrite it" ;;
+    *) fail "could not establish whether GitHub chart release ${release_tag} exists (HTTP ${status})" ;;
+  esac
+  curl --fail --location --show-error --silent --output "${ARTIFACT_DIR}/public-index.yaml" \
+    https://keel-hq.github.io/keel/index.yaml || fail "could not read the public Helm index"
+  if awk -v wanted="${CHART_VERSION}" '$1 == "version:" {gsub(/\"/, "", $2); if ($2 == wanted || $2 == "v" wanted) found=1} END {exit !found}' \
+    "${ARTIFACT_DIR}/public-index.yaml"; then
+    fail "chart ${CHART_VERSION} already exists in the public Helm index; refusing to overwrite it"
   fi
 fi
 


### PR DESCRIPTION
Closes #912.

## Summary

- publish the matching Helm chart automatically after the application image and GitHub Release are verified
- reject application tags unless `Chart.yaml.appVersion` matches the tag
- reject chart changes unless `Chart.yaml.version` increases
- reject reused chart versions before application image publication and again before chart publication
- prepare chart `1.2.1` with appVersion `0.22.2`
- retain manual chart-only tags and add a guarded workflow dispatch for recovery/catch-up releases

## Validation

- `make test`
- `make release-lint`
- `GITHUB_REF=refs/tags/0.22.2 KEEL_RELEASE_SKIP_IMAGE=true KEEL_ENFORCE_UNPUBLISHED=true make release-package`
- `KEEL_CHART_BASE_REF=origin/master scripts/check-chart-version-bump.sh`
- `make release-validate` completed chart lint/render/package and the release-equivalent image build; the local macOS host then stopped because the native k3s harness requires Linux `findmnt`. Required Linux k3s CI is expected to provide install, upgrade, rollout, probe, and behavioral validation.