### PR TITLE
fix(kubernetes): stop starving Keel on the API server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -210,6 +210,9 @@ Set via `keel.sh/approvals: "2"` annotation to require N approvals.
 | `KUBERNETES_CONFIG` | Kubeconfig path | `~/.kube/config` |
 | `POLL_DEFAULTSCHEDULE` | Default poll interval | `@every 1m` |
 | `POLL_SCAN_INTERVAL` | Tracked workload discovery interval | `1m` |
+| `KUBERNETES_CLIENT_QPS` | Client side API rate limit (negative disables it) | `20` |
+| `KUBERNETES_CLIENT_BURST` | Client side API burst | `40` |
+| `KUBERNETES_POD_CACHE_TTL` | Pod listing cache lifetime (`0` disables it) | `30s` |
 
 Empty environment values are treated as unset so manifests that render
 `value: ""` continue to receive the documented defaults. Boolean settings use

--- a/chart/keel/Chart.yaml
+++ b/chart/keel/Chart.yaml
@@ -3,7 +3,7 @@ name: keel
 description: Open source tool for automating Kubernetes deployment updates.
 # Increase this version for every chart change. Application releases publish the
 # matching chart automatically; chart-v{version} is reserved for chart-only releases.
-version: 1.2.2
+version: 1.3.0
 appVersion: 0.22.3
 keywords:
 - kubernetes deployment

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -97,6 +97,21 @@ spec:
             - name: POLL_DEFAULTSCHEDULE
               value: "{{ .Values.polling.defaultSchedule }}"
 {{- end }}
+{{- if .Values.kubernetesClient }}
+{{- if .Values.kubernetesClient.qps }}
+            # Kubernetes API client rate limits
+            - name: KUBERNETES_CLIENT_QPS
+              value: "{{ .Values.kubernetesClient.qps }}"
+{{- end }}
+{{- if .Values.kubernetesClient.burst }}
+            - name: KUBERNETES_CLIENT_BURST
+              value: "{{ .Values.kubernetesClient.burst }}"
+{{- end }}
+{{- if .Values.kubernetesClient.podCacheTTL }}
+            - name: KUBERNETES_POD_CACHE_TTL
+              value: "{{ .Values.kubernetesClient.podCacheTTL }}"
+{{- end }}
+{{- end }}
 {{- if .Values.helmProvider.enabled }}
             # Enable/disable Helm provider
             - name: HELM3_PROVIDER

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -27,6 +27,16 @@ polling:
   enabled: true
   defaultSchedule: "@every 1m"
 
+# Kubernetes API client tuning. Keel lists the pods of every tracked workload
+# to resolve platforms and running digests, so clusters with many tracked
+# workloads or many watched images need more than the client-go defaults
+# (5 QPS / burst 10) to avoid client side throttling.
+kubernetesClient:
+  qps: 20
+  burst: 40
+  # how long a pod listing is reused, "0" disables the cache
+  podCacheTTL: 30s
+
 # Extra Containers to run alongside Keel
 # extraContainers:
 #   - name: busybox

--- a/cmd/keel/main.go
+++ b/cmd/keel/main.go
@@ -179,6 +179,8 @@ func main() {
 	// getting k8s provider
 	k8sCfg := &kubernetes.Opts{
 		ConfigPath: *kubeconfig,
+		QPS:        cfg.Kubernetes.ClientQPS,
+		Burst:      cfg.Kubernetes.ClientBurst,
 	}
 
 	if os.Getenv(EnvKubernetesConfig) != "" {
@@ -195,12 +197,22 @@ func main() {
 
 	k8sCfg.InCluster = *inCluster
 
-	implementer, err := kubernetes.NewKubernetesImplementer(k8sCfg)
+	kubernetesImplementer, err := kubernetes.NewKubernetesImplementer(k8sCfg)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error":  err,
 			"config": k8sCfg,
 		}).Fatal("main: failed to create kubernetes implementer")
+	}
+
+	// pods are listed for every tracked workload on every poll scan and on
+	// every watcher tick, so a short lived cache keeps that traffic
+	// proportional to the number of workloads instead of to the number of
+	// workloads multiplied by the number of watched images
+	var implementer kubernetes.Implementer = kubernetesImplementer
+	if cfg.Kubernetes.PodCacheTTL > 0 {
+		implementer = kubernetes.NewCachingImplementer(kubernetesImplementer, cfg.Kubernetes.PodCacheTTL)
+		log.WithField("ttl", cfg.Kubernetes.PodCacheTTL).Info("main: pod listing cache enabled")
 	}
 
 	var g workgroup.Group
