### PR TITLE
fix(helm): stop decoding release history every 3 seconds

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -209,6 +209,7 @@ Set via `keel.sh/approvals: "2"` annotation to require N approvals.
 | `UI_DIR` | Web UI static files | `www` |
 | `KUBERNETES_CONFIG` | Kubeconfig path | `~/.kube/config` |
 | `POLL_DEFAULTSCHEDULE` | Default poll interval | `@every 1m` |
+| `POLL_SCAN_INTERVAL` | Tracked workload discovery interval | `1m` |
 
 Empty environment values are treated as unset so manifests that render
 `value: ""` continue to receive the documented defaults. Boolean settings use

--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -450,7 +450,7 @@ func setupTriggers(ctx context.Context, opts *TriggerOpts) (teardown func()) {
 
 		registryClient := registry.New()
 		watcher := poll.NewRepositoryWatcher(opts.providers, registryClient)
-		pollManager := poll.NewPollManager(opts.providers, watcher)
+		pollManager := poll.NewPollManager(opts.providers, watcher, opts.appConfig.Trigger.PollScanInterval)
 
 		// start poll manager, will finish with ctx
 		go watcher.Start(ctx)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -12,7 +13,7 @@ import (
 var loadMutex sync.Mutex
 
 var environmentVariables = []string{
-	"DEBUG", "PUBSUB", "POLL", "PROJECT_ID", "CLUSTER_NAME", "XDG_DATA_HOME", "HELM3_PROVIDER", "UI_DIR",
+	"DEBUG", "PUBSUB", "POLL", "POLL_SCAN_INTERVAL", "PROJECT_ID", "CLUSTER_NAME", "XDG_DATA_HOME", "HELM3_PROVIDER", "UI_DIR",
 	"NOTIFICATION_LEVEL", "WEBHOOK_ENDPOINT", "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_BOT_NAME", "SLACK_CHANNELS", "SLACK_APPROVALS_CHANNEL",
 	"HIPCHAT_SERVER", "HIPCHAT_TOKEN", "HIPCHAT_BOT_NAME", "HIPCHAT_CHANNELS", "HIPCHAT_APPROVALS_CHANNEL", "HIPCHAT_APPROVALS_USER_NAME",
 	"HIPCHAT_APPROVALS_BOT_NAME", "HIPCHAT_APPROVALS_PASSWORT", "HIPCHAT_CONNECTION_ATTEMPTS", "MATTERMOST_ENDPOINT", "MATTERMOST_USERNAME",
@@ -36,10 +37,11 @@ type Config struct {
 
 // TriggerConfig controls the event sources that detect and initiate image updates.
 type TriggerConfig struct {
-	PubSub      bool   `ignored:"true"`
-	Poll        bool   `envconfig:"POLL" default:"true"`
-	ProjectID   string `envconfig:"PROJECT_ID"`
-	ClusterName string `envconfig:"CLUSTER_NAME"`
+	PubSub           bool          `ignored:"true"`
+	Poll             bool          `envconfig:"POLL" default:"true"`
+	PollScanInterval time.Duration `envconfig:"POLL_SCAN_INTERVAL" default:"1m"`
+	ProjectID        string        `envconfig:"PROJECT_ID"`
+	ClusterName      string        `envconfig:"CLUSTER_NAME"`
 }
 
 // StorageConfig controls where Keel stores its persistent application data.
@@ -213,6 +215,9 @@ func Load() (Config, error) {
 		if err := envconfig.Process("", section); err != nil {
 			return Config{}, err
 		}
+	}
+	if cfg.Trigger.PollScanInterval <= 0 {
+		return Config{}, fmt.Errorf("POLL_SCAN_INTERVAL must be greater than zero")
 	}
 
 	cfg.Debug = root.Debug

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ func TestLoadDefaults(t *testing.T) {
 	cfg, err := Load()
 	require.NoError(t, err)
 	require.Equal(t, Config{
-		Trigger: TriggerConfig{Poll: true}, Storage: StorageConfig{DataDir: "/data"}, UI: UIConfig{Dir: "www"},
+		Trigger: TriggerConfig{Poll: true, PollScanInterval: time.Minute}, Storage: StorageConfig{DataDir: "/data"}, UI: UIConfig{Dir: "www"},
 		Notifications: NotificationConfig{
 			Level: "info", Slack: SlackNotificationConfig{BotName: "keel"}, Hipchat: HipchatNotificationConfig{BotName: "keel"},
 			Mattermost: MattermostConfig{Username: "keel"}, Shoutrrr: ShoutrrrConfig{Timeout: "10s"}, Mail: MailConfig{SMTPPort: 25},
@@ -33,13 +34,14 @@ func TestLoadDefaults(t *testing.T) {
 
 func TestLoadTreatsExplicitlyEmptyValuesAsUnset(t *testing.T) {
 	clearConfigurationEnvironment(t)
-	for _, name := range []string{"POLL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
+	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
 		t.Setenv(name, "")
 	}
 
 	cfg, err := Load()
 	require.NoError(t, err)
 	require.True(t, cfg.Trigger.Poll)
+	require.Equal(t, time.Minute, cfg.Trigger.PollScanInterval)
 	require.False(t, cfg.Trigger.PubSub)
 	require.False(t, cfg.Debug)
 	require.False(t, cfg.Providers.Helm3)
@@ -47,7 +49,7 @@ func TestLoadTreatsExplicitlyEmptyValuesAsUnset(t *testing.T) {
 	require.Equal(t, 25, cfg.Notifications.Mail.SMTPPort)
 	require.Equal(t, 5, cfg.Bots.Hipchat.ConnectionAttempts)
 
-	for _, name := range []string{"POLL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
+	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
 		value, ok := os.LookupEnv(name)
 		require.True(t, ok, "%s should remain set", name)
 		require.Empty(t, value, "%s should remain empty", name)
@@ -95,7 +97,7 @@ func TestLoadIgnoresNestedAliasNames(t *testing.T) {
 func TestLoadMapsEveryTypedPath(t *testing.T) {
 	clearConfigurationEnvironment(t)
 	values := map[string]string{
-		"DEBUG": "true", "PUBSUB": "true", "POLL": "false", "PROJECT_ID": "project", "CLUSTER_NAME": "cluster", "XDG_DATA_HOME": "/var/lib/keel", "HELM3_PROVIDER": "true", "UI_DIR": "/ui",
+		"DEBUG": "true", "PUBSUB": "true", "POLL": "false", "POLL_SCAN_INTERVAL": "45s", "PROJECT_ID": "project", "CLUSTER_NAME": "cluster", "XDG_DATA_HOME": "/var/lib/keel", "HELM3_PROVIDER": "true", "UI_DIR": "/ui",
 		"NOTIFICATION_LEVEL": "warn", "WEBHOOK_ENDPOINT": "https://webhook", "SLACK_BOT_TOKEN": "xoxb-typed", "SLACK_APP_TOKEN": "xapp-typed", "SLACK_BOT_NAME": "typed-bot", "SLACK_CHANNELS": "one,two", "SLACK_APPROVALS_CHANNEL": "approvals",
 		"HIPCHAT_SERVER": "https://hipchat", "HIPCHAT_TOKEN": "hip-token", "HIPCHAT_BOT_NAME": "hip-notifier", "HIPCHAT_CHANNELS": "ops,dev", "HIPCHAT_APPROVALS_CHANNEL": "hip-approvals", "HIPCHAT_APPROVALS_USER_NAME": "hip-user", "HIPCHAT_APPROVALS_BOT_NAME": "hip-bot", "HIPCHAT_APPROVALS_PASSWORT": "hip-pass", "HIPCHAT_CONNECTION_ATTEMPTS": "4",
 		"MATTERMOST_ENDPOINT": "https://mattermost", "MATTERMOST_USERNAME": "matter-bot", "TEAMS_WEBHOOK_URL": "https://teams", "DISCORD_WEBHOOK_URL": "https://discord", "SHOUTRRR_URLS": "discord://token@id", "SHOUTRRR_TIMEOUT": "3s",
@@ -108,7 +110,7 @@ func TestLoadMapsEveryTypedPath(t *testing.T) {
 	cfg, err := Load()
 	require.NoError(t, err)
 	require.Equal(t, Config{
-		Debug: true, Trigger: TriggerConfig{PubSub: true, ProjectID: "project", ClusterName: "cluster"}, Storage: StorageConfig{DataDir: "/var/lib/keel"}, Providers: ProviderConfig{Helm3: true}, UI: UIConfig{Dir: "/ui"},
+		Debug: true, Trigger: TriggerConfig{PubSub: true, PollScanInterval: 45 * time.Second, ProjectID: "project", ClusterName: "cluster"}, Storage: StorageConfig{DataDir: "/var/lib/keel"}, Providers: ProviderConfig{Helm3: true}, UI: UIConfig{Dir: "/ui"},
 		Notifications: NotificationConfig{Level: "warn", Webhook: WebhookConfig{Endpoint: "https://webhook"}, Slack: SlackNotificationConfig{BotToken: "xoxb-typed", BotName: "typed-bot", Channels: "one,two"}, Hipchat: HipchatNotificationConfig{Server: "https://hipchat", Token: "hip-token", BotName: "hip-notifier", Channels: "ops,dev"}, Mattermost: MattermostConfig{Endpoint: "https://mattermost", Username: "matter-bot"}, Teams: TeamsConfig{WebhookURL: "https://teams"}, Discord: DiscordConfig{WebhookURL: "https://discord"}, Shoutrrr: ShoutrrrConfig{URLs: "discord://token@id", Timeout: "3s"}, Mail: MailConfig{To: "to@example.com", From: "from@example.com", SMTPServer: "smtp.example.com", SMTPPort: 2525, SMTPUser: "smtp-user", SMTPPass: "smtp-pass"}},
 		Bots:          BotConfig{Slack: SlackBotConfig{BotToken: "xoxb-typed", AppToken: "xapp-typed", BotName: "typed-bot", ApprovalsChannel: "approvals"}, Hipchat: HipchatBotConfig{ApprovalsChannel: "hip-approvals", ApprovalsUserName: "hip-user", ApprovalsBotName: "hip-bot", ApprovalsPassword: "hip-pass", ConnectionAttempts: 4}},
 		Auth:          AuthConfig{BasicUser: "admin", BasicPassword: "secret", AuthenticatedWebhooks: true, TokenSecret: "token-secret", Mode: "proxy", ProxyUserHeader: "X-User", ProxyLogoutURL: "https://logout"}, Kubernetes: KubernetesConfig{RestrictedNamespace: "production"},
@@ -116,7 +118,7 @@ func TestLoadMapsEveryTypedPath(t *testing.T) {
 }
 
 func TestLoadRejectsInvalidTypedValues(t *testing.T) {
-	for _, tt := range []struct{ name, key, value string }{{"boolean", "POLL", "sometimes"}, {"integer", "MAIL_SMTP_PORT", "smtp"}, {"nested integer", "HIPCHAT_CONNECTION_ATTEMPTS", "many"}} {
+	for _, tt := range []struct{ name, key, value string }{{"boolean", "POLL", "sometimes"}, {"duration", "POLL_SCAN_INTERVAL", "soon"}, {"non-positive duration", "POLL_SCAN_INTERVAL", "0s"}, {"integer", "MAIL_SMTP_PORT", "smtp"}, {"nested integer", "HIPCHAT_CONNECTION_ATTEMPTS", "many"}} {
 		t.Run(tt.name, func(t *testing.T) {
 			clearConfigurationEnvironment(t)
 			t.Setenv(tt.key, tt.value)

--- a/provider/helm3/implementer.go
+++ b/provider/helm3/implementer.go
@@ -1,7 +1,9 @@
 package helm3
 
 import (
+	"errors"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	// "helm.sh/helm/v3/pkg/cli"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -53,14 +56,75 @@ func NewHelm3Implementer() *Helm3Implementer {
 // ListReleases - list available releases
 func (i *Helm3Implementer) ListReleases() ([]*release.Release, error) {
 	actionConfig := i.generateConfig("")
-	client := action.NewList(actionConfig)
-	results, err := client.Run()
+	if err := actionConfig.KubeClient.IsReachable(); err != nil {
+		return nil, err
+	}
+	results, err := listCurrentReleases(actionConfig.Releases)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Fatal("helm3: failed to list release")
-		return []*release.Release{}, err
+		}).Error("helm3: failed to list releases")
+		return nil, err
 	}
+	return results, nil
+}
+
+type releaseQuerier interface {
+	Query(map[string]string) ([]*release.Release, error)
+}
+
+var currentReleaseStatuses = []release.Status{
+	release.StatusUnknown,
+	release.StatusDeployed,
+	release.StatusUninstalled,
+	release.StatusFailed,
+	release.StatusUninstalling,
+	release.StatusPendingInstall,
+	release.StatusPendingUpgrade,
+	release.StatusPendingRollback,
+}
+
+// listCurrentReleases uses Helm's storage labels to avoid retrieving and
+// decoding superseded revisions. It still considers every non-superseded
+// status when selecting the latest revision, matching action.List semantics
+// during installs, upgrades, rollbacks, and uninstalls.
+func listCurrentReleases(storage releaseQuerier) ([]*release.Release, error) {
+	latest := make(map[string]*release.Release)
+	for _, status := range currentReleaseStatuses {
+		releases, err := storage.Query(map[string]string{
+			"owner":  "helm",
+			"status": status.String(),
+		})
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, candidate := range releases {
+			if candidate == nil {
+				continue
+			}
+			key := candidate.Namespace + "\x00" + candidate.Name
+			if existing := latest[key]; existing == nil || candidate.Version > existing.Version {
+				latest[key] = candidate
+			}
+		}
+	}
+
+	results := make([]*release.Release, 0, len(latest))
+	for _, candidate := range latest {
+		if candidate.Info == nil || (candidate.Info.Status != release.StatusDeployed && candidate.Info.Status != release.StatusFailed) {
+			continue
+		}
+		results = append(results, candidate)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Name != results[j].Name {
+			return results[i].Name < results[j].Name
+		}
+		return results[i].Namespace < results[j].Namespace
+	})
 	return results, nil
 }
 
@@ -112,9 +176,12 @@ func (i *Helm3Implementer) generateConfig(namespace string) *action.Configuratio
 
 // convert map[string]string to map[string]interface
 // converts:
-//     map[string]string{"image.tag": "0.1.0"}
+//
+//	map[string]string{"image.tag": "0.1.0"}
+//
 // to:
-//     map[string]interface{"image": map[string]interface{"tag": "0.1.0"}}
+//
+//	map[string]interface{"image": map[string]interface{"tag": "0.1.0"}}
 func convertToInterface(values map[string]string) map[string]interface{} {
 	converted := make(map[string]interface{})
 	for key, value := range values {

--- a/provider/helm3/implementer_test.go
+++ b/provider/helm3/implementer_test.go
@@ -1,8 +1,77 @@
 package helm3
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
+
+type fakeReleaseQuerier struct {
+	releases map[string][]*release.Release
+	err      error
+	queries  []map[string]string
+}
+
+func (q *fakeReleaseQuerier) Query(labels map[string]string) ([]*release.Release, error) {
+	q.queries = append(q.queries, labels)
+	if q.err != nil {
+		return nil, q.err
+	}
+	results := q.releases[labels["status"]]
+	if len(results) == 0 {
+		return nil, driver.ErrReleaseNotFound
+	}
+	return results, nil
+}
+
+func helmRelease(namespace, name string, version int, status release.Status) *release.Release {
+	return &release.Release{
+		Namespace: namespace,
+		Name:      name,
+		Version:   version,
+		Info:      &release.Info{Status: status},
+	}
+}
+
+func TestListCurrentReleasesFiltersAtStorageLayerAndPreservesLatestSemantics(t *testing.T) {
+	querier := &fakeReleaseQuerier{releases: map[string][]*release.Release{
+		release.StatusDeployed.String(): {
+			helmRelease("apps", "current", 2, release.StatusDeployed),
+			helmRelease("apps", "upgrading", 3, release.StatusDeployed),
+			helmRelease("other", "current", 4, release.StatusDeployed),
+		},
+		release.StatusFailed.String(): {
+			helmRelease("apps", "failed", 5, release.StatusFailed),
+			helmRelease("apps", "current", 1, release.StatusFailed),
+		},
+		release.StatusPendingUpgrade.String(): {
+			helmRelease("apps", "upgrading", 4, release.StatusPendingUpgrade),
+		},
+	}}
+
+	results, err := listCurrentReleases(querier)
+	require.NoError(t, err)
+	require.Equal(t, []*release.Release{
+		helmRelease("apps", "current", 2, release.StatusDeployed),
+		helmRelease("other", "current", 4, release.StatusDeployed),
+		helmRelease("apps", "failed", 5, release.StatusFailed),
+	}, results)
+
+	require.Len(t, querier.queries, len(currentReleaseStatuses))
+	for _, labels := range querier.queries {
+		require.Equal(t, "helm", labels["owner"])
+		require.NotEqual(t, release.StatusSuperseded.String(), labels["status"])
+	}
+}
+
+func TestListCurrentReleasesReturnsStorageErrors(t *testing.T) {
+	expected := errors.New("storage unavailable")
+	_, err := listCurrentReleases(&fakeReleaseQuerier{err: expected})
+	require.ErrorIs(t, err, expected)
+}
 
 func TestImplementerList(t *testing.T) {
 	t.Skip()

--- a/tests/e2e_resources_test.go
+++ b/tests/e2e_resources_test.go
@@ -136,6 +136,7 @@ func keelDeployment(cfg e2eConfig) *appsv1.Deployment {
 							{Name: "INSECURE_REGISTRY", Value: "true"},
 							{Name: "POLL", Value: "true"},
 							{Name: "POLL_DEFAULTSCHEDULE", Value: "@every 2s"},
+							{Name: "POLL_SCAN_INTERVAL", Value: "2s"},
 						},
 						Ports:          []corev1.ContainerPort{{Name: "http", ContainerPort: 9300}},
 						ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("http")}}, InitialDelaySeconds: 1, PeriodSeconds: 1, FailureThreshold: 30},

--- a/trigger/poll/manager.go
+++ b/trigger/poll/manager.go
@@ -2,13 +2,17 @@ package poll
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/keel-hq/keel/provider"
 
 	log "github.com/sirupsen/logrus"
 )
+
+// DefaultScanInterval controls how often providers are re-enumerated. Registry
+// checks keep their own per-image schedules; this interval only discovers
+// changes to the set of tracked workloads.
+const DefaultScanInterval = time.Minute
 
 // DefaultManager - default manager is responsible for scanning deployments and identifying
 // deployments that have market
@@ -18,22 +22,23 @@ type DefaultManager struct {
 	// repository watcher
 	watcher Watcher
 
-	mu *sync.Mutex
-
-	// scanTick - scan interval in seconds, defaults to 60 seconds
-	scanTick int
+	// scanInterval is the interval between provider re-enumerations.
+	scanInterval time.Duration
 
 	// root context
 	ctx context.Context
 }
 
 // NewPollManager - new default poller
-func NewPollManager(providers provider.Providers, watcher Watcher) *DefaultManager {
+func NewPollManager(providers provider.Providers, watcher Watcher, intervals ...time.Duration) *DefaultManager {
+	scanInterval := DefaultScanInterval
+	if len(intervals) > 0 && intervals[0] > 0 {
+		scanInterval = intervals[0]
+	}
 	return &DefaultManager{
-		providers: providers,
-		watcher:   watcher,
-		mu:        &sync.Mutex{},
-		scanTick:  3,
+		providers:    providers,
+		watcher:      watcher,
+		scanInterval: scanInterval,
 	}
 }
 
@@ -42,7 +47,7 @@ func (s *DefaultManager) Start(ctx context.Context) error {
 	// setting root context
 	s.ctx = ctx
 
-	log.Info("trigger.poll.manager: polling trigger configured")
+	log.WithField("scan_interval", s.scanInterval).Info("trigger.poll.manager: polling trigger configured")
 
 	// initial scan
 	err := s.scan(ctx)
@@ -52,7 +57,7 @@ func (s *DefaultManager) Start(ctx context.Context) error {
 		}).Error("trigger.poll.manager: scan failed")
 	}
 
-	ticker := time.NewTicker(time.Duration(s.scanTick) * time.Second)
+	ticker := time.NewTicker(s.scanInterval)
 	defer ticker.Stop()
 
 	for {

--- a/trigger/poll/manager_test.go
+++ b/trigger/poll/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/keel-hq/keel/approvals"
 	"github.com/keel-hq/keel/pkg/store/sql"
@@ -21,6 +22,23 @@ import (
 
 	"testing"
 )
+
+func TestPollManagerScanInterval(t *testing.T) {
+	defaultManager := NewPollManager(nil, nil)
+	if defaultManager.scanInterval != time.Minute {
+		t.Fatalf("expected default scan interval %s, got %s", time.Minute, defaultManager.scanInterval)
+	}
+
+	customManager := NewPollManager(nil, nil, 15*time.Second)
+	if customManager.scanInterval != 15*time.Second {
+		t.Fatalf("expected custom scan interval %s, got %s", 15*time.Second, customManager.scanInterval)
+	}
+
+	invalidManager := NewPollManager(nil, nil, 0)
+	if invalidManager.scanInterval != time.Minute {
+		t.Fatalf("expected invalid interval to use default %s, got %s", time.Minute, invalidManager.scanInterval)
+	}
+}
 
 type FakeSecretsGetter struct {
 }


### PR DESCRIPTION
## Summary

- change tracked-workload discovery from the accidental 3-second cadence to the documented 1-minute default
- make that cadence configurable with `POLL_SCAN_INTERVAL`
- query Helm storage by non-superseded status so retained historical revisions are neither transferred nor decoded
- preserve Helm's latest-revision behavior during pending installs, upgrades, rollbacks, uninstalls, and failures

## Root cause

The poll manager synchronously calls every provider's `TrackedImages()` every 3 seconds. Helm's normal list action retrieves and decodes every `owner=helm` record before it filters superseded revisions and selects the latest release.

The latent loop became much more visible in 0.22.2 because Helm tracked-image discovery gained platform and running-digest resolution. Those add workload scans and live pod lookups to every enumeration, making it easier for an enumeration to consume the full 3-second period and run continuously. On clusters with retained Helm history, profiles then spend much of that continuous work decoding release Secrets.

This change addresses both multipliers: scans happen 20x less often by default, and each scan no longer fetches or decodes superseded history.

Closes #916.

## Validation

- `go test ./...`
- `go test -race ./trigger/poll ./pkg/config ./provider/helm3`
- release-equivalent image and chart packaging completed successfully through `make release-validate`
- local k3s phase could not start on macOS because the harness requires the Linux-only `findmnt` command; the PR's Ubuntu release-e2e jobs provide the required rollout, probe, and k3s validation
