### PR TITLE
Fix chart release workflow lint failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,7 @@ jobs:
           KEEL_APP_VERSION="$app_version" ./scripts/resolve-application-version.sh >/dev/null
           echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
 
-          previous_sha=$(git rev-parse --verify --quiet refs/tags/nightly^{commit} || true)
+          previous_sha=$(git rev-parse --verify --quiet 'refs/tags/nightly^{commit}' || true)
           if [[ "$FORCE_BUILD" == "true" ]]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             echo "Forced nightly build of $head_sha" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The first guarded chart 1.2.1 dispatch failed before publication because GitHub runner ShellCheck treated the unquoted nightly revision expression as literal braces.

This quotes the revision expression so release workflow linting can complete.

No chart release or Helm index entry was created by the failed run.

Validation: `make release-lint`.