@@ -211,10 +223,10 @@ func main() {
 
 	buf := k8s.NewBuffer(&g, t, log.StandardLogger(), 128)
 	wl := log.WithField("context", "watch")
-	k8s.WatchDeployments(&g, implementer.Client(), wl, cfg.Kubernetes, buf)
-	k8s.WatchStatefulSets(&g, implementer.Client(), wl, cfg.Kubernetes, buf)
-	k8s.WatchDaemonSets(&g, implementer.Client(), wl, cfg.Kubernetes, buf)
-	k8s.WatchCronJobs(&g, implementer.Client(), wl, cfg.Kubernetes, buf)
+	k8s.WatchDeployments(&g, kubernetesImplementer.Client(), wl, cfg.Kubernetes, buf)
+	k8s.WatchStatefulSets(&g, kubernetesImplementer.Client(), wl, cfg.Kubernetes, buf)
+	k8s.WatchDaemonSets(&g, kubernetesImplementer.Client(), wl, cfg.Kubernetes, buf)
+	k8s.WatchCronJobs(&g, kubernetesImplementer.Client(), wl, cfg.Kubernetes, buf)
 
 	// approvalsCache := memory.NewMemoryCache()
 	approvalsManager := approvals.New(&approvals.Opts{
@@ -243,8 +255,8 @@ func main() {
 		approvalsManager: approvalsManager,
 		grc:              &t.GenericResourceCache,
 		store:            sqlStore,
-		k8sClient:        implementer.Client(),
-		config:           implementer.Config(),
+		k8sClient:        kubernetesImplementer.Client(),
+		config:           kubernetesImplementer.Config(),
 		appConfig:        cfg,
 	})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var environmentVariables = []string{
 	"TEAMS_WEBHOOK_URL", "DISCORD_WEBHOOK_URL", "SHOUTRRR_URLS", "SHOUTRRR_TIMEOUT", "MAIL_TO", "MAIL_FROM", "MAIL_SMTP_SERVER",
 	"MAIL_SMTP_PORT", "MAIL_SMTP_USER", "MAIL_SMTP_PASS", "BASIC_AUTH_USER", "BASIC_AUTH_PASSWORD", "AUTHENTICATED_WEBHOOKS",
 	"TOKEN_SECRET", "AUTH_MODE", "AUTH_PROXY_USER_HEADER", "AUTH_PROXY_LOGOUT_URL", "RESTRICTED_NAMESPACE",
+	"KUBERNETES_CLIENT_QPS", "KUBERNETES_CLIENT_BURST", "KUBERNETES_POD_CACHE_TTL",
 }
 
 // Config contains Keel's application configuration loaded from environment variables.
@@ -167,9 +168,21 @@ type AuthConfig struct {
 	ProxyLogoutURL        string `envconfig:"AUTH_PROXY_LOGOUT_URL"`
 }
 
-// KubernetesConfig controls the scope of Kubernetes resources watched by Keel.
+// KubernetesConfig controls the scope of Kubernetes resources watched by Keel
+// and how hard Keel is allowed to hit the API server.
 type KubernetesConfig struct {
 	RestrictedNamespace string `envconfig:"RESTRICTED_NAMESPACE"`
+
+	// ClientQPS and ClientBurst size the client-go rate limiter. The library
+	// defaults (5 QPS, burst 10) are a CLI setting and are quickly saturated
+	// by a cluster with many tracked workloads. A negative QPS disables
+	// client side rate limiting and leaves throttling to the API server.
+	ClientQPS   float32 `envconfig:"KUBERNETES_CLIENT_QPS" default:"20"`
+	ClientBurst int     `envconfig:"KUBERNETES_CLIENT_BURST" default:"40"`
+
+	// PodCacheTTL is how long a pod listing is reused across the platform and
+	// running digest resolvers. Zero disables the cache.
+	PodCacheTTL time.Duration `envconfig:"KUBERNETES_POD_CACHE_TTL" default:"30s"`
 }
 
 // Load reads configuration from environment variables.
@@ -218,6 +231,12 @@ func Load() (Config, error) {
 	}
 	if cfg.Trigger.PollScanInterval <= 0 {
 		return Config{}, fmt.Errorf("POLL_SCAN_INTERVAL must be greater than zero")
+	}
+	if cfg.Kubernetes.ClientQPS == 0 {
+		return Config{}, fmt.Errorf("KUBERNETES_CLIENT_QPS must not be zero, use a negative value to disable client side rate limiting")
+	}
+	if cfg.Kubernetes.PodCacheTTL < 0 {
+		return Config{}, fmt.Errorf("KUBERNETES_POD_CACHE_TTL must not be negative")
 	}
 
 	cfg.Debug = root.Debug

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,13 +28,14 @@ func TestLoadDefaults(t *testing.T) {
 			Level: "info", Slack: SlackNotificationConfig{BotName: "keel"}, Hipchat: HipchatNotificationConfig{BotName: "keel"},
 			Mattermost: MattermostConfig{Username: "keel"}, Shoutrrr: ShoutrrrConfig{Timeout: "10s"}, Mail: MailConfig{SMTPPort: 25},
 		},
-		Bots: BotConfig{Slack: SlackBotConfig{BotName: "keel", ApprovalsChannel: "general"}, Hipchat: HipchatBotConfig{ApprovalsChannel: "general", ApprovalsBotName: "keel", ConnectionAttempts: 5}},
+		Bots:       BotConfig{Slack: SlackBotConfig{BotName: "keel", ApprovalsChannel: "general"}, Hipchat: HipchatBotConfig{ApprovalsChannel: "general", ApprovalsBotName: "keel", ConnectionAttempts: 5}},
+		Kubernetes: KubernetesConfig{ClientQPS: 20, ClientBurst: 40, PodCacheTTL: 30 * time.Second},
 	}, cfg)
 }
 
 func TestLoadTreatsExplicitlyEmptyValuesAsUnset(t *testing.T) {
 	clearConfigurationEnvironment(t)
-	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
+	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS", "KUBERNETES_CLIENT_QPS", "KUBERNETES_CLIENT_BURST", "KUBERNETES_POD_CACHE_TTL"} {
 		t.Setenv(name, "")
 	}
 
