### PR TITLE
chore(release): prepare 0.22.3

### DIFF
--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -3,8 +3,8 @@ name: keel
 description: Open source tool for automating Kubernetes deployment updates.
 # Increase this version for every chart change. Application releases publish the
 # matching chart automatically; chart-v{version} is reserved for chart-only releases.
-version: 1.2.1
-appVersion: 0.22.2
+version: 1.2.2
+appVersion: 0.22.3
 keywords:
 - kubernetes deployment
 - helm release


### PR DESCRIPTION
Prepare the release metadata for Keel 0.22.3.

- bump the Helm chart from 1.2.1 to 1.2.2
- align `appVersion` with Keel 0.22.3

Validation:
- `GITHUB_REF=refs/tags/0.22.3 make release-package` ✅
- `make release-validate` package phase ✅; local k3s phase could not start on macOS because the harness requires the Linux-only `findmnt` command. The pull request CI is the authoritative Linux k3s validation gate.