### PR TITLE
feat: Add `deploymentLabels` for the Deployment's own metadata

### DIFF
--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "keel.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.DeploymentLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: 1
   selector:

--- a/chart/keel/templates/deployment.yaml
+++ b/chart/keel/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "keel.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.DeploymentLabels }}
+{{- with .Values.deploymentLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -12,7 +12,7 @@ imagePullSecrets: []
 
 # Extra labels added to the Deployment's own metadata (not the pod template) -
 # e.g. for label selectors that key off the workload resource itself.
-DeploymentLabels: {}
+deploymentLabels: {}
 
 # Extra enviroment values
 extraEnv: []

--- a/chart/keel/values.yaml
+++ b/chart/keel/values.yaml
@@ -10,6 +10,10 @@ image:
 # Image pull secrets
 imagePullSecrets: []
 
+# Extra labels added to the Deployment's own metadata (not the pod template) -
+# e.g. for label selectors that key off the workload resource itself.
+DeploymentLabels: {}
+
 # Extra enviroment values
 extraEnv: []
 


### PR DESCRIPTION
## Problem

The chart's `templates/deployment.yaml` only sets labels via a fixed, hardcoded
block on the Deployment's own `metadata.labels`:

```yaml
labels:
  app: {{ template "keel.name" . }}
  chart: {{ template "keel.chart" . }}
  release: {{ .Release.Name }}
  heritage: {{ .Release.Service }}
```

There's no way to add a custom label to the Deployment resource itself. The
chart does expose `podAnnotations`, but nothing for object-level labels or
annotations on the Deployment (as opposed to its pod template).

We need this to let a label-selector-based tool (in our case, a Kyverno
`generate` policy that creates a scoped `NetworkPolicy` for workloads that
carry a specific label) target keel's Deployment without forking the whole
chart just to add one label.