@@ -49,7 +50,7 @@ func TestLoadTreatsExplicitlyEmptyValuesAsUnset(t *testing.T) {
 	require.Equal(t, 25, cfg.Notifications.Mail.SMTPPort)
 	require.Equal(t, 5, cfg.Bots.Hipchat.ConnectionAttempts)
 
-	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS"} {
+	for _, name := range []string{"POLL", "POLL_SCAN_INTERVAL", "PUBSUB", "DEBUG", "HELM3_PROVIDER", "AUTHENTICATED_WEBHOOKS", "MAIL_SMTP_PORT", "HIPCHAT_CONNECTION_ATTEMPTS", "KUBERNETES_CLIENT_QPS", "KUBERNETES_CLIENT_BURST", "KUBERNETES_POD_CACHE_TTL"} {
 		value, ok := os.LookupEnv(name)
 		require.True(t, ok, "%s should remain set", name)
 		require.Empty(t, value, "%s should remain empty", name)
@@ -103,6 +104,7 @@ func TestLoadMapsEveryTypedPath(t *testing.T) {
 		"MATTERMOST_ENDPOINT": "https://mattermost", "MATTERMOST_USERNAME": "matter-bot", "TEAMS_WEBHOOK_URL": "https://teams", "DISCORD_WEBHOOK_URL": "https://discord", "SHOUTRRR_URLS": "discord://token@id", "SHOUTRRR_TIMEOUT": "3s",
 		"MAIL_TO": "to@example.com", "MAIL_FROM": "from@example.com", "MAIL_SMTP_SERVER": "smtp.example.com", "MAIL_SMTP_PORT": "2525", "MAIL_SMTP_USER": "smtp-user", "MAIL_SMTP_PASS": "smtp-pass",
 		"BASIC_AUTH_USER": "admin", "BASIC_AUTH_PASSWORD": "secret", "AUTHENTICATED_WEBHOOKS": "true", "TOKEN_SECRET": "token-secret", "AUTH_MODE": "proxy", "AUTH_PROXY_USER_HEADER": "X-User", "AUTH_PROXY_LOGOUT_URL": "https://logout", "RESTRICTED_NAMESPACE": "production",
+		"KUBERNETES_CLIENT_QPS": "35", "KUBERNETES_CLIENT_BURST": "70", "KUBERNETES_POD_CACHE_TTL": "15s",
 	}
 	for key, value := range values {
 		t.Setenv(key, value)
@@ -113,12 +115,12 @@ func TestLoadMapsEveryTypedPath(t *testing.T) {
 		Debug: true, Trigger: TriggerConfig{PubSub: true, PollScanInterval: 45 * time.Second, ProjectID: "project", ClusterName: "cluster"}, Storage: StorageConfig{DataDir: "/var/lib/keel"}, Providers: ProviderConfig{Helm3: true}, UI: UIConfig{Dir: "/ui"},
 		Notifications: NotificationConfig{Level: "warn", Webhook: WebhookConfig{Endpoint: "https://webhook"}, Slack: SlackNotificationConfig{BotToken: "xoxb-typed", BotName: "typed-bot", Channels: "one,two"}, Hipchat: HipchatNotificationConfig{Server: "https://hipchat", Token: "hip-token", BotName: "hip-notifier", Channels: "ops,dev"}, Mattermost: MattermostConfig{Endpoint: "https://mattermost", Username: "matter-bot"}, Teams: TeamsConfig{WebhookURL: "https://teams"}, Discord: DiscordConfig{WebhookURL: "https://discord"}, Shoutrrr: ShoutrrrConfig{URLs: "discord://token@id", Timeout: "3s"}, Mail: MailConfig{To: "to@example.com", From: "from@example.com", SMTPServer: "smtp.example.com", SMTPPort: 2525, SMTPUser: "smtp-user", SMTPPass: "smtp-pass"}},
 		Bots:          BotConfig{Slack: SlackBotConfig{BotToken: "xoxb-typed", AppToken: "xapp-typed", BotName: "typed-bot", ApprovalsChannel: "approvals"}, Hipchat: HipchatBotConfig{ApprovalsChannel: "hip-approvals", ApprovalsUserName: "hip-user", ApprovalsBotName: "hip-bot", ApprovalsPassword: "hip-pass", ConnectionAttempts: 4}},
-		Auth:          AuthConfig{BasicUser: "admin", BasicPassword: "secret", AuthenticatedWebhooks: true, TokenSecret: "token-secret", Mode: "proxy", ProxyUserHeader: "X-User", ProxyLogoutURL: "https://logout"}, Kubernetes: KubernetesConfig{RestrictedNamespace: "production"},
+		Auth:          AuthConfig{BasicUser: "admin", BasicPassword: "secret", AuthenticatedWebhooks: true, TokenSecret: "token-secret", Mode: "proxy", ProxyUserHeader: "X-User", ProxyLogoutURL: "https://logout"}, Kubernetes: KubernetesConfig{RestrictedNamespace: "production", ClientQPS: 35, ClientBurst: 70, PodCacheTTL: 15 * time.Second},
 	}, cfg)
 }
 
 func TestLoadRejectsInvalidTypedValues(t *testing.T) {
-	for _, tt := range []struct{ name, key, value string }{{"boolean", "POLL", "sometimes"}, {"duration", "POLL_SCAN_INTERVAL", "soon"}, {"non-positive duration", "POLL_SCAN_INTERVAL", "0s"}, {"integer", "MAIL_SMTP_PORT", "smtp"}, {"nested integer", "HIPCHAT_CONNECTION_ATTEMPTS", "many"}} {
+	for _, tt := range []struct{ name, key, value string }{{"boolean", "POLL", "sometimes"}, {"duration", "POLL_SCAN_INTERVAL", "soon"}, {"non-positive duration", "POLL_SCAN_INTERVAL", "0s"}, {"integer", "MAIL_SMTP_PORT", "smtp"}, {"nested integer", "HIPCHAT_CONNECTION_ATTEMPTS", "many"}, {"float", "KUBERNETES_CLIENT_QPS", "fast"}, {"zero qps", "KUBERNETES_CLIENT_QPS", "0"}, {"negative pod cache ttl", "KUBERNETES_POD_CACHE_TTL", "-5s"}} {
 		t.Run(tt.name, func(t *testing.T) {
 			clearConfigurationEnvironment(t)
 			t.Setenv(tt.key, tt.value)

--- a/provider/kubernetes/caching_implementer.go
+++ b/provider/kubernetes/caching_implementer.go
@@ -1,0 +1,133 @@
+package kubernetes
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keel-hq/keel/internal/k8s"
+
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DefaultPodCacheTTL is how long a pod listing is reused before it is fetched
+// again. Workload definitions come from an informer backed cache, but pods are
+// listed straight from the API server: every TrackedImages() enumeration lists
+// the pods of every tracked workload twice (platform resolution and running
+// digest resolution), and TrackedImages() runs once per poll scan plus once per
+// watcher tick. Without a cache the request rate grows with
+// workloads x watchers and saturates the client side rate limiter.
+const DefaultPodCacheTTL = 30 * time.Second
+
+type podCacheEntry struct {
+	mu        sync.Mutex
+	fetchedAt time.Time
+	list      *v1.PodList
+}
+
+// CachingImplementer decorates an Implementer with a short lived cache for pod
+// lookups. Everything else is forwarded untouched.
+//
+// The cached list is shared between callers, so callers must treat the returned
+// PodList as read only - which is what every caller in this repository does.
+// Entries for a namespace are dropped as soon as Keel changes anything in it,
+// so an update is never planned against a pod listing from before the rollout.
+type CachingImplementer struct {
+	Implementer
+
+	ttl time.Duration
+	now func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]*podCacheEntry
+}
+
+// NewCachingImplementer wraps impl with a pod listing cache. A ttl of zero or
+// less selects DefaultPodCacheTTL.
+func NewCachingImplementer(impl Implementer, ttl time.Duration) *CachingImplementer {
+	if ttl <= 0 {
+		ttl = DefaultPodCacheTTL
+	}
+	return &CachingImplementer{
+		Implementer: impl,
+		ttl:         ttl,
+		now:         time.Now,
+		entries:     make(map[string]*podCacheEntry),
+	}
+}
+
+// Pods returns the pods matching labelSelector, reusing a recent listing when
+// there is one. Concurrent callers asking for the same namespace and selector
+// share a single API request instead of queueing one each behind the rate
+// limiter.
+func (c *CachingImplementer) Pods(namespace, labelSelector string) (*v1.PodList, error) {
+	entry := c.entryFor(cacheKey(namespace, labelSelector))
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.list != nil && c.now().Sub(entry.fetchedAt) < c.ttl {
+		return entry.list, nil
+	}
+
+	list, err := c.Implementer.Pods(namespace, labelSelector)
+	if err != nil {
+		// failures are not cached: a transient API error should not blind the
+		// next caller for a full TTL
+		return list, err
+	}
+
+	entry.list = list
+	entry.fetchedAt = c.now()
+
+	return list, nil
+}
+
+// Update applies the resource change and drops the cached pod listings of its
+// namespace, because the pods that are about to be replaced no longer describe
+// what the workload runs.
+func (c *CachingImplementer) Update(obj *k8s.GenericResource) error {
+	err := c.Implementer.Update(obj)
+	if obj != nil {
+		c.invalidate(obj.GetNamespace())
+	}
+	return err
+}
+
+// DeletePod removes the pod and drops the cached pod listings of its namespace.
+func (c *CachingImplementer) DeletePod(namespace, name string, opts *meta_v1.DeleteOptions) error {
+	err := c.Implementer.DeletePod(namespace, name, opts)
+	c.invalidate(namespace)
+	return err
+}
+
+func (c *CachingImplementer) entryFor(key string) *podCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		entry = &podCacheEntry{}
+		c.entries[key] = entry
+	}
+	return entry
+}
+
+func (c *CachingImplementer) invalidate(namespace string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	prefix := namespace + "/"
+	for key := range c.entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// cacheKey is unambiguous because a namespace name cannot contain a slash,
+// while a label selector can.
+func cacheKey(namespace, labelSelector string) string {
+	return namespace + "/" + labelSelector
+}

--- a/provider/kubernetes/caching_implementer_test.go
+++ b/provider/kubernetes/caching_implementer_test.go
@@ -1,0 +1,160 @@
+package kubernetes
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keel-hq/keel/internal/k8s"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// countingPodImplementer records how many pod listings actually reach the API.
+// Only the methods exercised by CachingImplementer are implemented, the
+// embedded interface is never called.
+type countingPodImplementer struct {
+	Implementer
+
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (c *countingPodImplementer) Pods(namespace, labelSelector string) (*v1.PodList, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &v1.PodList{Items: []v1.Pod{{ObjectMeta: meta_v1.ObjectMeta{Name: "pod", Namespace: namespace}}}}, nil
+}
+
+func (c *countingPodImplementer) Update(obj *k8s.GenericResource) error { return nil }
+
+func (c *countingPodImplementer) DeletePod(namespace, name string, opts *meta_v1.DeleteOptions) error {
+	return nil
+}
+
+func (c *countingPodImplementer) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+func TestCachingImplementerReusesRecentPodListing(t *testing.T) {
+	fake := &countingPodImplementer{}
+	caching := NewCachingImplementer(fake, time.Minute)
+
+	for i := 0; i < 5; i++ {
+		if _, err := caching.Pods("default", "app=foo"); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	}
+
+	if fake.callCount() != 1 {
+		t.Errorf("expected 1 API call, got %d", fake.callCount())
+	}
+}
+
+func TestCachingImplementerSeparatesNamespacesAndSelectors(t *testing.T) {
+	fake := &countingPodImplementer{}
+	caching := NewCachingImplementer(fake, time.Minute)
+
+	caching.Pods("default", "app=foo")
+	caching.Pods("default", "app=bar")
+	caching.Pods("other", "app=foo")
+	caching.Pods("default", "app=foo")
+
+	if fake.callCount() != 3 {
+		t.Errorf("expected 3 API calls, got %d", fake.callCount())
+	}
+}
+
+func TestCachingImplementerRefetchesAfterTTL(t *testing.T) {
+	fake := &countingPodImplementer{}
+	caching := NewCachingImplementer(fake, 30*time.Second)
+
+	now := time.Now()
+	caching.now = func() time.Time { return now }
+
+	caching.Pods("default", "app=foo")
+	now = now.Add(29 * time.Second)
+	caching.Pods("default", "app=foo")
+
+	if fake.callCount() != 1 {
+		t.Fatalf("expected the listing to be reused within the TTL, got %d calls", fake.callCount())
+	}
+
+	now = now.Add(2 * time.Second)
+	caching.Pods("default", "app=foo")
+
+	if fake.callCount() != 2 {
+		t.Errorf("expected the listing to be refreshed after the TTL, got %d calls", fake.callCount())
+	}
+}
+
+func TestCachingImplementerDoesNotCacheErrors(t *testing.T) {
+	fake := &countingPodImplementer{err: errors.New("api is down")}
+	caching := NewCachingImplementer(fake, time.Minute)
+
+	if _, err := caching.Pods("default", "app=foo"); err == nil {
+		t.Fatal("expected an error")
+	}
+	if _, err := caching.Pods("default", "app=foo"); err == nil {
+		t.Fatal("expected an error")
+	}
+
+	if fake.callCount() != 2 {
+		t.Errorf("expected the failed listing to be retried, got %d calls", fake.callCount())
+	}
+}
+
+func TestCachingImplementerInvalidatesNamespaceOnUpdate(t *testing.T) {
+	fake := &countingPodImplementer{}
+	caching := NewCachingImplementer(fake, time.Minute)
+
+	caching.Pods("default", "app=foo")
+	caching.Pods("other", "app=foo")
+
+	resource, err := k8s.NewGenericResource(&apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "foo", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create generic resource: %s", err)
+	}
+
+	if err := caching.Update(resource); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	caching.Pods("default", "app=foo")
+	caching.Pods("other", "app=foo")
+
+	if fake.callCount() != 3 {
+		t.Errorf("expected the updated namespace to be refetched and the other one reused, got %d calls", fake.callCount())
+	}
+}
+
+func TestCachingImplementerCollapsesConcurrentListings(t *testing.T) {
+	fake := &countingPodImplementer{}
+	caching := NewCachingImplementer(fake, time.Minute)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			caching.Pods("default", "app=foo")
+		}()
+	}
+	wg.Wait()
+
+	if fake.callCount() != 1 {
+		t.Errorf("expected concurrent callers to share one API call, got %d", fake.callCount())
+	}
+}

--- a/provider/kubernetes/implementer.go
+++ b/provider/kubernetes/implementer.go
@@ -52,6 +52,14 @@ type Opts struct {
 	CurrentContext string
 	// Unused, possibly legacy
 	Master string
+
+	// QPS and Burst configure the client side rate limiter. Left at zero,
+	// client-go applies its own defaults (5 QPS, burst 10), which are sized
+	// for a CLI rather than for a controller that lists pods for every
+	// tracked workload on every poll. A negative QPS disables client side
+	// rate limiting entirely and leaves throttling to the API server.
+	QPS   float32
+	Burst int
 }
 
 // NewKubernetesImplementer - create new k8s implementer
@@ -83,6 +91,18 @@ func NewKubernetesImplementer(opts *Opts) (*KubernetesImplementer, error) {
 	} else {
 		return nil, fmt.Errorf("kubernetes config is missing")
 	}
+
+	if opts.QPS != 0 {
+		cfg.QPS = opts.QPS
+	}
+	if opts.Burst != 0 {
+		cfg.Burst = opts.Burst
+	}
+
+	log.WithFields(log.Fields{
+		"qps":   cfg.QPS,
+		"burst": cfg.Burst,
+	}).Info("provider.kubernetes: client rate limits configured")
 
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
Keel builds its client with rest.InClusterConfig() and never sets QPS or Burst, so it runs on the client-go defaults of 5 QPS and burst 10. On top of that, every TrackedImages() enumeration lists the pods of every tracked workload twice — once for platform resolution, once for running digest resolution — with no cache, and TrackedImages() is called once per poll scan and once per watcher tick in WatchRepositoryTagsJob.computeEvents.

The resulting request rate grows with workloads × watched images and saturates the limiter. Polling starts late, then gets progressively slower as concurrent cron jobs queue behind it, with Waited for Ns due to client-side throttling climbing in the logs.

Two changes:

- KUBERNETES_CLIENT_QPS (default 20) and KUBERNETES_CLIENT_BURST (default 40) size the client-side rate limiter. A negative QPS disables client-side limiting entirely and defers to API Priority and Fairness.
- CachingImplementer reuses a pod listing for KUBERNETES_POD_CACHE_TTL (default 30s), collapsing concurrent identical listings into a single request. A namespace's entries are dropped as soon as Keel updates a workload or deletes a pod in it, so an update is never planned against a stale listing. Setting the TTL to 0 disables the cache.

Defaults are conservative and the previous behaviour is reachable through configuration. Errors are never cached, so a transient API failure doesn't blind the next caller for a full TTL.

The chart exposes all three through kubernetesClient.{qps,burst,podCacheTTL}; chart version bumped to 1.3.0 accordingly, and ARCHITECTURE.md documents the new variables.

Testing: six new unit tests cover TTL reuse, per-namespace/selector separation, refetch after expiry, error passthrough, namespace invalidation on update, and concurrent-caller collapsing. The full CI suite — unit tests, make release-validate in k3s (install and upgrade), and the behavioral k3s end-to-end suite — passes on this branch's content: https://github.com/Arno500/keel/actions/runs/33872020791